### PR TITLE
Adding new stations since 2018 that are not in list and removal of 'rail station' from the names.

### DIFF
--- a/uk-train-stations-dictonary.json
+++ b/uk-train-stations-dictonary.json
@@ -1,386 +1,386 @@
 {
   "AAP": {
-    "station_name": "Alexandra Palace Rail Station",
+    "station_name": "Alexandra Palace",
     "latitude": 51.5979250073,
     "longitude": -0.1202099313
   },
   "AAT": {
-    "station_name": "Achanalt Rail Station",
+    "station_name": "Achanalt",
     "latitude": 57.6095763828,
     "longitude": -4.913846165
   },
   "ABA": {
-    "station_name": "Aberdare Rail Station",
+    "station_name": "Aberdare",
     "latitude": 51.7150603368,
     "longitude": -3.4430947912
   },
   "ABC": {
-    "station_name": "Altnabreac Rail Station",
+    "station_name": "Altnabreac",
     "latitude": 58.3881329239,
     "longitude": -3.7062873902
   },
   "ABD": {
-    "station_name": "Aberdeen Rail Station",
+    "station_name": "Aberdeen",
     "latitude": 57.1436867734,
     "longitude": -2.0986925585
   },
   "ABE": {
-    "station_name": "Aber Rail Station",
+    "station_name": "Aber",
     "latitude": 51.5749656756,
     "longitude": -3.2298391052
   },
   "ABH": {
-    "station_name": "Abererch Rail Station",
+    "station_name": "Abererch",
     "latitude": 52.8985982311,
     "longitude": -4.3741839689
   },
   "ABW": {
-    "station_name": "Abbey Wood (London) Rail Station",
+    "station_name": "Abbey Wood (London)",
     "latitude": 51.4910611665,
     "longitude": 0.1214217457
   },
   "ABY": {
-    "station_name": "Ashburys Rail Station",
+    "station_name": "Ashburys",
     "latitude": 53.4716521884,
     "longitude": -2.194434998
   },
   "ACB": {
-    "station_name": "Acton Bridge Rail Station",
+    "station_name": "Acton Bridge",
     "latitude": 53.2665207003,
     "longitude": -2.6031255204
   },
   "ACC": {
-    "station_name": "Acton Central Rail Station",
+    "station_name": "Acton Central",
     "latitude": 51.5087156784,
     "longitude": -0.2629477949
   },
   "ACG": {
-    "station_name": "Acocks Green Rail Station",
+    "station_name": "Acocks Green",
     "latitude": 52.4493357815,
     "longitude": -1.8189696484
   },
   "ACH": {
-    "station_name": "Achnashellach Rail Station",
+    "station_name": "Achnashellach",
     "latitude": 57.4820517208,
     "longitude": -5.3330497284
   },
   "ACK": {
-    "station_name": "Acklington Rail Station",
+    "station_name": "Acklington",
     "latitude": 55.3070995797,
     "longitude": -1.6518483985
   },
   "ACL": {
-    "station_name": "Acle Rail Station",
+    "station_name": "Acle",
     "latitude": 52.6347061444,
     "longitude": 1.5439384675
   },
   "ACN": {
-    "station_name": "Achnasheen Rail Station",
+    "station_name": "Achnasheen",
     "latitude": 57.5792680938,
     "longitude": -5.0723280881
   },
   "ACR": {
-    "station_name": "Accrington Rail Station",
+    "station_name": "Accrington",
     "latitude": 53.7529844843,
     "longitude": -2.3695474455
   },
   "ACT": {
-    "station_name": "Ascot Rail Station",
+    "station_name": "Ascot",
     "latitude": 51.4062421592,
     "longitude": -0.6758156963
   },
   "ACY": {
-    "station_name": "Abercynon Rail Station",
+    "station_name": "Abercynon",
     "latitude": 51.6447111646,
     "longitude": -3.3270008927
   },
   "ADC": {
-    "station_name": "Adlington (Cheshire) Rail Station",
+    "station_name": "Adlington (Cheshire)",
     "latitude": 53.3195695329,
     "longitude": -2.1335617879
   },
   "ADD": {
-    "station_name": "Adderley Park Rail Station",
+    "station_name": "Adderley Park",
     "latitude": 52.4830987434,
     "longitude": -1.8559397876
   },
   "ADK": {
-    "station_name": "Ardwick Rail Station",
+    "station_name": "Ardwick",
     "latitude": 53.471358298,
     "longitude": -2.213882234
   },
   "ADL": {
-    "station_name": "Adlington (Lancs) Rail Station",
+    "station_name": "Adlington (Lancs)",
     "latitude": 53.6132582182,
     "longitude": -2.603069152
   },
   "ADM": {
-    "station_name": "Adisham Rail Station",
+    "station_name": "Adisham",
     "latitude": 51.2412043148,
     "longitude": 1.1991182098
   },
   "ADN": {
-    "station_name": "Ardrossan Town Rail Station",
+    "station_name": "Ardrossan Town",
     "latitude": 55.6397026924,
     "longitude": -4.8126528377
   },
   "ADR": {
-    "station_name": "Airdrie Rail Station",
+    "station_name": "Airdrie",
     "latitude": 55.8639734432,
     "longitude": -3.9829014475
   },
   "ADS": {
-    "station_name": "Ardrossan Harbour Rail Station",
+    "station_name": "Ardrossan Harbour",
     "latitude": 55.6398684301,
     "longitude": -4.8210878622
   },
   "ADV": {
-    "station_name": "Andover Rail Station",
+    "station_name": "Andover",
     "latitude": 51.2115409141,
     "longitude": -1.4922208179
   },
   "ADW": {
-    "station_name": "Addiewell Rail Station",
+    "station_name": "Addiewell",
     "latitude": 55.8434039199,
     "longitude": -3.6065211407
   },
   "AFK": {
-    "station_name": "Ashford International Rail Station",
+    "station_name": "Ashford International",
     "latitude": 51.143703647,
     "longitude": 0.8762282027
   },
   "AFS": {
-    "station_name": "Ashford (Surrey) Rail Station",
+    "station_name": "Ashford (Surrey)",
     "latitude": 51.4365050918,
     "longitude": -0.4680505426
   },
   "AFV": {
-    "station_name": "Ansdell & Fairhaven Rail Station",
+    "station_name": "Ansdell & Fairhaven",
     "latitude": 53.7414755302,
     "longitude": -2.9930315929
   },
   "AGL": {
-    "station_name": "Abergele & Pensarn Rail Station",
+    "station_name": "Abergele & Pensarn",
     "latitude": 53.2945885877,
     "longitude": -3.5826252049
   },
   "AGR": {
-    "station_name": "Angel Road Rail Station",
+    "station_name": "Angel Road",
     "latitude": 51.612404791,
     "longitude": -0.0487664558
   },
   "AGS": {
-    "station_name": "Argyle Street Rail Station",
+    "station_name": "Argyle Street",
     "latitude": 55.8572976321,
     "longitude": -4.2506797284
   },
   "AGT": {
-    "station_name": "Aldrington Rail Station",
+    "station_name": "Aldrington",
     "latitude": 50.8363759964,
     "longitude": -0.1837938786
   },
   "AGV": {
-    "station_name": "Abergavenny Rail Station",
+    "station_name": "Abergavenny",
     "latitude": 51.8166929204,
     "longitude": -3.0096529786
   },
   "AHD": {
-    "station_name": "Ashtead Rail Station",
+    "station_name": "Ashtead",
     "latitude": 51.3178707762,
     "longitude": -0.3075480044
   },
   "AHN": {
-    "station_name": "Ashton-under-Lyne Rail Station",
+    "station_name": "Ashton-under-Lyne",
     "latitude": 53.4912877289,
     "longitude": -2.0943117675
   },
   "AHS": {
-    "station_name": "Ashurst (Kent) Rail Station",
+    "station_name": "Ashurst (Kent)",
     "latitude": 51.1286581521,
     "longitude": 0.1526783965
   },
   "AHT": {
-    "station_name": "Aldershot Rail Station",
+    "station_name": "Aldershot",
     "latitude": 51.2464146675,
     "longitude": -0.7598418662
   },
   "AHV": {
-    "station_name": "Ash Vale Rail Station",
+    "station_name": "Ash Vale",
     "latitude": 51.2722439454,
     "longitude": -0.721630982
   },
   "AIG": {
-    "station_name": "Aigburth Rail Station",
+    "station_name": "Aigburth",
     "latitude": 53.364579864,
     "longitude": -2.9271549702
   },
   "AIN": {
-    "station_name": "Aintree Rail Station",
+    "station_name": "Aintree",
     "latitude": 53.4739239739,
     "longitude": -2.9562794487
   },
   "AIR": {
-    "station_name": "Airbles Rail Station",
+    "station_name": "Airbles",
     "latitude": 55.7828281606,
     "longitude": -3.9941848819
   },
   "ALB": {
-    "station_name": "Albrighton Rail Station",
+    "station_name": "Albrighton",
     "latitude": 52.637955578,
     "longitude": -2.2688961662
   },
   "ALD": {
-    "station_name": "Alderley Edge Rail Station",
+    "station_name": "Alderley Edge",
     "latitude": 53.3037949434,
     "longitude": -2.2367975748
   },
   "ALF": {
-    "station_name": "Alfreton Rail Station",
+    "station_name": "Alfreton",
     "latitude": 53.1004491479,
     "longitude": -1.3696938892
   },
   "ALK": {
-    "station_name": "Aslockton Rail Station",
+    "station_name": "Aslockton",
     "latitude": 52.9515688778,
     "longitude": -0.8980931448
   },
   "ALM": {
-    "station_name": "Alnmouth Rail Station",
+    "station_name": "Alnmouth",
     "latitude": 55.3927781339,
     "longitude": -1.6366531856
   },
   "ALN": {
-    "station_name": "Althorne Rail Station",
+    "station_name": "Althorne",
     "latitude": 51.647874589,
     "longitude": 0.7525126479
   },
   "ALO": {
-    "station_name": "Alloa Rail Station",
+    "station_name": "Alloa",
     "latitude": 56.1177816937,
     "longitude": -3.7900478514
   },
   "ALP": {
-    "station_name": "Althorpe Rail Station",
+    "station_name": "Althorpe",
     "latitude": 53.5855202235,
     "longitude": -0.7331858491
   },
   "ALR": {
-    "station_name": "Alresford (Essex) Rail Station",
+    "station_name": "Alresford (Essex)",
     "latitude": 51.8540099196,
     "longitude": 0.9974663385
   },
   "ALT": {
-    "station_name": "Altrincham Rail Station",
+    "station_name": "Altrincham",
     "latitude": 53.3877312834,
     "longitude": -2.3468882352
   },
   "ALV": {
-    "station_name": "Alvechurch Rail Station",
+    "station_name": "Alvechurch",
     "latitude": 52.3460841489,
     "longitude": -1.96765319
   },
   "ALW": {
-    "station_name": "Allens West Rail Station",
+    "station_name": "Allens West",
     "latitude": 54.5246329186,
     "longitude": -1.361128823
   },
   "ALX": {
-    "station_name": "Alexandria Rail Station",
+    "station_name": "Alexandria",
     "latitude": 55.9850750252,
     "longitude": -4.5774669847
   },
   "AMB": {
-    "station_name": "Ambergate Rail Station",
+    "station_name": "Ambergate",
     "latitude": 53.0605332632,
     "longitude": -1.4806950473
   },
   "AMF": {
-    "station_name": "Ammanford Rail Station",
+    "station_name": "Ammanford",
     "latitude": 51.7959802661,
     "longitude": -3.9967546569
   },
   "AML": {
-    "station_name": "Acton Main Line Rail Station",
+    "station_name": "Acton Main Line",
     "latitude": 51.5171796932,
     "longitude": -0.2667334712
   },
   "AMR": {
-    "station_name": "Amersham Rail Station",
+    "station_name": "Amersham",
     "latitude": 51.6742082152,
     "longitude": -0.6075738184
   },
   "AMT": {
-    "station_name": "Aldermaston Rail Station",
+    "station_name": "Aldermaston",
     "latitude": 51.4019601992,
     "longitude": -1.1374044609
   },
   "AMY": {
-    "station_name": "Amberley Rail Station",
+    "station_name": "Amberley",
     "latitude": 50.8966706624,
     "longitude": -0.5419699859
   },
   "ANC": {
-    "station_name": "Ancaster Rail Station",
+    "station_name": "Ancaster",
     "latitude": 52.9877078434,
     "longitude": -0.5356177511
   },
   "AND": {
-    "station_name": "Anderston Rail Station",
+    "station_name": "Anderston",
     "latitude": 55.8598905332,
     "longitude": -4.2709646678
   },
   "ANF": {
-    "station_name": "Ashurst New Forest Rail Station",
+    "station_name": "Ashurst New Forest",
     "latitude": 50.8898407705,
     "longitude": -1.5266232035
   },
   "ANG": {
-    "station_name": "Angmering Rail Station",
+    "station_name": "Angmering",
     "latitude": 50.8165649857,
     "longitude": -0.4893702151
   },
   "ANL": {
-    "station_name": "Anniesland Rail Station",
+    "station_name": "Anniesland",
     "latitude": 55.8893432336,
     "longitude": -4.3219418416
   },
   "ANN": {
-    "station_name": "Annan Rail Station",
+    "station_name": "Annan",
     "latitude": 54.9838392542,
     "longitude": -3.2625828964
   },
   "ANS": {
-    "station_name": "Ainsdale Rail Station",
+    "station_name": "Ainsdale",
     "latitude": 53.6020465522,
     "longitude": -3.0426494721
   },
   "ANZ": {
-    "station_name": "Anerley Rail Station",
+    "station_name": "Anerley",
     "latitude": 51.4121504955,
     "longitude": -0.0658599305
   },
   "AON": {
-    "station_name": "Alton Rail Station",
+    "station_name": "Alton",
     "latitude": 51.151964195,
     "longitude": -0.9668980606
   },
   "APB": {
-    "station_name": "Appley Bridge Rail Station",
+    "station_name": "Appley Bridge",
     "latitude": 53.5786855814,
     "longitude": -2.7192513076
   },
   "APD": {
-    "station_name": "Appledore (Kent) Rail Station",
+    "station_name": "Appledore (Kent)",
     "latitude": 51.0332339326,
     "longitude": 0.8163754751
   },
   "APF": {
-    "station_name": "Appleford Rail Station",
+    "station_name": "Appleford",
     "latitude": 51.6396427695,
     "longitude": -1.2421230581
   },
   "APG": {
-    "station_name": "Aspley Guise Rail Station",
+    "station_name": "Aspley Guise",
     "latitude": 52.0212455205,
     "longitude": -0.6323124906
   },
@@ -390,722 +390,732 @@
     "longitude": -1.7110611354
   },
   "APP": {
-    "station_name": "Appleby Rail Station",
+    "station_name": "Appleby",
     "latitude": 54.5803531214,
     "longitude": -2.4866970812
   },
   "APS": {
-    "station_name": "Apsley Rail Station",
+    "station_name": "Apsley",
     "latitude": 51.7325265818,
     "longitude": -0.462913617
   },
   "APY": {
-    "station_name": "Apperley Bridge Rail Station",
+    "station_name": "Apperley Bridge",
     "latitude": 53.8417623189,
     "longitude": -1.7058332
   },
   "ARB": {
-    "station_name": "Arbroath Rail Station",
+    "station_name": "Arbroath",
     "latitude": 56.5595623759,
     "longitude": -2.58893669
   },
   "ARD": {
-    "station_name": "Ardgay Rail Station",
+    "station_name": "Ardgay",
     "latitude": 57.8814343743,
     "longitude": -4.3620902545
   },
   "ARG": {
-    "station_name": "Arisaig Rail Station",
+    "station_name": "Arisaig",
     "latitude": 56.9125239651,
     "longitude": -5.8390581876
   },
   "ARL": {
-    "station_name": "Arlesey Rail Station",
+    "station_name": "Arlesey",
     "latitude": 52.0260393622,
     "longitude": -0.2662942214
   },
   "ARM": {
-    "station_name": "Armadale (W Lothian) Rail Station",
+    "station_name": "Armadale (W Lothian)",
     "latitude": 55.8857041796,
     "longitude": -3.6954045698
   },
   "ARN": {
-    "station_name": "Arnside Rail Station",
+    "station_name": "Arnside",
     "latitude": 54.2027369524,
     "longitude": -2.8282411629
   },
   "ARR": {
-    "station_name": "Arram Rail Station",
+    "station_name": "Arram",
     "latitude": 53.8843617225,
     "longitude": -0.4265787094
   },
   "ART": {
-    "station_name": "Arrochar & Tarbet Rail Station",
+    "station_name": "Arrochar & Tarbet",
     "latitude": 56.2039604882,
     "longitude": -4.7227536136
   },
   "ARU": {
-    "station_name": "Arundel Rail Station",
+    "station_name": "Arundel",
     "latitude": 50.848204225,
     "longitude": -0.5461513877
   },
   "ASB": {
-    "station_name": "Ardrossan South Beach Rail Station",
+    "station_name": "Ardrossan South Beach",
     "latitude": 55.6414123987,
     "longitude": -4.8011892639
   },
   "ASC": {
-    "station_name": "Ashchurch for Tewkesbury Rail Station",
+    "station_name": "Ashchurch for Tewkesbury",
     "latitude": 51.9989119042,
     "longitude": -2.1087526816
   },
   "ASF": {
-    "station_name": "Ashfield Rail Station",
+    "station_name": "Ashfield",
     "latitude": 55.8889152278,
     "longitude": -4.2492001758
   },
   "ASG": {
-    "station_name": "Alsager Rail Station",
+    "station_name": "Alsager",
     "latitude": 53.0930183471,
     "longitude": -2.2990577384
   },
   "ASH": {
-    "station_name": "Ash Rail Station",
+    "station_name": "Ash",
     "latitude": 51.2495930968,
     "longitude": -0.7127872134
   },
   "ASK": {
-    "station_name": "Askam Rail Station",
+    "station_name": "Askam",
     "latitude": 54.1889365481,
     "longitude": -3.2045108901
   },
   "ASN": {
-    "station_name": "Addlestone Rail Station",
+    "station_name": "Addlestone",
     "latitude": 51.3730427936,
     "longitude": -0.4844377608
   },
   "ASP": {
-    "station_name": "Aspatria Rail Station",
+    "station_name": "Aspatria",
     "latitude": 54.7589613565,
     "longitude": -3.3318751754
   },
   "ASS": {
-    "station_name": "Alness Rail Station",
+    "station_name": "Alness",
     "latitude": 57.6943767246,
     "longitude": -4.2497156226
   },
   "AST": {
-    "station_name": "Aston Rail Station",
+    "station_name": "Aston",
     "latitude": 52.5042436334,
     "longitude": -1.8719289166
   },
   "ASY": {
-    "station_name": "Ashley Rail Station",
+    "station_name": "Ashley",
     "latitude": 53.3557384507,
     "longitude": -2.3414591344
   },
   "ATB": {
-    "station_name": "Attenborough Rail Station",
+    "station_name": "Attenborough",
     "latitude": 52.9062307659,
     "longitude": -1.2314110309
   },
   "ATH": {
-    "station_name": "Atherstone Rail Station",
+    "station_name": "Atherstone",
     "latitude": 52.5789873633,
     "longitude": -1.5528024825
   },
   "ATL": {
-    "station_name": "Attleborough Rail Station",
+    "station_name": "Attleborough",
     "latitude": 52.5145682909,
     "longitude": 1.0223710881
   },
   "ATN": {
-    "station_name": "Atherton Rail Station",
+    "station_name": "Atherton",
     "latitude": 53.5291592416,
     "longitude": -2.4789715129
   },
   "ATT": {
-    "station_name": "Attadale Rail Station",
+    "station_name": "Attadale",
     "latitude": 57.395013788,
     "longitude": -5.4555693529
   },
   "AUD": {
-    "station_name": "Audley End Rail Station",
+    "station_name": "Audley End",
     "latitude": 52.0044503988,
     "longitude": 0.2071861287
   },
   "AUG": {
-    "station_name": "Aughton Park Rail Station",
+    "station_name": "Aughton Park",
     "latitude": 53.5542616334,
     "longitude": -2.8952192106
   },
   "AUI": {
-    "station_name": "Ardlui Rail Station",
+    "station_name": "Ardlui",
     "latitude": 56.3019554792,
     "longitude": -4.7216411129
   },
   "AUK": {
-    "station_name": "Auchinleck Rail Station",
+    "station_name": "Auchinleck",
     "latitude": 55.4702735607,
     "longitude": -4.2953352235
   },
   "AUR": {
-    "station_name": "Aberdour Rail Station",
+    "station_name": "Aberdour",
     "latitude": 56.0545845646,
     "longitude": -3.3005596025
   },
   "AUW": {
-    "station_name": "Ascott-under-Wychwood Rail Station",
+    "station_name": "Ascott-under-Wychwood",
     "latitude": 51.8673469281,
     "longitude": -1.5640381523
   },
   "AVF": {
-    "station_name": "Avoncliff Rail Station",
+    "station_name": "Avoncliff",
     "latitude": 51.3396455319,
     "longitude": -2.2813231272
   },
   "AVM": {
-    "station_name": "Aviemore Rail Station",
+    "station_name": "Aviemore",
     "latitude": 57.1884955899,
     "longitude": -3.8288664748
   },
   "AVN": {
-    "station_name": "Avonmouth Rail Station",
+    "station_name": "Avonmouth",
     "latitude": 51.5003586482,
     "longitude": -2.6994701634
   },
   "AVP": {
-    "station_name": "Aylesbury Vale Parkway Rail Station",
+    "station_name": "Aylesbury Vale Parkway",
     "latitude": 51.8311641936,
     "longitude": -0.860160203
   },
   "AVY": {
-    "station_name": "Aberdovey Rail Station",
+    "station_name": "Aberdovey",
     "latitude": 52.5439709134,
     "longitude": -4.0570763906
   },
   "AWK": {
-    "station_name": "Adwick Rail Station",
+    "station_name": "Adwick",
     "latitude": 53.5723385016,
     "longitude": -1.1803591649
   },
   "AWM": {
-    "station_name": "Ashwell & Morden Rail Station",
+    "station_name": "Ashwell & Morden",
     "latitude": 52.0307801801,
     "longitude": -0.1097609643
   },
   "AWT": {
-    "station_name": "Armathwaite Rail Station",
+    "station_name": "Armathwaite",
     "latitude": 54.8094705871,
     "longitude": -2.7720762415
   },
   "AXM": {
-    "station_name": "Axminster Rail Station",
+    "station_name": "Axminster",
     "latitude": 50.7792590196,
     "longitude": -3.0047301649
   },
   "AXP": {
-    "station_name": "Alexandra Parade Rail Station",
+    "station_name": "Alexandra Parade",
     "latitude": 55.8631647206,
     "longitude": -4.2106343183
   },
   "AYH": {
-    "station_name": "Aylesham Rail Station",
+    "station_name": "Aylesham",
     "latitude": 51.2272573443,
     "longitude": 1.2094822749
   },
   "AYL": {
-    "station_name": "Aylesford Rail Station",
+    "station_name": "Aylesford",
     "latitude": 51.3013150665,
     "longitude": 0.4661994822
   },
   "AYP": {
-    "station_name": "Albany Park Rail Station",
+    "station_name": "Albany Park",
     "latitude": 51.4354510748,
     "longitude": 0.1257631402
   },
   "AYR": {
-    "station_name": "Ayr Rail Station",
+    "station_name": "Ayr",
     "latitude": 55.4581420821,
     "longitude": -4.6258547017
   },
   "AYS": {
-    "station_name": "Aylesbury Rail Station",
+    "station_name": "Aylesbury",
     "latitude": 51.8138958856,
     "longitude": -0.8150732917
   },
   "AYW": {
-    "station_name": "Aberystwyth Rail Station",
+    "station_name": "Aberystwyth",
     "latitude": 52.4140589056,
     "longitude": -4.081904916
   },
   "BAA": {
-    "station_name": "Barnham Rail Station",
+    "station_name": "Barnham",
     "latitude": 50.8308955044,
     "longitude": -0.6396586529
   },
   "BAB": {
-    "station_name": "Balcombe Rail Station",
+    "station_name": "Balcombe",
     "latitude": 51.0555161298,
     "longitude": -0.1369064512
   },
   "BAC": {
-    "station_name": "Bache Rail Station",
+    "station_name": "Bache",
     "latitude": 53.2087996005,
     "longitude": -2.8916714556
   },
   "BAD": {
-    "station_name": "Banstead Rail Station",
+    "station_name": "Banstead",
     "latitude": 51.3293456873,
     "longitude": -0.2131338747
   },
   "BAG": {
-    "station_name": "Bagshot Rail Station",
+    "station_name": "Bagshot",
     "latitude": 51.3643658384,
     "longitude": -0.688644212
   },
   "BAH": {
-    "station_name": "Bank Hall Rail Station",
+    "station_name": "Bank Hall",
     "latitude": 53.4375081504,
     "longitude": -2.9875109807
   },
   "BAI": {
-    "station_name": "Blairhill Rail Station",
+    "station_name": "Blairhill",
     "latitude": 55.866445195,
     "longitude": -4.0432793703
   },
   "BAJ": {
-    "station_name": "Baglan Rail Station",
+    "station_name": "Baglan",
     "latitude": 51.6155428964,
     "longitude": -3.8111528304
   },
   "BAK": {
-    "station_name": "Battersea Park Rail Station",
+    "station_name": "Battersea Park",
     "latitude": 51.4769589055,
     "longitude": -0.1475087424
   },
   "BAL": {
-    "station_name": "Balham Rail Station",
+    "station_name": "Balham",
     "latitude": 51.4432235254,
     "longitude": -0.1523989843
   },
   "BAM": {
-    "station_name": "Bamford Rail Station",
+    "station_name": "Bamford",
     "latitude": 53.3390149874,
     "longitude": -1.6890804845
   },
   "BAN": {
-    "station_name": "Banbury Rail Station",
+    "station_name": "Banbury",
     "latitude": 52.0603171415,
     "longitude": -1.3281174658
   },
   "BAR": {
-    "station_name": "Bare Lane Rail Station",
+    "station_name": "Bare Lane",
     "latitude": 54.0745502872,
     "longitude": -2.8353285199
   },
   "BAS": {
-    "station_name": "Bere Alston Rail Station",
+    "station_name": "Bere Alston",
     "latitude": 50.4855801051,
     "longitude": -4.2003841017
   },
   "BAT": {
-    "station_name": "Battle Rail Station",
+    "station_name": "Battle",
     "latitude": 50.9129099302,
     "longitude": 0.494731748
   },
   "BAU": {
-    "station_name": "Barton-on-Humber Rail Station",
+    "station_name": "Barton-on-Humber",
     "latitude": 53.6889361427,
     "longitude": -0.443441463
   },
   "BAV": {
-    "station_name": "Barrow Haven Rail Station",
+    "station_name": "Barrow Haven",
     "latitude": 53.6974399715,
     "longitude": -0.3929610176
   },
   "BAW": {
-    "station_name": "Blackwater Rail Station",
+    "station_name": "Blackwater",
     "latitude": 51.3315799276,
     "longitude": -0.7767238015
   },
   "BAY": {
-    "station_name": "Bayford Rail Station",
+    "station_name": "Bayford",
     "latitude": 51.7577191097,
     "longitude": -0.0955835363
   },
   "BBG": {
-    "station_name": "Bishopbriggs Rail Station",
+    "station_name": "Bishopbriggs",
     "latitude": 55.9038715243,
     "longitude": -4.2249012111
   },
   "BBK": {
-    "station_name": "Bilbrook Rail Station",
+    "station_name": "Bilbrook",
     "latitude": 52.6237315662,
     "longitude": -2.1860832074
   },
   "BBL": {
-    "station_name": "Bat & Ball Rail Station",
+    "station_name": "Bat & Ball",
     "latitude": 51.28975765,
     "longitude": 0.1942546658
   },
   "BBN": {
-    "station_name": "Blackburn Rail Station",
+    "station_name": "Blackburn",
     "latitude": 53.7465295919,
     "longitude": -2.4791202443
   },
   "BBS": {
-    "station_name": "Bordesley Rail Station",
+    "station_name": "Bordesley",
     "latitude": 52.4718857429,
     "longitude": -1.877763734
   },
   "BBW": {
-    "station_name": "Berry Brow Rail Station",
+    "station_name": "Berry Brow",
     "latitude": 53.6210542572,
     "longitude": -1.793433127
   },
   "BCB": {
-    "station_name": "Burscough Bridge Rail Station",
+    "station_name": "Burscough Bridge",
     "latitude": 53.6052706223,
     "longitude": -2.8408791461
   },
   "BCC": {
-    "station_name": "Beccles Rail Station",
+    "station_name": "Beccles",
     "latitude": 52.4585445204,
     "longitude": 1.5695203477
   },
   "BCE": {
-    "station_name": "Bracknell Rail Station",
+    "station_name": "Bracknell",
     "latitude": 51.4130905636,
     "longitude": -0.7516868278
   },
   "BCF": {
-    "station_name": "Beaconsfield Rail Station",
+    "station_name": "Beaconsfield",
     "latitude": 51.6112923305,
     "longitude": -0.6438028303
   },
   "BCG": {
-    "station_name": "Birchgrove Rail Station",
+    "station_name": "Birchgrove",
     "latitude": 51.5215559616,
     "longitude": -3.2018626211
   },
   "BCH": {
-    "station_name": "Birchington-on-Sea Rail Station",
+    "station_name": "Birchington-on-Sea",
     "latitude": 51.37749655,
     "longitude": 1.3014357084
   },
   "BCJ": {
-    "station_name": "Burscough Junction Rail Station",
+    "station_name": "Burscough Junction",
     "latitude": 53.5975334888,
     "longitude": -2.8406044888
   },
   "BCK": {
-    "station_name": "Buckley Rail Station",
+    "station_name": "Buckley",
     "latitude": 53.1630498684,
     "longitude": -3.0559258882
   },
   "BCN": {
-    "station_name": "Branchton Rail Station",
+    "station_name": "Branchton",
     "latitude": 55.9405880748,
     "longitude": -4.8035281728
   },
   "BCS": {
-    "station_name": "Bicester North Rail Station",
+    "station_name": "Bicester North",
     "latitude": 51.9034889722,
     "longitude": -1.1503639712
   },
   "BCU": {
-    "station_name": "Brockenhurst Rail Station",
+    "station_name": "Brockenhurst",
     "latitude": 50.8168300371,
     "longitude": -1.5735227393
   },
   "BCV": {
-    "station_name": "Bruce Grove Rail Station",
+    "station_name": "Bruce Grove",
     "latitude": 51.5939593358,
     "longitude": -0.0698420983
   },
   "BCY": {
-    "station_name": "Brockley Rail Station",
+    "station_name": "Brockley",
     "latitude": 51.4646472415,
     "longitude": -0.0375111039
   },
+  "BCZ": {
+    "station_name": "Brent Cross West",
+    "latitude": 51.5687,
+    "longitude": -0.2269
+  },
   "BDA": {
-    "station_name": "Brundall Rail Station",
+    "station_name": "Brundall",
     "latitude": 52.6195070541,
     "longitude": 1.4393221465
   },
   "BDB": {
-    "station_name": "Broadbottom Rail Station",
+    "station_name": "Broadbottom",
     "latitude": 53.4409884275,
     "longitude": -2.0165194714
   },
   "BDG": {
-    "station_name": "Bridgeton Rail Station",
+    "station_name": "Bridgeton",
     "latitude": 55.8489565185,
     "longitude": -4.2260423916
   },
   "BDH": {
-    "station_name": "Bedhampton Rail Station",
+    "station_name": "Bedhampton",
     "latitude": 50.8539453593,
     "longitude": -0.9958127279
   },
   "BDI": {
-    "station_name": "Bradford Interchange Rail Station",
+    "station_name": "Bradford Interchange",
     "latitude": 53.7910884508,
     "longitude": -1.7495992021
   },
   "BDK": {
-    "station_name": "Baldock Rail Station",
+    "station_name": "Baldock",
     "latitude": 51.9928784919,
     "longitude": -0.1875367625
   },
   "BDL": {
-    "station_name": "Birkdale Rail Station",
+    "station_name": "Birkdale",
     "latitude": 53.6340637332,
     "longitude": -3.0144470298
   },
   "BDM": {
-    "station_name": "Bedford Rail Station",
+    "station_name": "Bedford",
     "latitude": 52.1361978063,
     "longitude": -0.4794210009
   },
   "BDN": {
-    "station_name": "Brading Rail Station",
+    "station_name": "Brading",
     "latitude": 50.6783584598,
     "longitude": -1.1387118948
   },
   "BDQ": {
-    "station_name": "Bradford Forster Square Rail Station",
+    "station_name": "Bradford Forster Square",
     "latitude": 53.7969375902,
     "longitude": -1.7529651428
   },
   "BDT": {
-    "station_name": "Bridlington Rail Station",
+    "station_name": "Bridlington",
     "latitude": 54.0841498279,
     "longitude": -0.198733799
   },
   "BDW": {
-    "station_name": "Bedwyn Rail Station",
+    "station_name": "Bedwyn",
     "latitude": 51.3796362626,
     "longitude": -1.5987734873
   },
   "BDY": {
-    "station_name": "Bredbury Rail Station",
+    "station_name": "Bredbury",
     "latitude": 53.423168059,
     "longitude": -2.1104866302
   },
   "BEA": {
-    "station_name": "Bridge of Allan Rail Station",
+    "station_name": "Bridge of Allan",
     "latitude": 56.1566272012,
     "longitude": -3.9572209128
   },
   "BEB": {
-    "station_name": "Bebington Rail Station",
+    "station_name": "Bebington",
     "latitude": 53.3576688627,
     "longitude": -3.0036346698
   },
   "BEC": {
-    "station_name": "Beckenham Hill Rail Station",
+    "station_name": "Beckenham Hill",
     "latitude": 51.4245803532,
     "longitude": -0.0159250385
   },
   "BEE": {
-    "station_name": "Beeston Rail Station",
+    "station_name": "Beeston",
     "latitude": 52.920772808,
     "longitude": -1.2076539126
   },
   "BEF": {
-    "station_name": "Benfleet Rail Station",
+    "station_name": "Benfleet",
     "latitude": 51.543946833,
     "longitude": 0.5617405199
   },
   "BEG": {
-    "station_name": "Beltring Rail Station",
+    "station_name": "Beltring",
     "latitude": 51.2047052539,
     "longitude": 0.4035240323
   },
   "BEH": {
-    "station_name": "Bedworth Rail Station",
+    "station_name": "Bedworth",
     "latitude": 52.4793121537,
     "longitude": -1.4673840381
   },
   "BEL": {
-    "station_name": "Beauly Rail Station",
+    "station_name": "Beauly",
     "latitude": 57.4782638344,
     "longitude": -4.4698634331
   },
   "BEM": {
-    "station_name": "Bempton Rail Station",
+    "station_name": "Bempton",
     "latitude": 54.1276779105,
     "longitude": -0.1804704307
   },
   "BEN": {
-    "station_name": "Bentham Rail Station",
+    "station_name": "Bentham",
     "latitude": 54.115527405,
     "longitude": -2.5106784228
   },
   "BEP": {
-    "station_name": "Bermuda Park Rail Station",
+    "station_name": "Bermuda Park",
     "latitude": 52.5014490814,
     "longitude": -1.4721692914
   },
   "BER": {
-    "station_name": "Bearley Rail Station",
+    "station_name": "Bearley",
     "latitude": 52.2444229433,
     "longitude": -1.7502469172
   },
   "BES": {
-    "station_name": "Bescar Lane Rail Station",
+    "station_name": "Bescar Lane",
     "latitude": 53.6238666357,
     "longitude": -2.914609859
   },
   "BET": {
-    "station_name": "Bethnal Green Rail Station",
+    "station_name": "Bethnal Green",
     "latitude": 51.5239168448,
     "longitude": -0.0595413255
   },
   "BEU": {
-    "station_name": "Beaulieu Road Rail Station",
+    "station_name": "Beaulieu Road",
     "latitude": 50.8550379245,
     "longitude": -1.5047402125
   },
   "BEV": {
-    "station_name": "Beverley Rail Station",
+    "station_name": "Beverley",
     "latitude": 53.8422910042,
     "longitude": -0.4229880841
   },
   "BEX": {
-    "station_name": "Bexhill Rail Station",
+    "station_name": "Bexhill",
     "latitude": 50.8410361246,
     "longitude": 0.4770465179
   },
   "BEY": {
-    "station_name": "Ben Rhydding Rail Station",
+    "station_name": "Ben Rhydding",
     "latitude": 53.9257271035,
     "longitude": -1.797433526
   },
   "BFD": {
-    "station_name": "Brentford Rail Station",
+    "station_name": "Brentford",
     "latitude": 51.4875455966,
     "longitude": -0.3096291503
   },
   "BFE": {
-    "station_name": "Bere Ferrers Rail Station",
+    "station_name": "Bere Ferrers",
     "latitude": 50.4512627598,
     "longitude": -4.1814634554
   },
   "BFF": {
-    "station_name": "Blaenau Ffestiniog Rail Station",
+    "station_name": "Blaenau Ffestiniog",
     "latitude": 52.9945625755,
     "longitude": -3.9386014215
   },
   "BFN": {
-    "station_name": "Byfleet & New Haw Rail Station",
+    "station_name": "Byfleet & New Haw",
     "latitude": 51.3497933814,
     "longitude": -0.4813698884
   },
   "BFR": {
-    "station_name": "London Blackfriars Rail Station",
+    "station_name": "London Blackfriars",
     "latitude": 51.511809604,
     "longitude": -0.1033064322
   },
   "BGA": {
-    "station_name": "Brundall Gardens Rail Station",
+    "station_name": "Brundall Gardens",
     "latitude": 52.6234667847,
     "longitude": 1.4184395543
   },
   "BGD": {
-    "station_name": "Bargoed Rail Station",
+    "station_name": "Bargoed",
     "latitude": 51.6923106201,
     "longitude": -3.2296893004
   },
   "BGE": {
-    "station_name": "Broad Green Rail Station",
+    "station_name": "Broad Green",
     "latitude": 53.4065176265,
     "longitude": -2.8934838097
   },
   "BGG": {
-    "station_name": "Brigg Rail Station",
+    "station_name": "Brigg",
     "latitude": 53.5491644813,
     "longitude": -0.4861278561
   },
   "BGH": {
-    "station_name": "Brighouse Rail Station",
+    "station_name": "Brighouse",
     "latitude": 53.6982108642,
     "longitude": -1.7794410593
   },
   "BGI": {
-    "station_name": "Bargeddie Rail Station",
+    "station_name": "Bargeddie",
     "latitude": 55.8512854533,
     "longitude": -4.073795488
   },
   "BGL": {
-    "station_name": "Bugle Rail Station",
+    "station_name": "Bugle",
     "latitude": 50.4003357574,
     "longitude": -4.7921412594
   },
   "BGM": {
-    "station_name": "Bellingham Rail Station",
+    "station_name": "Bellingham",
     "latitude": 51.432910924,
     "longitude": -0.0193048772
   },
   "BGN": {
-    "station_name": "Bridgend Rail Station",
+    "station_name": "Bridgend",
     "latitude": 51.5069726538,
     "longitude": -3.5752917878
   },
   "BGS": {
-    "station_name": "Bogston Rail Station",
+    "station_name": "Bogston",
     "latitude": 55.9370336273,
     "longitude": -4.7113815133
   },
+  "BGV": {
+    "station_name": "Barking Riverside",
+    "latitude": 51.519108,
+    "longitude": 0.114764
+  },
   "BHC": {
-    "station_name": "Balloch Rail Station",
+    "station_name": "Balloch",
     "latitude": 56.0029254961,
     "longitude": -4.5834681974
   },
   "BHD": {
-    "station_name": "Brithdir Rail Station",
+    "station_name": "Brithdir",
     "latitude": 51.7103040613,
     "longitude": -3.2287299229
   },
   "BHG": {
-    "station_name": "Bathgate Rail Station",
+    "station_name": "Bathgate",
     "latitude": 55.8971463148,
     "longitude": -3.6360891747
   },
   "BHI": {
-    "station_name": "Birmingham International Rail Station",
+    "station_name": "Birmingham International",
     "latitude": 52.4508199122,
     "longitude": -1.7258497513
   },
   "BHK": {
-    "station_name": "Bush Hill Park Rail Station",
+    "station_name": "Bush Hill Park",
     "latitude": 51.6415193249,
     "longitude": -0.0691949356
   },
   "BHM": {
-    "station_name": "Birmingham New Street Rail Station",
+    "station_name": "Birmingham New Street",
     "latitude": 52.4778312827,
     "longitude": -1.9002004707
   },
   "BHO": {
-    "station_name": "Blackhorse Road Rail Station",
+    "station_name": "Blackhorse Road",
     "latitude": 51.5866055024,
     "longitude": -0.041209942
   },
   "BHR": {
-    "station_name": "Builth Road Rail Station",
+    "station_name": "Builth Road",
     "latitude": 52.1693300616,
     "longitude": -3.4270408474
   },
   "BHS": {
-    "station_name": "Brockholes Rail Station",
+    "station_name": "Brockholes",
     "latitude": 53.5969856546,
     "longitude": -1.7696922549
   },
   "BIA": {
-    "station_name": "Bishop Auckland Rail Station",
+    "station_name": "Bishop Auckland",
     "latitude": 54.6572030524,
     "longitude": -1.6777249795
   },
@@ -1115,1652 +1125,1657 @@
     "longitude": -3.194339982
   },
   "BIC": {
-    "station_name": "Billericay Rail Station",
+    "station_name": "Billericay",
     "latitude": 51.6288849556,
     "longitude": 0.4186576571
   },
   "BID": {
-    "station_name": "Bidston Rail Station",
+    "station_name": "Bidston",
     "latitude": 53.4091524654,
     "longitude": -3.0785590277
   },
   "BIF": {
-    "station_name": "Barrow-in-Furness Rail Station",
+    "station_name": "Barrow-in-Furness",
     "latitude": 54.1190066162,
     "longitude": -3.2261172119
   },
   "BIG": {
-    "station_name": "Billingshurst Rail Station",
+    "station_name": "Billingshurst",
     "latitude": 51.0151974096,
     "longitude": -0.4502767801
   },
   "BIK": {
-    "station_name": "Birkbeck Rail Station",
+    "station_name": "Birkbeck",
     "latitude": 51.403888888,
     "longitude": -0.0557126082
   },
   "BIL": {
-    "station_name": "Billingham Rail Station",
+    "station_name": "Billingham",
     "latitude": 54.6056166679,
     "longitude": -1.2797344554
   },
   "BIN": {
-    "station_name": "Bingham Rail Station",
+    "station_name": "Bingham",
     "latitude": 52.9542094023,
     "longitude": -0.9515394619
   },
   "BIO": {
-    "station_name": "Baillieston Rail Station",
+    "station_name": "Baillieston",
     "latitude": 55.8444952694,
     "longitude": -4.1136857366
   },
   "BIP": {
-    "station_name": "Bishopstone Rail Station",
+    "station_name": "Bishopstone",
     "latitude": 50.7801363721,
     "longitude": 0.0827845347
   },
   "BIS": {
-    "station_name": "Bishops Stortford Rail Station",
+    "station_name": "Bishops Stortford",
     "latitude": 51.8666972924,
     "longitude": 0.1649202653
   },
   "BIT": {
-    "station_name": "Bicester Village Rail Station",
+    "station_name": "Bicester Village",
     "latitude": 51.8930294144,
     "longitude": -1.1487446761
   },
   "BIW": {
-    "station_name": "Biggleswade Rail Station",
+    "station_name": "Biggleswade",
     "latitude": 52.0846893974,
     "longitude": -0.2611631855
   },
   "BIY": {
-    "station_name": "Bingley Rail Station",
+    "station_name": "Bingley",
     "latitude": 53.8486270204,
     "longitude": -1.8373250124
   },
   "BKA": {
-    "station_name": "Bookham Rail Station",
+    "station_name": "Bookham",
     "latitude": 51.2887348796,
     "longitude": -0.3839979684
   },
   "BKC": {
-    "station_name": "Birkenhead Central Rail Station",
+    "station_name": "Birkenhead Central",
     "latitude": 53.388328806,
     "longitude": -3.0208206224
   },
   "BKD": {
-    "station_name": "Blakedown Rail Station",
+    "station_name": "Blakedown",
     "latitude": 52.406413288,
     "longitude": -2.1768606091
   },
   "BKG": {
-    "station_name": "Barking Rail Station",
+    "station_name": "Barking",
     "latitude": 51.5394940483,
     "longitude": 0.0809293557
   },
   "BKH": {
-    "station_name": "Blackheath Rail Station",
+    "station_name": "Blackheath",
     "latitude": 51.4657947771,
     "longitude": 0.0088974464
   },
   "BKJ": {
-    "station_name": "Beckenham Junction Rail Station",
+    "station_name": "Beckenham Junction",
     "latitude": 51.4111710618,
     "longitude": -0.0259963666
   },
   "BKL": {
-    "station_name": "Bickley Rail Station",
+    "station_name": "Bickley",
     "latitude": 51.4001025009,
     "longitude": 0.0452659962
   },
   "BKM": {
-    "station_name": "Berkhamsted Rail Station",
+    "station_name": "Berkhamsted",
     "latitude": 51.7631393379,
     "longitude": -0.5619899853
   },
   "BKN": {
-    "station_name": "Birkenhead North Rail Station",
+    "station_name": "Birkenhead North",
     "latitude": 53.4044504204,
     "longitude": -3.057532076
   },
   "BKO": {
-    "station_name": "Brookwood Rail Station",
+    "station_name": "Brookwood",
     "latitude": 51.3037544754,
     "longitude": -0.6357308777
   },
   "BKP": {
-    "station_name": "Birkenhead Park Rail Station",
+    "station_name": "Birkenhead Park",
     "latitude": 53.3974209727,
     "longitude": -3.039100208
   },
   "BKQ": {
-    "station_name": "Birkenhead Hamilton Square Rail Station",
+    "station_name": "Birkenhead Hamilton Square",
     "latitude": 53.3947090805,
     "longitude": -3.013679563
   },
   "BKR": {
-    "station_name": "Blackridge Rail Station",
+    "station_name": "Blackridge",
     "latitude": 55.8842459211,
     "longitude": -3.7507875146
   },
   "BKS": {
-    "station_name": "Bekesbourne Rail Station",
+    "station_name": "Bekesbourne",
     "latitude": 51.2613599688,
     "longitude": 1.136737067
   },
   "BKT": {
-    "station_name": "Blake Street Rail Station",
+    "station_name": "Blake Street",
     "latitude": 52.6048991066,
     "longitude": -1.8449076544
   },
   "BKW": {
-    "station_name": "Berkswell Rail Station",
+    "station_name": "Berkswell",
     "latitude": 52.3958946388,
     "longitude": -1.6428309089
   },
   "BLA": {
-    "station_name": "Blair Atholl Rail Station",
+    "station_name": "Blair Atholl",
     "latitude": 56.7655325077,
     "longitude": -3.8502251597
   },
   "BLB": {
-    "station_name": "Battlesbridge Rail Station",
+    "station_name": "Battlesbridge",
     "latitude": 51.6248280358,
     "longitude": 0.5653129218
   },
   "BLD": {
-    "station_name": "Baildon Rail Station",
+    "station_name": "Baildon",
     "latitude": 53.8502374199,
     "longitude": -1.7536396791
   },
   "BLE": {
-    "station_name": "Bramley (West Yorks) Rail Station",
+    "station_name": "Bramley (West Yorks)",
     "latitude": 53.8053627078,
     "longitude": -1.6372110715
   },
   "BLG": {
-    "station_name": "Bellgrove Rail Station",
+    "station_name": "Bellgrove",
     "latitude": 55.8566980297,
     "longitude": -4.2243600625
   },
   "BLH": {
-    "station_name": "Bellshill Rail Station",
+    "station_name": "Bellshill",
     "latitude": 55.8170582892,
     "longitude": -4.0244880674
   },
   "BLK": {
-    "station_name": "Blackrod Rail Station",
+    "station_name": "Blackrod",
     "latitude": 53.5915357166,
     "longitude": -2.5695231754
   },
   "BLL": {
-    "station_name": "Bardon Mill Rail Station",
+    "station_name": "Bardon Mill",
     "latitude": 54.9744979891,
     "longitude": -2.346513133
   },
   "BLM": {
-    "station_name": "Belmont Rail Station",
+    "station_name": "Belmont",
     "latitude": 51.3438116974,
     "longitude": -0.1988301486
   },
   "BLN": {
-    "station_name": "Blundellsands & Crosby Rail Station",
+    "station_name": "Blundellsands & Crosby",
     "latitude": 53.4876981044,
     "longitude": -3.0398576774
   },
   "BLO": {
-    "station_name": "Blaydon Rail Station",
+    "station_name": "Blaydon",
     "latitude": 54.9657939357,
     "longitude": -1.7125935978
   },
   "BLP": {
-    "station_name": "Belper Rail Station",
+    "station_name": "Belper",
     "latitude": 53.0237754008,
     "longitude": -1.482508538
   },
   "BLT": {
-    "station_name": "Blantyre Rail Station",
+    "station_name": "Blantyre",
     "latitude": 55.7973203505,
     "longitude": -4.0869580948
   },
   "BLV": {
-    "station_name": "Belle Vue Rail Station",
+    "station_name": "Belle Vue",
     "latitude": 53.4623891164,
     "longitude": -2.1805056874
   },
   "BLW": {
-    "station_name": "Bulwell Rail Station",
+    "station_name": "Bulwell",
     "latitude": 52.9997132956,
     "longitude": -1.1962272378
   },
   "BLX": {
-    "station_name": "Bloxwich Rail Station",
+    "station_name": "Bloxwich",
     "latitude": 52.6182145823,
     "longitude": -2.0114721566
   },
   "BLY": {
-    "station_name": "Bletchley Rail Station",
+    "station_name": "Bletchley",
     "latitude": 51.9953423523,
     "longitude": -0.7362994344
   },
   "BMB": {
-    "station_name": "Bamber Bridge Rail Station",
+    "station_name": "Bamber Bridge",
     "latitude": 53.7268807835,
     "longitude": -2.6607719493
   },
   "BMC": {
-    "station_name": "Bromley Cross Rail Station",
+    "station_name": "Bromley Cross",
     "latitude": 53.61405521,
     "longitude": -2.4108970227
   },
   "BMD": {
-    "station_name": "Brimsdown Rail Station",
+    "station_name": "Brimsdown",
     "latitude": 51.6555835568,
     "longitude": -0.0307911888
   },
   "BME": {
-    "station_name": "Broome Rail Station",
+    "station_name": "Broome",
     "latitude": 52.4227839595,
     "longitude": -2.8852059507
   },
   "BMF": {
-    "station_name": "Broomfleet Rail Station",
+    "station_name": "Broomfleet",
     "latitude": 53.7402272872,
     "longitude": -0.6718345795
   },
   "BMG": {
-    "station_name": "Barming Rail Station",
+    "station_name": "Barming",
     "latitude": 51.2848921433,
     "longitude": 0.4789874974
   },
   "BMH": {
-    "station_name": "Bournemouth Rail Station",
+    "station_name": "Bournemouth",
     "latitude": 50.7272603225,
     "longitude": -1.8644946471
   },
   "BML": {
-    "station_name": "Bramhall Rail Station",
+    "station_name": "Bramhall",
     "latitude": 53.3606279318,
     "longitude": -2.1635920263
   },
   "BMN": {
-    "station_name": "Bromley North Rail Station",
+    "station_name": "Bromley North",
     "latitude": 51.4083255508,
     "longitude": 0.0170184004
   },
   "BMO": {
-    "station_name": "Birmingham Moor Street Rail Station",
+    "station_name": "Birmingham Moor Street",
     "latitude": 52.4790920668,
     "longitude": -1.8924677323
   },
   "BMP": {
-    "station_name": "Brampton (Cumbria) Rail Station",
+    "station_name": "Brampton (Cumbria)",
     "latitude": 54.9323952275,
     "longitude": -2.7029523076
   },
   "BMR": {
-    "station_name": "Bromborough Rake Rail Station",
+    "station_name": "Bromborough Rake",
     "latitude": 53.3299208626,
     "longitude": -2.9894688327
   },
   "BMS": {
-    "station_name": "Bromley South Rail Station",
+    "station_name": "Bromley South",
     "latitude": 51.3999742022,
     "longitude": 0.0173696569
   },
   "BMT": {
-    "station_name": "Bedminster Rail Station",
+    "station_name": "Bedminster",
     "latitude": 51.4400845068,
     "longitude": -2.5941516846
   },
   "BMV": {
-    "station_name": "Bromsgrove Rail Station",
+    "station_name": "Bromsgrove",
     "latitude": 52.3222981835,
     "longitude": -2.0473389281
   },
   "BMY": {
-    "station_name": "Bramley (Hants) Rail Station",
+    "station_name": "Bramley (Hants)",
     "latitude": 51.330292014,
     "longitude": -1.0609834929
   },
   "BNA": {
-    "station_name": "Burnage Rail Station",
+    "station_name": "Burnage",
     "latitude": 53.4211811715,
     "longitude": -2.2156768396
   },
   "BNC": {
-    "station_name": "Burnley Central Rail Station",
+    "station_name": "Burnley Central",
     "latitude": 53.7935247085,
     "longitude": -2.2449718815
   },
   "BND": {
-    "station_name": "Brandon Rail Station",
+    "station_name": "Brandon",
     "latitude": 52.4540242165,
     "longitude": 0.6247556786
   },
   "BNE": {
-    "station_name": "Bourne End Rail Station",
+    "station_name": "Bourne End",
     "latitude": 51.5771193996,
     "longitude": -0.7104544193
   },
   "BNF": {
-    "station_name": "Briton Ferry Rail Station",
+    "station_name": "Briton Ferry",
     "latitude": 51.6378987804,
     "longitude": -3.8192683057
   },
   "BNG": {
-    "station_name": "Bangor (Gwynedd) Rail Station",
+    "station_name": "Bangor (Gwynedd)",
     "latitude": 53.2222979654,
     "longitude": -4.1358869294
   },
   "BNH": {
-    "station_name": "Barnehurst Rail Station",
+    "station_name": "Barnehurst",
     "latitude": 51.4649576152,
     "longitude": 0.1596730747
   },
   "BNI": {
-    "station_name": "Barnes Bridge Rail Station",
+    "station_name": "Barnes Bridge",
     "latitude": 51.4720070868,
     "longitude": -0.2526072102
   },
   "BNL": {
-    "station_name": "Barnhill Rail Station",
+    "station_name": "Barnhill",
     "latitude": 55.8774834443,
     "longitude": -4.2229911506
   },
   "BNM": {
-    "station_name": "Burnham (Berks) Rail Station",
+    "station_name": "Burnham (Berks)",
     "latitude": 51.5235064374,
     "longitude": -0.6463561439
   },
   "BNP": {
-    "station_name": "Barnstaple Rail Station",
+    "station_name": "Barnstaple",
     "latitude": 51.0739644921,
     "longitude": -4.0631402025
   },
   "BNR": {
-    "station_name": "Brockley Whins Rail Station",
+    "station_name": "Brockley Whins",
     "latitude": 54.9595502728,
     "longitude": -1.4613667215
   },
   "BNS": {
-    "station_name": "Barnes Rail Station",
+    "station_name": "Barnes",
     "latitude": 51.4670846365,
     "longitude": -0.2421410454
   },
   "BNT": {
-    "station_name": "Brinnington Rail Station",
+    "station_name": "Brinnington",
     "latitude": 53.432131208,
     "longitude": -2.1351183485
   },
   "BNV": {
-    "station_name": "Banavie Rail Station",
+    "station_name": "Banavie",
     "latitude": 56.8432899877,
     "longitude": -5.0954121623
   },
   "BNW": {
-    "station_name": "Bootle New Strand Rail Station",
+    "station_name": "Bootle New Strand",
     "latitude": 53.4534030856,
     "longitude": -2.9947465497
   },
   "BNY": {
-    "station_name": "Barnsley Rail Station",
+    "station_name": "Barnsley",
     "latitude": 53.5543175422,
     "longitude": -1.47716617
   },
   "BOA": {
-    "station_name": "Bradford-on-Avon Rail Station",
+    "station_name": "Bradford-on-Avon",
     "latitude": 51.3449090983,
     "longitude": -2.2523240424
   },
   "BOC": {
-    "station_name": "Bootle (Cumbria) Rail Station",
+    "station_name": "Bootle (Cumbria)",
     "latitude": 54.291308954,
     "longitude": -3.3938621381
   },
   "BOD": {
-    "station_name": "Bodmin Parkway Rail Station",
+    "station_name": "Bodmin Parkway",
     "latitude": 50.4458496871,
     "longitude": -4.6629674421
   },
   "BOE": {
-    "station_name": "Botley Rail Station",
+    "station_name": "Botley",
     "latitude": 50.9164438022,
     "longitude": -1.2592242694
   },
   "BOG": {
-    "station_name": "Bognor Regis Rail Station",
+    "station_name": "Bognor Regis",
     "latitude": 50.786547177,
     "longitude": -0.6761573725
   },
   "BOH": {
-    "station_name": "Bosham Rail Station",
+    "station_name": "Bosham",
     "latitude": 50.8427366135,
     "longitude": -0.8474129936
   },
   "BOM": {
-    "station_name": "Bromborough Rail Station",
+    "station_name": "Bromborough",
     "latitude": 53.321860927,
     "longitude": -2.9868952277
   },
   "BON": {
-    "station_name": "Bolton Rail Station",
+    "station_name": "Bolton",
     "latitude": 53.5741575045,
     "longitude": -2.425822783
   },
   "BOP": {
-    "station_name": "Bowes Park Rail Station",
+    "station_name": "Bowes Park",
     "latitude": 51.6070128955,
     "longitude": -0.1205568702
   },
   "BOR": {
-    "station_name": "Bodorgan Rail Station",
+    "station_name": "Bodorgan",
     "latitude": 53.2043181126,
     "longitude": -4.4180098996
   },
   "BOT": {
-    "station_name": "Bootle Oriel Road Rail Station",
+    "station_name": "Bootle Oriel Road",
     "latitude": 53.4466353518,
     "longitude": -2.9957327823
   },
+  "BOW": {
+    "station_name": "Bow Street",
+    "latitude": 52.4400,
+    "longitude": -4.0303
+  },
   "BPB": {
-    "station_name": "Blackpool Pleasure Beach Rail Station",
+    "station_name": "Blackpool Pleasure Beach",
     "latitude": 53.7879651191,
     "longitude": -3.0538730548
   },
   "BPC": {
-    "station_name": "Penychain Rail Station",
+    "station_name": "Penychain",
     "latitude": 52.9028982685,
     "longitude": -4.3387298378
   },
   "BPK": {
-    "station_name": "Brookmans Park Rail Station",
+    "station_name": "Brookmans Park",
     "latitude": 51.7210644329,
     "longitude": -0.204525873
   },
   "BPN": {
-    "station_name": "Blackpool North Rail Station",
+    "station_name": "Blackpool North",
     "latitude": 53.8219272752,
     "longitude": -3.0492707494
   },
   "BPS": {
-    "station_name": "Blackpool South Rail Station",
+    "station_name": "Blackpool South",
     "latitude": 53.7987134952,
     "longitude": -3.0489347667
   },
   "BPT": {
-    "station_name": "Bishopton Rail Station",
+    "station_name": "Bishopton",
     "latitude": 55.9022563659,
     "longitude": -4.5004702272
   },
   "BPW": {
-    "station_name": "Bristol Parkway Rail Station",
+    "station_name": "Bristol Parkway",
     "latitude": 51.5137984154,
     "longitude": -2.5421644857
   },
   "BRA": {
-    "station_name": "Brora Rail Station",
+    "station_name": "Brora",
     "latitude": 58.012933425,
     "longitude": -3.8522865622
   },
   "BRC": {
-    "station_name": "Breich Rail Station",
+    "station_name": "Breich",
     "latitude": 55.8273074741,
     "longitude": -3.6681187271
   },
   "BRE": {
-    "station_name": "Brentwood Rail Station",
+    "station_name": "Brentwood",
     "latitude": 51.6136062194,
     "longitude": 0.2996132443
   },
   "BRF": {
-    "station_name": "Brierfield Rail Station",
+    "station_name": "Brierfield",
     "latitude": 53.8239929448,
     "longitude": -2.2364914709
   },
   "BRG": {
-    "station_name": "Borough Green & Wrotham Rail Station",
+    "station_name": "Borough Green & Wrotham",
     "latitude": 51.293215966,
     "longitude": 0.3062721999
   },
   "BRH": {
-    "station_name": "Borth Rail Station",
+    "station_name": "Borth",
     "latitude": 52.4910411643,
     "longitude": -4.0501863389
   },
   "BRI": {
-    "station_name": "Bristol Temple Meads Rail Station",
+    "station_name": "Bristol Temple Meads",
     "latitude": 51.4491404983,
     "longitude": -2.5813170589
   },
   "BRK": {
-    "station_name": "Berwick (Sussex) Rail Station",
+    "station_name": "Berwick (Sussex)",
     "latitude": 50.8403713146,
     "longitude": 0.1660450404
   },
   "BRL": {
-    "station_name": "Barrhill Rail Station",
+    "station_name": "Barrhill",
     "latitude": 55.0970097604,
     "longitude": -4.7817610115
   },
   "BRM": {
-    "station_name": "Barmouth Rail Station",
+    "station_name": "Barmouth",
     "latitude": 52.7229049113,
     "longitude": -4.0566037471
   },
   "BRN": {
-    "station_name": "Bearsden Rail Station",
+    "station_name": "Bearsden",
     "latitude": 55.9171219632,
     "longitude": -4.3320048257
   },
   "BRO": {
-    "station_name": "Bridge of Orchy Rail Station",
+    "station_name": "Bridge of Orchy",
     "latitude": 56.5158519882,
     "longitude": -4.7629778286
   },
   "BRP": {
-    "station_name": "Brampton (Suffolk) Rail Station",
+    "station_name": "Brampton (Suffolk)",
     "latitude": 52.39545585,
     "longitude": 1.5438396721
   },
   "BRR": {
-    "station_name": "Barrhead Rail Station",
+    "station_name": "Barrhead",
     "latitude": 55.8037470316,
     "longitude": -4.3972682443
   },
   "BRS": {
-    "station_name": "Berrylands Rail Station",
+    "station_name": "Berrylands",
     "latitude": 51.3990426839,
     "longitude": -0.280691098
   },
   "BRT": {
-    "station_name": "Barlaston Rail Station",
+    "station_name": "Barlaston",
     "latitude": 52.9428868109,
     "longitude": -2.1681101939
   },
   "BRU": {
-    "station_name": "Bruton Rail Station",
+    "station_name": "Bruton",
     "latitude": 51.1116312549,
     "longitude": -2.4470735628
   },
   "BRV": {
-    "station_name": "Bournville Rail Station",
+    "station_name": "Bournville",
     "latitude": 52.4269759491,
     "longitude": -1.9264177275
   },
   "BRW": {
-    "station_name": "Brunswick Rail Station",
+    "station_name": "Brunswick",
     "latitude": 53.3832558566,
     "longitude": -2.9760770621
   },
   "BRX": {
-    "station_name": "Brixton Rail Station",
+    "station_name": "Brixton",
     "latitude": 51.4632979174,
     "longitude": -0.1141578263
   },
   "BRY": {
-    "station_name": "Barry Rail Station",
+    "station_name": "Barry",
     "latitude": 51.3967799856,
     "longitude": -3.2849950221
   },
   "BSB": {
-    "station_name": "Bleasby Rail Station",
+    "station_name": "Bleasby",
     "latitude": 53.0413834346,
     "longitude": -0.9436832322
   },
   "BSC": {
-    "station_name": "Bescot Stadium Rail Station",
+    "station_name": "Bescot Stadium",
     "latitude": 52.5631069514,
     "longitude": -1.9911001339
   },
   "BSD": {
-    "station_name": "Bearsted Rail Station",
+    "station_name": "Bearsted",
     "latitude": 51.2758186317,
     "longitude": 0.5776101903
   },
   "BSE": {
-    "station_name": "Bury St Edmunds Rail Station",
+    "station_name": "Bury St Edmunds",
     "latitude": 52.2537779145,
     "longitude": 0.7133353034
   },
   "BSH": {
-    "station_name": "Bushey Rail Station",
+    "station_name": "Bushey",
     "latitude": 51.6457542219,
     "longitude": -0.3852982939
   },
   "BSI": {
-    "station_name": "Balmossie Rail Station",
+    "station_name": "Balmossie",
     "latitude": 56.4745544268,
     "longitude": -2.8389594192
   },
   "BSJ": {
-    "station_name": "Bedford St Johns Rail Station",
+    "station_name": "Bedford St Johns",
     "latitude": 52.1294885146,
     "longitude": -0.4674793726
   },
   "BSK": {
-    "station_name": "Basingstoke Rail Station",
+    "station_name": "Basingstoke",
     "latitude": 51.2683550841,
     "longitude": -1.0872452751
   },
   "BSL": {
-    "station_name": "Beasdale Rail Station",
+    "station_name": "Beasdale",
     "latitude": 56.8995320852,
     "longitude": -5.7637827088
   },
   "BSM": {
-    "station_name": "Branksome Rail Station",
+    "station_name": "Branksome",
     "latitude": 50.7269511745,
     "longitude": -1.9197490477
   },
   "BSN": {
-    "station_name": "Boston Rail Station",
+    "station_name": "Boston",
     "latitude": 52.9781123717,
     "longitude": -0.0309954737
   },
   "BSO": {
-    "station_name": "Basildon Rail Station",
+    "station_name": "Basildon",
     "latitude": 51.5681072863,
     "longitude": 0.4568185797
   },
   "BSP": {
-    "station_name": "Brondesbury Park Rail Station",
+    "station_name": "Brondesbury Park",
     "latitude": 51.5406994758,
     "longitude": -0.2101030164
   },
   "BSR": {
-    "station_name": "Broadstairs Rail Station",
+    "station_name": "Broadstairs",
     "latitude": 51.3606801474,
     "longitude": 1.4335860392
   },
   "BSS": {
-    "station_name": "Barassie Rail Station",
+    "station_name": "Barassie",
     "latitude": 55.5610564283,
     "longitude": -4.6511181093
   },
   "BSU": {
-    "station_name": "Brunstane Rail Station",
+    "station_name": "Brunstane",
     "latitude": 55.9425045311,
     "longitude": -3.1009897555
   },
   "BSV": {
-    "station_name": "Buckshaw Parkway Rail Station",
+    "station_name": "Buckshaw Parkway",
     "latitude": 53.6733558277,
     "longitude": -2.6608267264
   },
   "BSW": {
-    "station_name": "Birmingham Snow Hill Rail Station",
+    "station_name": "Birmingham Snow Hill",
     "latitude": 52.4833681846,
     "longitude": -1.89908361
   },
   "BSY": {
-    "station_name": "Brondesbury Rail Station",
+    "station_name": "Brondesbury",
     "latitude": 51.5451661494,
     "longitude": -0.2022838772
   },
   "BTB": {
-    "station_name": "Barnetby Rail Station",
+    "station_name": "Barnetby",
     "latitude": 53.5751404569,
     "longitude": -0.4096836565
   },
   "BTD": {
-    "station_name": "Bolton-Upon-Dearne Rail Station",
+    "station_name": "Bolton-Upon-Dearne",
     "latitude": 53.5189640059,
     "longitude": -1.3115478698
   },
   "BTE": {
-    "station_name": "Bitterne Rail Station",
+    "station_name": "Bitterne",
     "latitude": 50.9182096759,
     "longitude": -1.3769901266
   },
   "BTF": {
-    "station_name": "Bottesford Rail Station",
+    "station_name": "Bottesford",
     "latitude": 52.944634247,
     "longitude": -0.7948377662
   },
   "BTG": {
-    "station_name": "Barnt Green Rail Station",
+    "station_name": "Barnt Green",
     "latitude": 52.3611012481,
     "longitude": -1.9924584823
   },
   "BTH": {
-    "station_name": "Bath Spa Rail Station",
+    "station_name": "Bath Spa",
     "latitude": 51.3776813346,
     "longitude": -2.3570165586
   },
   "BTL": {
-    "station_name": "Batley Rail Station",
+    "station_name": "Batley",
     "latitude": 53.7099546488,
     "longitude": -1.6229560553
   },
   "BTN": {
-    "station_name": "Brighton Rail Station",
+    "station_name": "Brighton",
     "latitude": 50.8289969623,
     "longitude": -0.1412525289
   },
   "BTO": {
-    "station_name": "Betchworth Rail Station",
+    "station_name": "Betchworth",
     "latitude": 51.2481856234,
     "longitude": -0.2669489143
   },
   "BTP": {
-    "station_name": "Braintree Freeport Rail Station",
+    "station_name": "Braintree Freeport",
     "latitude": 51.86942396,
     "longitude": 0.5684631055
   },
   "BTR": {
-    "station_name": "Braintree Rail Station",
+    "station_name": "Braintree",
     "latitude": 51.8753991861,
     "longitude": 0.5567148512
   },
   "BTS": {
-    "station_name": "Burntisland Rail Station",
+    "station_name": "Burntisland",
     "latitude": 56.0570735491,
     "longitude": -3.233198596
   },
   "BTT": {
-    "station_name": "Battersby Rail Station",
+    "station_name": "Battersby",
     "latitude": 54.4576909817,
     "longitude": -1.092985447
   },
   "BTY": {
-    "station_name": "Bentley (Hants) Rail Station",
+    "station_name": "Bentley (Hants)",
     "latitude": 51.1812286564,
     "longitude": -0.8681101444
   },
   "BUB": {
-    "station_name": "Burnley Barracks Rail Station",
+    "station_name": "Burnley Barracks",
     "latitude": 53.7908906624,
     "longitude": -2.2580864157
   },
   "BUC": {
-    "station_name": "Buckenham Rail Station",
+    "station_name": "Buckenham",
     "latitude": 52.5977618232,
     "longitude": 1.4703489483
   },
   "BUD": {
-    "station_name": "Burneside (Cumbria) Rail Station",
+    "station_name": "Burneside (Cumbria)",
     "latitude": 54.3549872461,
     "longitude": -2.7666793226
   },
   "BUE": {
-    "station_name": "Bures Rail Station",
+    "station_name": "Bures",
     "latitude": 51.9711715742,
     "longitude": 0.7691763467
   },
   "BUG": {
-    "station_name": "Burgess Hill Rail Station",
+    "station_name": "Burgess Hill",
     "latitude": 50.9536493887,
     "longitude": -0.1273860328
   },
   "BUH": {
-    "station_name": "Brough Rail Station",
+    "station_name": "Brough",
     "latitude": 53.7269790626,
     "longitude": -0.5787296823
   },
   "BUI": {
-    "station_name": "Burnside (Strathclyde) Rail Station",
+    "station_name": "Burnside (Strathclyde)",
     "latitude": 55.8169207887,
     "longitude": -4.2023757518
   },
   "BUJ": {
-    "station_name": "Burton Joyce Rail Station",
+    "station_name": "Burton Joyce",
     "latitude": 52.9834597732,
     "longitude": -1.0408745342
   },
   "BUK": {
-    "station_name": "Bucknell Rail Station",
+    "station_name": "Bucknell",
     "latitude": 52.3573903067,
     "longitude": -2.94737686
   },
   "BUL": {
-    "station_name": "Butlers Lane Rail Station",
+    "station_name": "Butlers Lane",
     "latitude": 52.5924838341,
     "longitude": -1.8380133232
   },
   "BUO": {
-    "station_name": "Bursledon Rail Station",
+    "station_name": "Bursledon",
     "latitude": 50.8836771224,
     "longitude": -1.3050217804
   },
   "BUS": {
-    "station_name": "Busby Rail Station",
+    "station_name": "Busby",
     "latitude": 55.7803335966,
     "longitude": -4.2621874207
   },
   "BUT": {
-    "station_name": "Burton-on-Trent Rail Station",
+    "station_name": "Burton-on-Trent",
     "latitude": 52.805831535,
     "longitude": -1.6424549107
   },
   "BUU": {
-    "station_name": "Burnham-on-Crouch Rail Station",
+    "station_name": "Burnham-on-Crouch",
     "latitude": 51.6336616952,
     "longitude": 0.8140576821
   },
   "BUW": {
-    "station_name": "Burley-in-Wharfedale Rail Station",
+    "station_name": "Burley-in-Wharfedale",
     "latitude": 53.9081639278,
     "longitude": -1.7533757307
   },
   "BUX": {
-    "station_name": "Buxton Rail Station",
+    "station_name": "Buxton",
     "latitude": 53.2607356445,
     "longitude": -1.9128621475
   },
   "BUY": {
-    "station_name": "Burley Park Rail Station",
+    "station_name": "Burley Park",
     "latitude": 53.8120445498,
     "longitude": -1.5777714582
   },
   "BVD": {
-    "station_name": "Belvedere Rail Station",
+    "station_name": "Belvedere",
     "latitude": 51.4921169254,
     "longitude": 0.1523141776
   },
   "BWB": {
-    "station_name": "Bow Brickhill Rail Station",
+    "station_name": "Bow Brickhill",
     "latitude": 52.0043090172,
     "longitude": -0.6960564274
   },
   "BWD": {
-    "station_name": "Birchwood Rail Station",
+    "station_name": "Birchwood",
     "latitude": 53.4127333746,
     "longitude": -2.5253084603
   },
   "BWG": {
-    "station_name": "Bowling Rail Station",
+    "station_name": "Bowling",
     "latitude": 55.9310714655,
     "longitude": -4.4938258606
   },
   "BWK": {
-    "station_name": "Berwick-upon-Tweed Rail Station",
+    "station_name": "Berwick-upon-Tweed",
     "latitude": 55.774332462,
     "longitude": -2.0109833916
   },
   "BWN": {
-    "station_name": "Bloxwich North Rail Station",
+    "station_name": "Bloxwich North",
     "latitude": 52.6254506167,
     "longitude": -2.0176785833
   },
   "BWO": {
-    "station_name": "Bricket Wood Rail Station",
+    "station_name": "Bricket Wood",
     "latitude": 51.7054311593,
     "longitude": -0.3590920111
   },
   "BWS": {
-    "station_name": "Barrow upon Soar Rail Station",
+    "station_name": "Barrow upon Soar",
     "latitude": 52.7493534585,
     "longitude": -1.1448359281
   },
   "BWT": {
-    "station_name": "Bridgwater Rail Station",
+    "station_name": "Bridgwater",
     "latitude": 51.1278501854,
     "longitude": -2.9904134747
   },
   "BXB": {
-    "station_name": "Broxbourne Rail Station",
+    "station_name": "Broxbourne",
     "latitude": 51.746913795,
     "longitude": -0.0110606305
   },
   "BXD": {
-    "station_name": "Buxted Rail Station",
+    "station_name": "Buxted",
     "latitude": 50.9900076084,
     "longitude": 0.1314658692
   },
   "BXH": {
-    "station_name": "Bexleyheath Rail Station",
+    "station_name": "Bexleyheath",
     "latitude": 51.4634986628,
     "longitude": 0.1337619475
   },
   "BXW": {
-    "station_name": "Box Hill & Westhumble Rail Station",
+    "station_name": "Box Hill & Westhumble",
     "latitude": 51.2540077838,
     "longitude": -0.3284670481
   },
   "BXY": {
-    "station_name": "Bexley Rail Station",
+    "station_name": "Bexley",
     "latitude": 51.4402179279,
     "longitude": 0.1479285922
   },
   "BYA": {
-    "station_name": "Berney Arms Rail Station",
+    "station_name": "Berney Arms",
     "latitude": 52.5898102913,
     "longitude": 1.6303988741
   },
   "BYB": {
-    "station_name": "Blythe Bridge Rail Station",
+    "station_name": "Blythe Bridge",
     "latitude": 52.9681588029,
     "longitude": -2.0669597492
   },
   "BYC": {
-    "station_name": "Betws-y-Coed Rail Station",
+    "station_name": "Betws-y-Coed",
     "latitude": 53.0920807045,
     "longitude": -3.8008660334
   },
   "BYD": {
-    "station_name": "Barry Docks Rail Station",
+    "station_name": "Barry Docks",
     "latitude": 51.4024388396,
     "longitude": -3.2607138987
   },
   "BYE": {
-    "station_name": "Bynea Rail Station",
+    "station_name": "Bynea",
     "latitude": 51.6720355869,
     "longitude": -4.0989020803
   },
   "BYF": {
-    "station_name": "Broughty Ferry Rail Station",
+    "station_name": "Broughty Ferry",
     "latitude": 56.467149407,
     "longitude": -2.8731557887
   },
   "BYI": {
-    "station_name": "Barry Island Rail Station",
+    "station_name": "Barry Island",
     "latitude": 51.3924107233,
     "longitude": -3.2733735249
   },
   "BYK": {
-    "station_name": "Bentley (S Yorks) Rail Station",
+    "station_name": "Bentley (S Yorks)",
     "latitude": 53.5439546043,
     "longitude": -1.1509511595
   },
   "BYL": {
-    "station_name": "Barry Links Rail Station",
+    "station_name": "Barry Links",
     "latitude": 56.4931375583,
     "longitude": -2.7454472508
   },
   "BYM": {
-    "station_name": "Burnley Manchester Road Rail Station",
+    "station_name": "Burnley Manchester Road",
     "latitude": 53.7849780535,
     "longitude": -2.2488678001
   },
   "BYN": {
-    "station_name": "Bryn Rail Station",
+    "station_name": "Bryn",
     "latitude": 53.4998801227,
     "longitude": -2.6472139369
   },
   "BYS": {
-    "station_name": "Braystones Rail Station",
+    "station_name": "Braystones",
     "latitude": 54.4393680606,
     "longitude": -3.5418249064
   },
   "CAA": {
-    "station_name": "Coventry Arena Rail Station",
+    "station_name": "Coventry Arena",
     "latitude": 52.4477480204,
     "longitude": -1.4941167693
   },
   "CAC": {
-    "station_name": "Caldercruix Rail Station",
+    "station_name": "Caldercruix",
     "latitude": 55.887937313,
     "longitude": -3.8877014781
   },
   "CAD": {
-    "station_name": "Cadoxton Rail Station",
+    "station_name": "Cadoxton",
     "latitude": 51.4122775163,
     "longitude": -3.2489057172
   },
   "CAG": {
-    "station_name": "Carrbridge Rail Station",
+    "station_name": "Carrbridge",
     "latitude": 57.2794851095,
     "longitude": -3.8282023232
   },
   "CAK": {
-    "station_name": "Cark Rail Station",
+    "station_name": "Cark",
     "latitude": 54.177962852,
     "longitude": -2.9740635997
   },
   "CAM": {
-    "station_name": "Camberley Rail Station",
+    "station_name": "Camberley",
     "latitude": 51.3363253942,
     "longitude": -0.7442546332
   },
   "CAN": {
-    "station_name": "Carnoustie Rail Station",
+    "station_name": "Carnoustie",
     "latitude": 56.5005520159,
     "longitude": -2.7066067008
   },
   "CAO": {
-    "station_name": "Cannock Rail Station",
+    "station_name": "Cannock",
     "latitude": 52.6861755085,
     "longitude": -2.0221416067
   },
   "CAR": {
-    "station_name": "Carlisle Rail Station",
+    "station_name": "Carlisle",
     "latitude": 54.8906568723,
     "longitude": -2.9331955073
   },
   "CAS": {
-    "station_name": "Castleton (Manchester) Rail Station",
+    "station_name": "Castleton (Manchester)",
     "latitude": 53.5918610828,
     "longitude": -2.1782323207
   },
   "CAT": {
-    "station_name": "Caterham Rail Station",
+    "station_name": "Caterham",
     "latitude": 51.2821380427,
     "longitude": -0.0782806392
   },
   "CAU": {
-    "station_name": "Causeland Rail Station",
+    "station_name": "Causeland",
     "latitude": 50.4056755023,
     "longitude": -4.466483549
   },
   "CAY": {
-    "station_name": "Carntyne Rail Station",
+    "station_name": "Carntyne",
     "latitude": 55.8548667252,
     "longitude": -4.178558829
   },
   "CBB": {
-    "station_name": "Carbis Bay Rail Station",
+    "station_name": "Carbis Bay",
     "latitude": 50.1970388168,
     "longitude": -5.4633147211
   },
   "CBC": {
-    "station_name": "Coatbridge Central Rail Station",
+    "station_name": "Coatbridge Central",
     "latitude": 55.8624998584,
     "longitude": -4.0318858547
   },
   "CBD": {
-    "station_name": "Conon Bridge Rail Station",
+    "station_name": "Conon Bridge",
     "latitude": 57.5617327905,
     "longitude": -4.4404033769
   },
   "CBE": {
-    "station_name": "Canterbury East Rail Station",
+    "station_name": "Canterbury East",
     "latitude": 51.2742704504,
     "longitude": 1.0759983241
   },
   "CBG": {
-    "station_name": "Cambridge Rail Station",
+    "station_name": "Cambridge",
     "latitude": 52.1940786826,
     "longitude": 0.1374844883
   },
   "CBH": {
-    "station_name": "Cambridge Heath (London) Rail Station",
+    "station_name": "Cambridge Heath (London)",
     "latitude": 51.5319721727,
     "longitude": -0.0572520963
   },
   "CBK": {
-    "station_name": "Cranbrook Rail Station",
+    "station_name": "Cranbrook",
     "latitude": 50.7500793373,
     "longitude": -3.4204288894
   },
   "CBL": {
-    "station_name": "Cambuslang Rail Station",
+    "station_name": "Cambuslang",
     "latitude": 55.8196005407,
     "longitude": -4.1729949447
   },
   "CBN": {
-    "station_name": "Camborne Rail Station",
+    "station_name": "Camborne",
     "latitude": 50.210424474,
     "longitude": -5.2974601339
   },
   "CBP": {
-    "station_name": "Castle Bar Park Rail Station",
+    "station_name": "Castle Bar Park",
     "latitude": 51.5229296496,
     "longitude": -0.3315265492
   },
   "CBR": {
-    "station_name": "Cooksbridge Rail Station",
+    "station_name": "Cooksbridge",
     "latitude": 50.9037495693,
     "longitude": -0.0091755079
   },
   "CBS": {
-    "station_name": "Coatbridge Sunnyside Rail Station",
+    "station_name": "Coatbridge Sunnyside",
     "latitude": 55.8668282944,
     "longitude": -4.0282763675
   },
   "CBW": {
-    "station_name": "Canterbury West Rail Station",
+    "station_name": "Canterbury West",
     "latitude": 51.284271981,
     "longitude": 1.0753330452
   },
   "CBY": {
-    "station_name": "Charlbury Rail Station",
+    "station_name": "Charlbury",
     "latitude": 51.8724337794,
     "longitude": -1.4896781604
   },
   "CCC": {
-    "station_name": "Criccieth Rail Station",
+    "station_name": "Criccieth",
     "latitude": 52.9184246922,
     "longitude": -4.2375196432
   },
   "CCH": {
-    "station_name": "Chichester Rail Station",
+    "station_name": "Chichester",
     "latitude": 50.8320420668,
     "longitude": -0.7817301783
   },
   "CCT": {
-    "station_name": "Cathcart Rail Station",
+    "station_name": "Cathcart",
     "latitude": 55.8176625197,
     "longitude": -4.260522045
   },
   "CDB": {
-    "station_name": "Cardiff Bay Rail Station",
+    "station_name": "Cardiff Bay",
     "latitude": 51.4671073886,
     "longitude": -3.1664118035
   },
   "CDD": {
-    "station_name": "Cardenden Rail Station",
+    "station_name": "Cardenden",
     "latitude": 56.1412469307,
     "longitude": -3.2616419946
   },
   "CDF": {
-    "station_name": "Cardiff Central Rail Station",
+    "station_name": "Cardiff Central",
     "latitude": 51.4760241554,
     "longitude": -3.1793104707
   },
   "CDI": {
-    "station_name": "Crediton Rail Station",
+    "station_name": "Crediton",
     "latitude": 50.7832916037,
     "longitude": -3.6467942575
   },
   "CDN": {
-    "station_name": "Coulsdon Town Rail Station",
+    "station_name": "Coulsdon Town",
     "latitude": 51.3220392402,
     "longitude": -0.1344387303
   },
   "CDO": {
-    "station_name": "Cardonald Rail Station",
+    "station_name": "Cardonald",
     "latitude": 55.8525617165,
     "longitude": -4.340677662
   },
   "CDQ": {
-    "station_name": "Cardiff Queen Street Rail Station",
+    "station_name": "Cardiff Queen Street",
     "latitude": 51.4819604384,
     "longitude": -3.1701891748
   },
   "CDR": {
-    "station_name": "Cardross Rail Station",
+    "station_name": "Cardross",
     "latitude": 55.9603705466,
     "longitude": -4.6530550015
   },
   "CDS": {
-    "station_name": "Coulsdon South Rail Station",
+    "station_name": "Coulsdon South",
     "latitude": 51.3158346141,
     "longitude": -0.1378616075
   },
   "CDT": {
-    "station_name": "Caldicot Rail Station",
+    "station_name": "Caldicot",
     "latitude": 51.5847886548,
     "longitude": -2.7605785503
   },
   "CDU": {
-    "station_name": "Cam & Dursley Rail Station",
+    "station_name": "Cam & Dursley",
     "latitude": 51.7176208933,
     "longitude": -2.3590816591
   },
   "CDY": {
-    "station_name": "Cartsdyke Rail Station",
+    "station_name": "Cartsdyke",
     "latitude": 55.9422051727,
     "longitude": -4.7315711125
   },
   "CEA": {
-    "station_name": "Cleland Rail Station",
+    "station_name": "Cleland",
     "latitude": 55.8046428518,
     "longitude": -3.9102338035
   },
   "CED": {
-    "station_name": "Cheddington Rail Station",
+    "station_name": "Cheddington",
     "latitude": 51.8579248983,
     "longitude": -0.6621263072
   },
   "CEF": {
-    "station_name": "Chapel-en-le-Frith Rail Station",
+    "station_name": "Chapel-en-le-Frith",
     "latitude": 53.3122450065,
     "longitude": -1.9187614767
   },
   "CEH": {
-    "station_name": "Coleshill Parkway Rail Station",
+    "station_name": "Coleshill Parkway",
     "latitude": 52.5165405856,
     "longitude": -1.7081695542
   },
   "CEL": {
-    "station_name": "Chelford Rail Station",
+    "station_name": "Chelford",
     "latitude": 53.270324898,
     "longitude": -2.2805759167
   },
   "CES": {
-    "station_name": "Cressing Rail Station",
+    "station_name": "Cressing",
     "latitude": 51.8523442178,
     "longitude": 0.5779891355
   },
   "CET": {
-    "station_name": "Colchester Town Rail Station",
+    "station_name": "Colchester Town",
     "latitude": 51.8864651647,
     "longitude": 0.904792312
   },
   "CEY": {
-    "station_name": "Cononley Rail Station",
+    "station_name": "Cononley",
     "latitude": 53.917582567,
     "longitude": -2.012071028
   },
   "CFB": {
-    "station_name": "Catford Bridge Rail Station",
+    "station_name": "Catford Bridge",
     "latitude": 51.4447386824,
     "longitude": -0.0247654501
   },
   "CFD": {
-    "station_name": "Castleford Rail Station",
+    "station_name": "Castleford",
     "latitude": 53.7240933891,
     "longitude": -1.3546560801
   },
   "CFF": {
-    "station_name": "Croftfoot Rail Station",
+    "station_name": "Croftfoot",
     "latitude": 55.818250801,
     "longitude": -4.2283107571
   },
   "CFH": {
-    "station_name": "Chafford Hundred Rail Station",
+    "station_name": "Chafford Hundred",
     "latitude": 51.4855557794,
     "longitude": 0.2874752389
   },
   "CFL": {
-    "station_name": "Crossflatts Rail Station",
+    "station_name": "Crossflatts",
     "latitude": 53.8584785,
     "longitude": -1.8448891769
   },
   "CFN": {
-    "station_name": "Clifton Down Rail Station",
+    "station_name": "Clifton Down",
     "latitude": 51.4645414825,
     "longitude": -2.6117434096
   },
   "CFO": {
-    "station_name": "Chalfont & Latimer Rail Station",
+    "station_name": "Chalfont & Latimer",
     "latitude": 51.6681107756,
     "longitude": -0.5605042796
   },
   "CFR": {
-    "station_name": "Chandlers Ford Rail Station",
+    "station_name": "Chandlers Ford",
     "latitude": 50.9836745047,
     "longitude": -1.3851600502
   },
   "CFT": {
-    "station_name": "Crofton Park Rail Station",
+    "station_name": "Crofton Park",
     "latitude": 51.45518736,
     "longitude": -0.036477467
   },
   "CGD": {
-    "station_name": "Craigendoran Rail Station",
+    "station_name": "Craigendoran",
     "latitude": 55.9947875724,
     "longitude": -4.7112248712
   },
   "CGM": {
-    "station_name": "Cottingham Rail Station",
+    "station_name": "Cottingham",
     "latitude": 53.7816677653,
     "longitude": -0.4064399418
   },
   "CGN": {
-    "station_name": "Cogan Rail Station",
+    "station_name": "Cogan",
     "latitude": 51.4459907902,
     "longitude": -3.189098989
   },
   "CGW": {
-    "station_name": "Caergwrle Rail Station",
+    "station_name": "Caergwrle",
     "latitude": 53.1078775755,
     "longitude": -3.0329132338
   },
   "CHC": {
-    "station_name": "Charing Cross (Glasgow) Rail Station",
+    "station_name": "Charing Cross (Glasgow)",
     "latitude": 55.8646752269,
     "longitude": -4.2698055885
   },
   "CHD": {
-    "station_name": "Chesterfield Rail Station",
+    "station_name": "Chesterfield",
     "latitude": 53.2382369384,
     "longitude": -1.4201139064
   },
   "CHE": {
-    "station_name": "Cheam Rail Station",
+    "station_name": "Cheam",
     "latitude": 51.3554760901,
     "longitude": -0.2141426137
   },
   "CHF": {
-    "station_name": "Church Fenton Rail Station",
+    "station_name": "Church Fenton",
     "latitude": 53.826617281,
     "longitude": -1.227593241
   },
   "CHG": {
-    "station_name": "Charing (Kent) Rail Station",
+    "station_name": "Charing (Kent)",
     "latitude": 51.2080968918,
     "longitude": 0.790361474
   },
   "CHH": {
-    "station_name": "Christs Hospital Rail Station",
+    "station_name": "Christs Hospital",
     "latitude": 51.0506799602,
     "longitude": -0.3635305612
   },
   "CHI": {
-    "station_name": "Chingford Rail Station",
+    "station_name": "Chingford",
     "latitude": 51.6330861875,
     "longitude": 0.0099231874
   },
   "CHK": {
-    "station_name": "Chiswick Rail Station",
+    "station_name": "Chiswick",
     "latitude": 51.4811352623,
     "longitude": -0.2678126102
   },
   "CHL": {
-    "station_name": "Chilworth Rail Station",
+    "station_name": "Chilworth",
     "latitude": 51.2152082426,
     "longitude": -0.5248019553
   },
   "CHM": {
-    "station_name": "Chelmsford Rail Station",
+    "station_name": "Chelmsford",
     "latitude": 51.736377313,
     "longitude": 0.4685976033
   },
   "CHN": {
-    "station_name": "Cheshunt Rail Station",
+    "station_name": "Cheshunt",
     "latitude": 51.7028782333,
     "longitude": -0.0239334005
   },
   "CHO": {
-    "station_name": "Cholsey Rail Station",
+    "station_name": "Cholsey",
     "latitude": 51.5702030857,
     "longitude": -1.1580033162
   },
   "CHP": {
-    "station_name": "Chipstead Rail Station",
+    "station_name": "Chipstead",
     "latitude": 51.3092732695,
     "longitude": -0.1694772828
   },
   "CHR": {
-    "station_name": "Christchurch Rail Station",
+    "station_name": "Christchurch",
     "latitude": 50.7382022761,
     "longitude": -1.7845391826
   },
   "CHT": {
-    "station_name": "Chathill Rail Station",
+    "station_name": "Chathill",
     "latitude": 55.5367311282,
     "longitude": -1.7063916064
   },
   "CHU": {
-    "station_name": "Cheadle Hulme Rail Station",
+    "station_name": "Cheadle Hulme",
     "latitude": 53.3759438577,
     "longitude": -2.1883016906
   },
   "CHW": {
-    "station_name": "Chalkwell Rail Station",
+    "station_name": "Chalkwell",
     "latitude": 51.5387210852,
     "longitude": 0.6706212378
   },
   "CHX": {
-    "station_name": "London Charing Cross Rail Station",
+    "station_name": "London Charing Cross",
     "latitude": 51.5080271291,
     "longitude": -0.124776951
   },
   "CHY": {
-    "station_name": "Chertsey Rail Station",
+    "station_name": "Chertsey",
     "latitude": 51.3870662195,
     "longitude": -0.5092980361
   },
   "CIL": {
-    "station_name": "Chilham Rail Station",
+    "station_name": "Chilham",
     "latitude": 51.244611699,
     "longitude": 0.9759253356
   },
   "CIM": {
-    "station_name": "Cilmeri Rail Station",
+    "station_name": "Cilmeri",
     "latitude": 52.1505372986,
     "longitude": -3.456549557
   },
   "CIR": {
-    "station_name": "Caledonian Road & Barnsbury Rail Station",
+    "station_name": "Caledonian Road & Barnsbury",
     "latitude": 51.5430414168,
     "longitude": -0.1167032568
   },
   "CIT": {
-    "station_name": "Chislehurst Rail Station",
+    "station_name": "Chislehurst",
     "latitude": 51.4055548954,
     "longitude": 0.0574432034
   },
   "CKH": {
-    "station_name": "Corkerhill Rail Station",
+    "station_name": "Corkerhill",
     "latitude": 55.8374943521,
     "longitude": -4.3342780321
   },
   "CKL": {
-    "station_name": "Corkickle Rail Station",
+    "station_name": "Corkickle",
     "latitude": 54.5416855173,
     "longitude": -3.5821649914
   },
   "CKN": {
-    "station_name": "Crewkerne Rail Station",
+    "station_name": "Crewkerne",
     "latitude": 50.8735260536,
     "longitude": -2.7784973275
   },
   "CKS": {
-    "station_name": "Clarkston Rail Station",
+    "station_name": "Clarkston",
     "latitude": 55.7893425756,
     "longitude": -4.2756304312
   },
   "CKT": {
-    "station_name": "Crookston Rail Station",
+    "station_name": "Crookston",
     "latitude": 55.842306531,
     "longitude": -4.3646599927
   },
   "CKY": {
-    "station_name": "Crosskeys Rail Station",
+    "station_name": "Crosskeys",
     "latitude": 51.6209031401,
     "longitude": -3.1261795275
   },
   "CLA": {
-    "station_name": "Clandon Rail Station",
+    "station_name": "Clandon",
     "latitude": 51.2640008411,
     "longitude": -0.5027439883
   },
   "CLC": {
-    "station_name": "Castle Cary Rail Station",
+    "station_name": "Castle Cary",
     "latitude": 51.0998071422,
     "longitude": -2.5227962269
   },
   "CLD": {
-    "station_name": "Chelsfield Rail Station",
+    "station_name": "Chelsfield",
     "latitude": 51.3562553945,
     "longitude": 0.109096599
   },
   "CLE": {
-    "station_name": "Cleethorpes Rail Station",
+    "station_name": "Cleethorpes",
     "latitude": 53.5619299115,
     "longitude": -0.0292269788
   },
   "CLG": {
-    "station_name": "Claygate Rail Station",
+    "station_name": "Claygate",
     "latitude": 51.3612107148,
     "longitude": -0.3482245539
   },
   "CLH": {
-    "station_name": "Clitheroe Rail Station",
+    "station_name": "Clitheroe",
     "latitude": 53.8734784154,
     "longitude": -2.3943371754
   },
   "CLI": {
-    "station_name": "Clifton (Manchester) Rail Station",
+    "station_name": "Clifton (Manchester)",
     "latitude": 53.5225049162,
     "longitude": -2.3147448248
   },
   "CLJ": {
-    "station_name": "Clapham Junction Rail Station",
+    "station_name": "Clapham Junction",
     "latitude": 51.4641869937,
     "longitude": -0.1702686508
   },
   "CLK": {
-    "station_name": "Clock House Rail Station",
+    "station_name": "Clock House",
     "latitude": 51.4085837591,
     "longitude": -0.0406309221
   },
   "CLL": {
-    "station_name": "Collington Rail Station",
+    "station_name": "Collington",
     "latitude": 50.8392826491,
     "longitude": 0.4578912206
   },
   "CLM": {
-    "station_name": "Collingham Rail Station",
+    "station_name": "Collingham",
     "latitude": 53.1441054305,
     "longitude": -0.7503911592
   },
   "CLN": {
-    "station_name": "Chapeltown Rail Station",
+    "station_name": "Chapeltown",
     "latitude": 53.46235275,
     "longitude": -1.4662753767
   },
   "CLP": {
-    "station_name": "Clapham High Street Rail Station",
+    "station_name": "Clapham High Street",
     "latitude": 51.4654799498,
     "longitude": -0.1324962988
   },
   "CLR": {
-    "station_name": "Clarbeston Road Rail Station",
+    "station_name": "Clarbeston Road",
     "latitude": 51.8516764519,
     "longitude": -4.883577935
   },
   "CLS": {
-    "station_name": "Chester-le-Street Rail Station",
+    "station_name": "Chester-le-Street",
     "latitude": 54.8546014236,
     "longitude": -1.5780279033
   },
   "CLT": {
-    "station_name": "Clacton-on-Sea Rail Station",
+    "station_name": "Clacton-on-Sea",
     "latitude": 51.7940121532,
     "longitude": 1.1541237294
   },
   "CLU": {
-    "station_name": "Carluke Rail Station",
+    "station_name": "Carluke",
     "latitude": 55.7312612023,
     "longitude": -3.8489142324
   },
   "CLV": {
-    "station_name": "Claverdon Rail Station",
+    "station_name": "Claverdon",
     "latitude": 52.2771032987,
     "longitude": -1.696549552
   },
   "CLW": {
-    "station_name": "Chorleywood Rail Station",
+    "station_name": "Chorleywood",
     "latitude": 51.6542505776,
     "longitude": -0.5182984244
   },
   "CLY": {
-    "station_name": "Chinley Rail Station",
+    "station_name": "Chinley",
     "latitude": 53.3403042037,
     "longitude": -1.9439397765
   },
   "CMB": {
-    "station_name": "Cambridge North Rail Station",
+    "station_name": "Cambridge North",
     "latitude": 52.2244936969,
     "longitude": 0.158507305
   },
   "CMD": {
-    "station_name": "Camden Road Rail Station",
+    "station_name": "Camden Road",
     "latitude": 51.5417913143,
     "longitude": -0.1386752331
   },
   "CME": {
-    "station_name": "Combe (Oxon) Rail Station",
+    "station_name": "Combe (Oxon)",
     "latitude": 51.8325979785,
     "longitude": -1.3940563489
   },
   "CMF": {
-    "station_name": "Cromford Rail Station",
+    "station_name": "Cromford",
     "latitude": 53.1129487944,
     "longitude": -1.5491593967
   },
   "CMH": {
-    "station_name": "Cwmbach Rail Station",
+    "station_name": "Cwmbach",
     "latitude": 51.7019306049,
     "longitude": -3.4137347518
   },
   "CML": {
-    "station_name": "Carmyle Rail Station",
+    "station_name": "Carmyle",
     "latitude": 55.8343311624,
     "longitude": -4.1581669693
   },
   "CMN": {
-    "station_name": "Carmarthen Rail Station",
+    "station_name": "Carmarthen",
     "latitude": 51.8533597764,
     "longitude": -4.3059837569
   },
   "CMO": {
-    "station_name": "Camelon Rail Station",
+    "station_name": "Camelon",
     "latitude": 56.0060850872,
     "longitude": -3.8175985504
   },
   "CMR": {
-    "station_name": "Cromer Rail Station",
+    "station_name": "Cromer",
     "latitude": 52.9301115682,
     "longitude": 1.2928430662
   },
   "CMY": {
-    "station_name": "Crossmyloof Rail Station",
+    "station_name": "Crossmyloof",
     "latitude": 55.8339394759,
     "longitude": -4.2843030651
   },
   "CNE": {
-    "station_name": "Colne Rail Station",
+    "station_name": "Colne",
     "latitude": 53.854755007,
     "longitude": -2.1818613773
   },
   "CNF": {
-    "station_name": "Carnforth Rail Station",
+    "station_name": "Carnforth",
     "latitude": 54.1296866595,
     "longitude": -2.7712312791
   },
   "CNG": {
-    "station_name": "Congleton Rail Station",
+    "station_name": "Congleton",
     "latitude": 53.1578702503,
     "longitude": -2.1925793889
   },
   "CNL": {
-    "station_name": "Canley Rail Station",
+    "station_name": "Canley",
     "latitude": 52.3992554076,
     "longitude": -1.5475652767
   },
   "CNM": {
-    "station_name": "Cheltenham Spa Rail Station",
+    "station_name": "Cheltenham Spa",
     "latitude": 51.8974028753,
     "longitude": -2.0996135055
   },
   "CNN": {
-    "station_name": "Canonbury Rail Station",
+    "station_name": "Canonbury",
     "latitude": 51.5487325338,
     "longitude": -0.09216443
   },
   "CNO": {
-    "station_name": "Chetnole Rail Station",
+    "station_name": "Chetnole",
     "latitude": 50.8663529505,
     "longitude": -2.5729267275
   },
   "CNP": {
-    "station_name": "Conway Park Rail Station",
+    "station_name": "Conway Park",
     "latitude": 53.3933739019,
     "longitude": -3.0226705989
   },
   "CNR": {
-    "station_name": "Crianlarich Rail Station",
+    "station_name": "Crianlarich",
     "latitude": 56.3904637247,
     "longitude": -4.6184189492
   },
   "CNS": {
-    "station_name": "Conisbrough Rail Station",
+    "station_name": "Conisbrough",
     "latitude": 53.4893269216,
     "longitude": -1.2343330775
   },
   "CNW": {
-    "station_name": "Conwy Rail Station",
+    "station_name": "Conwy",
     "latitude": 53.2801164248,
     "longitude": -3.8305284521
   },
   "CNY": {
-    "station_name": "Cantley Rail Station",
+    "station_name": "Cantley",
     "latitude": 52.5787715007,
     "longitude": 1.5134359903
   },
   "COA": {
-    "station_name": "Coatdyke Rail Station",
+    "station_name": "Coatdyke",
     "latitude": 55.8643346399,
     "longitude": -4.0049736959
   },
   "COB": {
-    "station_name": "Cooden Beach Rail Station",
+    "station_name": "Cooden Beach",
     "latitude": 50.8333660029,
     "longitude": 0.4268882942
   },
@@ -2770,3167 +2785,3187 @@
     "longitude": -4.4818867991
   },
   "COH": {
-    "station_name": "Crowborough Rail Station",
+    "station_name": "Crowborough",
     "latitude": 51.0463770048,
     "longitude": 0.1880407337
   },
   "COI": {
-    "station_name": "Crosshill Rail Station",
+    "station_name": "Crosshill",
     "latitude": 55.8332791971,
     "longitude": -4.2567970862
   },
   "COL": {
-    "station_name": "Colchester Rail Station",
+    "station_name": "Colchester",
     "latitude": 51.9007230246,
     "longitude": 0.8926284517
   },
   "COM": {
-    "station_name": "Commondale Rail Station",
+    "station_name": "Commondale",
     "latitude": 54.4812856119,
     "longitude": -0.9751641461
   },
   "CON": {
-    "station_name": "Connel Ferry Rail Station",
+    "station_name": "Connel Ferry",
     "latitude": 56.45233723,
     "longitude": -5.3854201352
   },
   "COO": {
-    "station_name": "Cookham Rail Station",
+    "station_name": "Cookham",
     "latitude": 51.5574642725,
     "longitude": -0.7220603119
   },
   "COP": {
-    "station_name": "Copplestone Rail Station",
+    "station_name": "Copplestone",
     "latitude": 50.8144563375,
     "longitude": -3.751590555
   },
   "COR": {
-    "station_name": "Corby Rail Station",
+    "station_name": "Corby",
     "latitude": 52.4888659511,
     "longitude": -0.6883213327
   },
   "COS": {
-    "station_name": "Cosford Rail Station",
+    "station_name": "Cosford",
     "latitude": 52.6448470661,
     "longitude": -2.3002712165
   },
   "COT": {
-    "station_name": "Cottingley Rail Station",
+    "station_name": "Cottingley",
     "latitude": 53.7678308023,
     "longitude": -1.5877119373
   },
   "COV": {
-    "station_name": "Coventry Rail Station",
+    "station_name": "Coventry",
     "latitude": 52.4008284145,
     "longitude": -1.5134504816
   },
   "COW": {
-    "station_name": "Cowdenbeath Rail Station",
+    "station_name": "Cowdenbeath",
     "latitude": 56.112083991,
     "longitude": -3.3431844925
   },
   "COY": {
-    "station_name": "Coryton Rail Station",
+    "station_name": "Coryton",
     "latitude": 51.5204358321,
     "longitude": -3.2318279619
   },
   "CPA": {
-    "station_name": "Corpach Rail Station",
+    "station_name": "Corpach",
     "latitude": 56.8428086004,
     "longitude": -5.121943037
   },
   "CPH": {
-    "station_name": "Caerphilly Rail Station",
+    "station_name": "Caerphilly",
     "latitude": 51.5715771276,
     "longitude": -3.2184921838
   },
   "CPK": {
-    "station_name": "Carpenders Park Rail Station",
+    "station_name": "Carpenders Park",
     "latitude": 51.6283534546,
     "longitude": -0.3859168008
   },
   "CPM": {
-    "station_name": "Chippenham Rail Station",
+    "station_name": "Chippenham",
     "latitude": 51.4624852566,
     "longitude": -2.1153890334
   },
   "CPN": {
-    "station_name": "Chapelton (Devon) Rail Station",
+    "station_name": "Chapelton (Devon)",
     "latitude": 51.0165289386,
     "longitude": -4.0247448242
   },
   "CPT": {
-    "station_name": "Clapton Rail Station",
+    "station_name": "Clapton",
     "latitude": 51.5616436677,
     "longitude": -0.0569984893
   },
   "CPU": {
-    "station_name": "Capenhurst Rail Station",
+    "station_name": "Capenhurst",
     "latitude": 53.2601877687,
     "longitude": -2.9422844784
   },
   "CPW": {
-    "station_name": "Chepstow Rail Station",
+    "station_name": "Chepstow",
     "latitude": 51.6401793133,
     "longitude": -2.6719110922
   },
   "CPY": {
-    "station_name": "Clapham (N Yorks) Rail Station",
+    "station_name": "Clapham (N Yorks)",
     "latitude": 54.1053962118,
     "longitude": -2.4103793434
   },
   "CRA": {
-    "station_name": "Cradley Heath Rail Station",
+    "station_name": "Cradley Heath",
     "latitude": 52.4696668258,
     "longitude": -2.0904823836
   },
   "CRB": {
-    "station_name": "Corbridge Rail Station",
+    "station_name": "Corbridge",
     "latitude": 54.9662659971,
     "longitude": -2.0184091796
   },
   "CRD": {
-    "station_name": "Chester Road Rail Station",
+    "station_name": "Chester Road",
     "latitude": 52.5356593313,
     "longitude": -1.832472162
   },
   "CRE": {
-    "station_name": "Crewe Rail Station",
+    "station_name": "Crewe",
     "latitude": 53.089639576,
     "longitude": -2.4329694874
   },
   "CRF": {
-    "station_name": "Carfin Rail Station",
+    "station_name": "Carfin",
     "latitude": 55.8073342674,
     "longitude": -3.9562432142
   },
   "CRG": {
-    "station_name": "Cross Gates Rail Station",
+    "station_name": "Cross Gates",
     "latitude": 53.8049283962,
     "longitude": -1.4515849362
   },
   "CRH": {
-    "station_name": "Crouch Hill Rail Station",
+    "station_name": "Crouch Hill",
     "latitude": 51.5713028362,
     "longitude": -0.11712295
   },
   "CRI": {
-    "station_name": "Cricklewood Rail Station",
+    "station_name": "Cricklewood",
     "latitude": 51.5584538453,
     "longitude": -0.212652067
   },
   "CRK": {
-    "station_name": "Chirk Rail Station",
+    "station_name": "Chirk",
     "latitude": 52.9330999763,
     "longitude": -3.0656421264
   },
   "CRL": {
-    "station_name": "Chorley Rail Station",
+    "station_name": "Chorley",
     "latitude": 53.6525509696,
     "longitude": -2.6268378803
   },
   "CRM": {
-    "station_name": "Cramlington Rail Station",
+    "station_name": "Cramlington",
     "latitude": 55.0877729503,
     "longitude": -1.5986098387
   },
   "CRN": {
-    "station_name": "Crowthorne Rail Station",
+    "station_name": "Crowthorne",
     "latitude": 51.3667259688,
     "longitude": -0.8192566155
   },
   "CRO": {
-    "station_name": "Croy Rail Station",
+    "station_name": "Croy",
     "latitude": 55.9556707554,
     "longitude": -4.0359670002
   },
   "CRR": {
-    "station_name": "Corrour Rail Station",
+    "station_name": "Corrour",
     "latitude": 56.7601959475,
     "longitude": -4.6905898827
   },
   "CRS": {
-    "station_name": "Carstairs Rail Station",
+    "station_name": "Carstairs",
     "latitude": 55.6910435615,
     "longitude": -3.6684653164
   },
   "CRT": {
-    "station_name": "Chartham Rail Station",
+    "station_name": "Chartham",
     "latitude": 51.2572676132,
     "longitude": 1.0180692196
   },
   "CRV": {
-    "station_name": "Craven Arms Rail Station",
+    "station_name": "Craven Arms",
     "latitude": 52.4425511842,
     "longitude": -2.8374211059
   },
   "CRW": {
-    "station_name": "Crawley Rail Station",
+    "station_name": "Crawley",
     "latitude": 51.1122079127,
     "longitude": -0.1866457301
   },
   "CRY": {
-    "station_name": "Crayford Rail Station",
+    "station_name": "Crayford",
     "latitude": 51.4482784318,
     "longitude": 0.1789624549
   },
   "CSA": {
-    "station_name": "Cosham Rail Station",
+    "station_name": "Cosham",
     "latitude": 50.8419131216,
     "longitude": -1.0673147963
   },
   "CSB": {
-    "station_name": "Carshalton Beeches Rail Station",
+    "station_name": "Carshalton Beeches",
     "latitude": 51.3574078701,
     "longitude": -0.1697719787
   },
   "CSD": {
-    "station_name": "Cobham & Stoke d'Abernon Rail Station",
+    "station_name": "Cobham & Stoke d'Abernon",
     "latitude": 51.3180974283,
     "longitude": -0.389323466
   },
   "CSG": {
-    "station_name": "Cressington Rail Station",
+    "station_name": "Cressington",
     "latitude": 53.3587637655,
     "longitude": -2.9120028641
   },
   "CSH": {
-    "station_name": "Carshalton Rail Station",
+    "station_name": "Carshalton",
     "latitude": 51.368451556,
     "longitude": -0.166343454
   },
   "CSK": {
-    "station_name": "Calstock Rail Station",
+    "station_name": "Calstock",
     "latitude": 50.497783854,
     "longitude": -4.2090174117
   },
   "CSL": {
-    "station_name": "Codsall Rail Station",
+    "station_name": "Codsall",
     "latitude": 52.6273016994,
     "longitude": -2.2017584348
   },
   "CSM": {
-    "station_name": "Castleton Moor Rail Station",
+    "station_name": "Castleton Moor",
     "latitude": 54.4671552873,
     "longitude": -0.9466648318
   },
   "CSN": {
-    "station_name": "Chessington North Rail Station",
+    "station_name": "Chessington North",
     "latitude": 51.3640376909,
     "longitude": -0.3006757682
   },
   "CSO": {
-    "station_name": "Croston Rail Station",
+    "station_name": "Croston",
     "latitude": 53.6675742668,
     "longitude": -2.7777477556
   },
   "CSR": {
-    "station_name": "Chassen Road Rail Station",
+    "station_name": "Chassen Road",
     "latitude": 53.4461736991,
     "longitude": -2.3682321593
   },
   "CSS": {
-    "station_name": "Chessington South Rail Station",
+    "station_name": "Chessington South",
     "latitude": 51.3565467942,
     "longitude": -0.3081340168
   },
   "CST": {
-    "station_name": "London Cannon Street Rail Station",
+    "station_name": "London Cannon Street",
     "latitude": 51.5113821708,
     "longitude": -0.0902671514
   },
   "CSW": {
-    "station_name": "Chestfield & Swalecliffe Rail Station",
+    "station_name": "Chestfield & Swalecliffe",
     "latitude": 51.3602434955,
     "longitude": 1.0669610537
   },
   "CSY": {
-    "station_name": "Coseley Rail Station",
+    "station_name": "Coseley",
     "latitude": 52.545096174,
     "longitude": -2.0857720388
   },
   "CTE": {
-    "station_name": "Chatelherault Rail Station",
+    "station_name": "Chatelherault",
     "latitude": 55.7652139884,
     "longitude": -4.004665396
   },
   "CTF": {
-    "station_name": "Catford Rail Station",
+    "station_name": "Catford",
     "latitude": 51.4444046468,
     "longitude": -0.0262908765
   },
   "CTH": {
-    "station_name": "Chadwell Heath Rail Station",
+    "station_name": "Chadwell Heath",
     "latitude": 51.5680380571,
     "longitude": 0.1289849608
   },
   "CTK": {
-    "station_name": "City Thameslink Rail Station",
+    "station_name": "City Thameslink",
     "latitude": 51.5139360643,
     "longitude": -0.1035639706
   },
   "CTL": {
-    "station_name": "Cattal Rail Station",
+    "station_name": "Cattal",
     "latitude": 53.997454781,
     "longitude": -1.3205413788
   },
   "CTM": {
-    "station_name": "Chatham Rail Station",
+    "station_name": "Chatham",
     "latitude": 51.3803760302,
     "longitude": 0.5211794412
   },
   "CTN": {
-    "station_name": "Charlton Rail Station",
+    "station_name": "Charlton",
     "latitude": 51.4868121438,
     "longitude": 0.0312832554
   },
   "CTO": {
-    "station_name": "Carlton Rail Station",
+    "station_name": "Carlton",
     "latitude": 52.9651058655,
     "longitude": -1.0786513766
   },
   "CTR": {
-    "station_name": "Chester Rail Station",
+    "station_name": "Chester",
     "latitude": 53.1967089901,
     "longitude": -2.8795954639
   },
   "CTT": {
-    "station_name": "Church Stretton Rail Station",
+    "station_name": "Church Stretton",
     "latitude": 52.5374347501,
     "longitude": -2.8036939757
   },
   "CTW": {
-    "station_name": "Church & Oswaldtwistle Rail Station",
+    "station_name": "Church & Oswaldtwistle",
     "latitude": 53.7505339398,
     "longitude": -2.3912114012
   },
   "CUA": {
-    "station_name": "Culrain Rail Station",
+    "station_name": "Culrain",
     "latitude": 57.9194946106,
     "longitude": -4.4042721672
   },
   "CUB": {
-    "station_name": "Cumbernauld Rail Station",
+    "station_name": "Cumbernauld",
     "latitude": 55.942019023,
     "longitude": -3.9803257587
   },
   "CUD": {
-    "station_name": "Cuddington Rail Station",
+    "station_name": "Cuddington",
     "latitude": 53.2399328038,
     "longitude": -2.5993047996
   },
   "CUF": {
-    "station_name": "Cuffley Rail Station",
+    "station_name": "Cuffley",
     "latitude": 51.708723054,
     "longitude": -0.1097585788
   },
   "CUH": {
-    "station_name": "Curriehill Rail Station",
+    "station_name": "Curriehill",
     "latitude": 55.9005593257,
     "longitude": -3.3187497327
   },
   "CUM": {
-    "station_name": "Culham Rail Station",
+    "station_name": "Culham",
     "latitude": 51.653795137,
     "longitude": -1.2364953245
   },
   "CUP": {
-    "station_name": "Cupar Rail Station",
+    "station_name": "Cupar",
     "latitude": 56.3169774524,
     "longitude": -3.0087585168
   },
   "CUW": {
-    "station_name": "Clunderwen Rail Station",
+    "station_name": "Clunderwen",
     "latitude": 51.8405496199,
     "longitude": -4.731870145
   },
   "CUX": {
-    "station_name": "Cuxton Rail Station",
+    "station_name": "Cuxton",
     "latitude": 51.3739247395,
     "longitude": 0.4617373125
   },
   "CWB": {
-    "station_name": "Colwyn Bay Rail Station",
+    "station_name": "Colwyn Bay",
     "latitude": 53.2963736339,
     "longitude": -3.7254203797
   },
   "CWC": {
-    "station_name": "Chappel & Wakes Colne Rail Station",
+    "station_name": "Chappel & Wakes Colne",
     "latitude": 51.9259156453,
     "longitude": 0.7585305397
   },
   "CWD": {
-    "station_name": "Creswell (Derbys) Rail Station",
+    "station_name": "Creswell (Derbys)",
     "latitude": 53.2641317653,
     "longitude": -1.2163932459
   },
   "CWE": {
-    "station_name": "Crowle Rail Station",
+    "station_name": "Crowle",
     "latitude": 53.589752526,
     "longitude": -0.8173624763
   },
   "CWH": {
-    "station_name": "Crews Hill Rail Station",
+    "station_name": "Crews Hill",
     "latitude": 51.6844869604,
     "longitude": -0.1068615213
   },
   "CWL": {
-    "station_name": "Colwall Rail Station",
+    "station_name": "Colwall",
     "latitude": 52.0798767311,
     "longitude": -2.3569466545
   },
   "CWM": {
-    "station_name": "Cwmbran Rail Station",
+    "station_name": "Cwmbran",
     "latitude": 51.6565871606,
     "longitude": -3.01621063
   },
   "CWN": {
-    "station_name": "Cowden Rail Station",
+    "station_name": "Cowden",
     "latitude": 51.1556324991,
     "longitude": 0.1100591285
   },
   "CWS": {
-    "station_name": "Caersws Rail Station",
+    "station_name": "Caersws",
     "latitude": 52.5161370252,
     "longitude": -3.4325032748
   },
   "CWU": {
-    "station_name": "Crowhurst Rail Station",
+    "station_name": "Crowhurst",
     "latitude": 50.8885735262,
     "longitude": 0.5013656464
   },
+  "CWX": {
+    "station_name": "Canary Wharf",
+    "latitude": 51.5061,
+    "longitude": -0.01578
+  },
   "CYB": {
-    "station_name": "Cefn-y-Bedd Rail Station",
+    "station_name": "Cefn-y-Bedd",
     "latitude": 53.0988144368,
     "longitude": -3.0310532391
   },
   "CYK": {
-    "station_name": "Clydebank Rail Station",
+    "station_name": "Clydebank",
     "latitude": 55.9006838001,
     "longitude": -4.4043987103
   },
   "CYN": {
-    "station_name": "Cynghordy Rail Station",
+    "station_name": "Cynghordy",
     "latitude": 52.0515055365,
     "longitude": -3.7482227844
   },
   "CYP": {
-    "station_name": "Crystal Palace Rail Station",
+    "station_name": "Crystal Palace",
     "latitude": 51.4181067019,
     "longitude": -0.0725839873
   },
   "CYS": {
-    "station_name": "Cathays Rail Station",
+    "station_name": "Cathays",
     "latitude": 51.4888980023,
     "longitude": -3.178691896
   },
   "CYT": {
-    "station_name": "Cherry Tree Rail Station",
+    "station_name": "Cherry Tree",
     "latitude": 53.7328842568,
     "longitude": -2.5183765976
   },
   "DAG": {
-    "station_name": "Dalgety Bay Rail Station",
+    "station_name": "Dalgety Bay",
     "latitude": 56.0420879876,
     "longitude": -3.367719234
   },
   "DAK": {
-    "station_name": "Dalmarnock Rail Station",
+    "station_name": "Dalmarnock",
     "latitude": 55.8420793253,
     "longitude": -4.2176948019
   },
   "DAL": {
-    "station_name": "Dalmally Rail Station",
+    "station_name": "Dalmally",
     "latitude": 56.40117566,
     "longitude": -4.9835317937
   },
   "DAM": {
-    "station_name": "Dalmeny Rail Station",
+    "station_name": "Dalmeny",
     "latitude": 55.9863117819,
     "longitude": -3.381617481
   },
   "DAN": {
-    "station_name": "Darnall Rail Station",
+    "station_name": "Darnall",
     "latitude": 53.3846003446,
     "longitude": -1.4125666166
   },
   "DAR": {
-    "station_name": "Darlington Rail Station",
+    "station_name": "Darlington",
     "latitude": 54.5204574957,
     "longitude": -1.5473329223
   },
   "DAT": {
-    "station_name": "Datchet Rail Station",
+    "station_name": "Datchet",
     "latitude": 51.4830766846,
     "longitude": -0.5794049222
   },
   "DBC": {
-    "station_name": "Dumbarton Central Rail Station",
+    "station_name": "Dumbarton Central",
     "latitude": 55.9466469118,
     "longitude": -4.5669032007
   },
   "DBD": {
-    "station_name": "Denby Dale Rail Station",
+    "station_name": "Denby Dale",
     "latitude": 53.5726454936,
     "longitude": -1.6632128419
   },
   "DBE": {
-    "station_name": "Dumbarton East Rail Station",
+    "station_name": "Dumbarton East",
     "latitude": 55.9422389396,
     "longitude": -4.5541195047
   },
   "DBG": {
-    "station_name": "Mottisfont & Dunbridge Rail Station",
+    "station_name": "Mottisfont & Dunbridge",
     "latitude": 51.0339180849,
     "longitude": -1.5470733978
   },
   "DBL": {
-    "station_name": "Dunblane Rail Station",
+    "station_name": "Dunblane",
     "latitude": 56.1858813154,
     "longitude": -3.9654784274
   },
   "DBR": {
-    "station_name": "Derby Road (Ipswich) Rail Station",
+    "station_name": "Derby Road (Ipswich)",
     "latitude": 52.0505675726,
     "longitude": 1.182673697
   },
   "DBY": {
-    "station_name": "Derby Rail Station",
+    "station_name": "Derby",
     "latitude": 52.9165645679,
     "longitude": -1.4633507475
   },
   "DCG": {
-    "station_name": "Duncraig Rail Station",
+    "station_name": "Duncraig",
     "latitude": 57.3369773237,
     "longitude": -5.6371200748
   },
   "DCH": {
-    "station_name": "Dorchester South Rail Station",
+    "station_name": "Dorchester South",
     "latitude": 50.7092808049,
     "longitude": -2.43724064
   },
   "DCT": {
-    "station_name": "Danescourt Rail Station",
+    "station_name": "Danescourt",
     "latitude": 51.5005053214,
     "longitude": -3.2339264723
   },
   "DCW": {
-    "station_name": "Dorchester West Rail Station",
+    "station_name": "Dorchester West",
     "latitude": 50.7109424746,
     "longitude": -2.4425389873
   },
   "DDG": {
-    "station_name": "Dorridge Rail Station",
+    "station_name": "Dorridge",
     "latitude": 52.3720819757,
     "longitude": -1.7528919248
   },
   "DDK": {
-    "station_name": "Dagenham Dock Rail Station",
+    "station_name": "Dagenham Dock",
     "latitude": 51.5260887461,
     "longitude": 0.1461308631
   },
   "DDP": {
-    "station_name": "Dudley Port Rail Station",
+    "station_name": "Dudley Port",
     "latitude": 52.5246649483,
     "longitude": -2.0494739583
   },
   "DEA": {
-    "station_name": "Deal Rail Station",
+    "station_name": "Deal",
     "latitude": 51.2230510827,
     "longitude": 1.3988758198
   },
   "DEE": {
-    "station_name": "Dundee Rail Station",
+    "station_name": "Dundee",
     "latitude": 56.4564750929,
     "longitude": -2.9712080372
   },
   "DEN": {
-    "station_name": "Dean Rail Station",
+    "station_name": "Dean",
     "latitude": 51.0424533409,
     "longitude": -1.6348555051
   },
   "DEP": {
-    "station_name": "Deptford Rail Station",
+    "station_name": "Deptford",
     "latitude": 51.4788466717,
     "longitude": -0.0262441885
   },
   "DEW": {
-    "station_name": "Dewsbury Rail Station",
+    "station_name": "Dewsbury",
     "latitude": 53.6921445094,
     "longitude": -1.6331100451
   },
   "DFD": {
-    "station_name": "Dartford Rail Station",
+    "station_name": "Dartford",
     "latitude": 51.4473695898,
     "longitude": 0.2192754223
   },
   "DFE": {
-    "station_name": "Dunfermline Town Rail Station",
+    "station_name": "Dunfermline Town",
     "latitude": 56.0681835684,
     "longitude": -3.4525246789
   },
   "DFI": {
-    "station_name": "Duffield Rail Station",
+    "station_name": "Duffield",
     "latitude": 52.9884176714,
     "longitude": -1.4859685231
   },
   "DFL": {
-    "station_name": "Dunfermline Queen Margaret Rail Station",
+    "station_name": "Dunfermline Queen Margaret",
     "latitude": 56.0805680436,
     "longitude": -3.4214651879
   },
   "DFR": {
-    "station_name": "Drumfrochar Rail Station",
+    "station_name": "Drumfrochar",
     "latitude": 55.9412399388,
     "longitude": -4.7747462431
   },
   "DGC": {
-    "station_name": "Denham Golf Club Rail Station",
+    "station_name": "Denham Golf Club",
     "latitude": 51.5805981628,
     "longitude": -0.5177663959
   },
   "DGL": {
-    "station_name": "Dingle Road Rail Station",
+    "station_name": "Dingle Road",
     "latitude": 51.4400518803,
     "longitude": -3.1805995641
   },
   "DGT": {
-    "station_name": "Deansgate Rail Station",
+    "station_name": "Deansgate",
     "latitude": 53.4741986483,
     "longitude": -2.251049342
   },
   "DGY": {
-    "station_name": "Deganwy Rail Station",
+    "station_name": "Deganwy",
     "latitude": 53.2947621319,
     "longitude": -3.8333901264
   },
   "DHM": {
-    "station_name": "Durham Rail Station",
+    "station_name": "Durham",
     "latitude": 54.7793980708,
     "longitude": -1.5817625077
   },
   "DHN": {
-    "station_name": "Deighton Rail Station",
+    "station_name": "Deighton",
     "latitude": 53.6684962139,
     "longitude": -1.7518983268
   },
   "DID": {
-    "station_name": "Didcot Parkway Rail Station",
+    "station_name": "Didcot Parkway",
     "latitude": 51.6109553482,
     "longitude": -1.2428749913
   },
   "DIG": {
-    "station_name": "Digby & Sowton Rail Station",
+    "station_name": "Digby & Sowton",
     "latitude": 50.7139764327,
     "longitude": -3.4735740965
   },
   "DIN": {
-    "station_name": "Dingwall Rail Station",
+    "station_name": "Dingwall",
     "latitude": 57.5942168221,
     "longitude": -4.4221973842
   },
   "DIS": {
-    "station_name": "Diss Rail Station",
+    "station_name": "Diss",
     "latitude": 52.3736757898,
     "longitude": 1.1237252182
   },
   "DKD": {
-    "station_name": "Dunkeld & Birnam Rail Station",
+    "station_name": "Dunkeld & Birnam",
     "latitude": 56.5570452529,
     "longitude": -3.5783964404
   },
   "DKG": {
-    "station_name": "Dorking Rail Station",
+    "station_name": "Dorking",
     "latitude": 51.2409257562,
     "longitude": -0.3242277761
   },
   "DKT": {
-    "station_name": "Dorking West Rail Station",
+    "station_name": "Dorking West",
     "latitude": 51.2362217787,
     "longitude": -0.3399557367
   },
   "DLG": {
-    "station_name": "Dolgarrog Rail Station",
+    "station_name": "Dolgarrog",
     "latitude": 53.1863628038,
     "longitude": -3.8226405143
   },
   "DLH": {
-    "station_name": "Doleham Rail Station",
+    "station_name": "Doleham",
     "latitude": 50.9185826306,
     "longitude": 0.6100042375
   },
   "DLJ": {
-    "station_name": "Dalston Junction Rail Station",
+    "station_name": "Dalston Junction",
     "latitude": 51.5461154595,
     "longitude": -0.0751109378
   },
   "DLK": {
-    "station_name": "Dalston Kingsland Rail Station",
+    "station_name": "Dalston Kingsland",
     "latitude": 51.5481480385,
     "longitude": -0.0756742388
   },
   "DLM": {
-    "station_name": "Delamere Rail Station",
+    "station_name": "Delamere",
     "latitude": 53.2287882936,
     "longitude": -2.6665587536
   },
   "DLR": {
-    "station_name": "Dalreoch Rail Station",
+    "station_name": "Dalreoch",
     "latitude": 55.9474070119,
     "longitude": -4.5778455124
   },
   "DLS": {
-    "station_name": "Dalston (Cumbria) Rail Station",
+    "station_name": "Dalston (Cumbria)",
     "latitude": 54.8461812399,
     "longitude": -2.9888562179
   },
   "DLT": {
-    "station_name": "Dalton Rail Station",
+    "station_name": "Dalton",
     "latitude": 54.1542436887,
     "longitude": -3.1790013184
   },
   "DLW": {
-    "station_name": "Dalwhinnie Rail Station",
+    "station_name": "Dalwhinnie",
     "latitude": 56.9351543012,
     "longitude": -4.2461914619
   },
   "DLY": {
-    "station_name": "Dalry Rail Station",
+    "station_name": "Dalry",
     "latitude": 55.7062150527,
     "longitude": -4.7110594286
   },
   "DMC": {
-    "station_name": "Drumchapel Rail Station",
+    "station_name": "Drumchapel",
     "latitude": 55.9048050133,
     "longitude": -4.3628637433
   },
   "DMF": {
-    "station_name": "Dumfries Rail Station",
+    "station_name": "Dumfries",
     "latitude": 55.072559544,
     "longitude": -3.604300351
   },
   "DMG": {
-    "station_name": "Dinas (Rhondda) Rail Station",
+    "station_name": "Dinas (Rhondda)",
     "latitude": 51.6178352115,
     "longitude": -3.437552058
   },
   "DMH": {
-    "station_name": "Dilton Marsh Rail Station",
+    "station_name": "Dilton Marsh",
     "latitude": 51.2489808553,
     "longitude": -2.2079111292
   },
   "DMK": {
-    "station_name": "Denmark Hill Rail Station",
+    "station_name": "Denmark Hill",
     "latitude": 51.4682016412,
     "longitude": -0.0893351949
   },
   "DMP": {
-    "station_name": "Dumpton Park Rail Station",
+    "station_name": "Dumpton Park",
     "latitude": 51.3457052089,
     "longitude": 1.4258444805
   },
   "DMR": {
-    "station_name": "Dalmuir Rail Station",
+    "station_name": "Dalmuir",
     "latitude": 55.911921651,
     "longitude": -4.4266657755
   },
   "DMS": {
-    "station_name": "Dormans Rail Station",
+    "station_name": "Dormans",
     "latitude": 51.1557866779,
     "longitude": -0.0042811467
   },
   "DMY": {
-    "station_name": "Drumry Rail Station",
+    "station_name": "Drumry",
     "latitude": 55.9045847687,
     "longitude": -4.3854571409
   },
   "DND": {
-    "station_name": "Dinsdale Rail Station",
+    "station_name": "Dinsdale",
     "latitude": 54.5147386026,
     "longitude": -1.4670752041
   },
   "DNG": {
-    "station_name": "Dunton Green Rail Station",
+    "station_name": "Dunton Green",
     "latitude": 51.2964873167,
     "longitude": 0.1709649125
   },
   "DNL": {
-    "station_name": "Dunlop Rail Station",
+    "station_name": "Dunlop",
     "latitude": 55.7118747945,
     "longitude": -4.5323721773
   },
   "DNM": {
-    "station_name": "Denham Rail Station",
+    "station_name": "Denham",
     "latitude": 51.5788378122,
     "longitude": -0.4974160111
   },
   "DNO": {
-    "station_name": "Dunrobin Castle Rail Station",
+    "station_name": "Dunrobin Castle",
     "latitude": 57.9855164027,
     "longitude": -3.9489241071
   },
   "DNS": {
-    "station_name": "Dinas Powys Rail Station",
+    "station_name": "Dinas Powys",
     "latitude": 51.4316627486,
     "longitude": -3.2183612689
   },
   "DNT": {
-    "station_name": "Dent Rail Station",
+    "station_name": "Dent",
     "latitude": 54.2824184109,
     "longitude": -2.3636026167
   },
   "DNY": {
-    "station_name": "Danby Rail Station",
+    "station_name": "Danby",
     "latitude": 54.4661651822,
     "longitude": -0.9109721492
   },
   "DOC": {
-    "station_name": "Dockyard (Plymouth) Rail Station",
+    "station_name": "Dockyard (Plymouth)",
     "latitude": 50.3821534706,
     "longitude": -4.1759268375
   },
   "DOD": {
-    "station_name": "Dodworth Rail Station",
+    "station_name": "Dodworth",
     "latitude": 53.5443407648,
     "longitude": -1.5316921206
   },
   "DOL": {
-    "station_name": "Dolau Rail Station",
+    "station_name": "Dolau",
     "latitude": 52.2953601526,
     "longitude": -3.2636234021
   },
   "DON": {
-    "station_name": "Doncaster Rail Station",
+    "station_name": "Doncaster",
     "latitude": 53.522167905,
     "longitude": -1.1398476982
   },
   "DOR": {
-    "station_name": "Dore & Totley Rail Station",
+    "station_name": "Dore & Totley",
     "latitude": 53.3276504838,
     "longitude": -1.5152967348
   },
   "DOT": {
-    "station_name": "Dunston Rail Station",
+    "station_name": "Dunston",
     "latitude": 54.9500607179,
     "longitude": -1.6420561513
   },
   "DOW": {
-    "station_name": "Downham Market Rail Station",
+    "station_name": "Downham Market",
     "latitude": 52.6041264601,
     "longitude": 0.3656997898
   },
   "DPD": {
-    "station_name": "Dorking Deepdene Rail Station",
+    "station_name": "Dorking Deepdene",
     "latitude": 51.2388000949,
     "longitude": -0.3246201844
   },
   "DPT": {
-    "station_name": "Devonport Rail Station",
+    "station_name": "Devonport",
     "latitude": 50.3785177656,
     "longitude": -4.1707389477
   },
   "DRF": {
-    "station_name": "Driffield Rail Station",
+    "station_name": "Driffield",
     "latitude": 54.001546492,
     "longitude": -0.4346760339
   },
   "DRG": {
-    "station_name": "Drayton Green Rail Station",
+    "station_name": "Drayton Green",
     "latitude": 51.5166156836,
     "longitude": -0.3301719985
   },
   "DRI": {
-    "station_name": "Drigg Rail Station",
+    "station_name": "Drigg",
     "latitude": 54.3769668358,
     "longitude": -3.443413857
   },
   "DRM": {
-    "station_name": "Drem Rail Station",
+    "station_name": "Drem",
     "latitude": 56.0051170654,
     "longitude": -2.7860534175
   },
   "DRN": {
-    "station_name": "Duirinish Rail Station",
+    "station_name": "Duirinish",
     "latitude": 57.319951049,
     "longitude": -5.6913048804
   },
   "DRO": {
-    "station_name": "Dronfield Rail Station",
+    "station_name": "Dronfield",
     "latitude": 53.3013854109,
     "longitude": -1.4687777286
   },
   "DRT": {
-    "station_name": "Darton Rail Station",
+    "station_name": "Darton",
     "latitude": 53.5883833705,
     "longitude": -1.5316604623
   },
   "DRU": {
-    "station_name": "Drumgelloch Rail Station",
+    "station_name": "Drumgelloch",
     "latitude": 55.8673480624,
     "longitude": -3.9488717169
   },
   "DSL": {
-    "station_name": "Disley Rail Station",
+    "station_name": "Disley",
     "latitude": 53.3581971647,
     "longitude": -2.0424809658
   },
   "DSM": {
-    "station_name": "Darsham Rail Station",
+    "station_name": "Darsham",
     "latitude": 52.2730184572,
     "longitude": 1.5235008921
   },
   "DST": {
-    "station_name": "Duke Street Rail Station",
+    "station_name": "Duke Street",
     "latitude": 55.8584302018,
     "longitude": -4.213033844
   },
   "DSY": {
-    "station_name": "Daisy Hill Rail Station",
+    "station_name": "Daisy Hill",
     "latitude": 53.5394676714,
     "longitude": -2.5158611336
   },
   "DTG": {
-    "station_name": "Dinting Rail Station",
+    "station_name": "Dinting",
     "latitude": 53.4493453873,
     "longitude": -1.9702958822
   },
   "DTN": {
-    "station_name": "Denton Rail Station",
+    "station_name": "Denton",
     "latitude": 53.456880489,
     "longitude": -2.1316584707
   },
   "DTW": {
-    "station_name": "Droitwich Spa Rail Station",
+    "station_name": "Droitwich Spa",
     "latitude": 52.2682155287,
     "longitude": -2.1583562459
   },
   "DUD": {
-    "station_name": "Duddeston Rail Station",
+    "station_name": "Duddeston",
     "latitude": 52.4883756068,
     "longitude": -1.8713859825
   },
   "DUL": {
-    "station_name": "Dullingham Rail Station",
+    "station_name": "Dullingham",
     "latitude": 52.2016639915,
     "longitude": 0.3666921781
   },
   "DUM": {
-    "station_name": "Dumbreck Rail Station",
+    "station_name": "Dumbreck",
     "latitude": 55.8446425043,
     "longitude": -4.3012244995
   },
   "DUN": {
-    "station_name": "Dunbar Rail Station",
+    "station_name": "Dunbar",
     "latitude": 55.9982866312,
     "longitude": -2.513351643
   },
   "DUR": {
-    "station_name": "Durrington-on-Sea Rail Station",
+    "station_name": "Durrington-on-Sea",
     "latitude": 50.817518034,
     "longitude": -0.4114439
   },
   "DVC": {
-    "station_name": "Dovercourt Rail Station",
+    "station_name": "Dovercourt",
     "latitude": 51.9387503243,
     "longitude": 1.2806410709
   },
   "DVH": {
-    "station_name": "Dove Holes Rail Station",
+    "station_name": "Dove Holes",
     "latitude": 53.3000420778,
     "longitude": -1.8897505662
   },
   "DVN": {
-    "station_name": "Davenport Rail Station",
+    "station_name": "Davenport",
     "latitude": 53.3909155002,
     "longitude": -2.1529566556
   },
   "DVP": {
-    "station_name": "Dover Priory Rail Station",
+    "station_name": "Dover Priory",
     "latitude": 51.1257054631,
     "longitude": 1.3053252348
   },
   "DVY": {
-    "station_name": "Dovey Junction Rail Station",
+    "station_name": "Dovey Junction",
     "latitude": 52.5643723647,
     "longitude": -3.9239110192
   },
   "DWD": {
-    "station_name": "Dolwyddelan Rail Station",
+    "station_name": "Dolwyddelan",
     "latitude": 53.0520264903,
     "longitude": -3.885137383
   },
   "DWL": {
-    "station_name": "Dawlish Rail Station",
+    "station_name": "Dawlish",
     "latitude": 50.5808060844,
     "longitude": -3.4646385825
   },
   "DWN": {
-    "station_name": "Darwen Rail Station",
+    "station_name": "Darwen",
     "latitude": 53.6980500658,
     "longitude": -2.4649373867
   },
   "DWW": {
-    "station_name": "Dawlish Warren Rail Station",
+    "station_name": "Dawlish Warren",
     "latitude": 50.5986963334,
     "longitude": -3.4435746881
   },
   "DYC": {
-    "station_name": "Dyce Rail Station",
+    "station_name": "Dyce",
     "latitude": 57.2056334738,
     "longitude": -2.1923277179
   },
   "DYF": {
-    "station_name": "Dyffryn Ardudwy Rail Station",
+    "station_name": "Dyffryn Ardudwy",
     "latitude": 52.7888658497,
     "longitude": -4.1046506676
   },
   "DYP": {
-    "station_name": "Drayton Park Rail Station",
+    "station_name": "Drayton Park",
     "latitude": 51.5527705023,
     "longitude": -0.1054827348
   },
   "DZY": {
-    "station_name": "Danzey Rail Station",
+    "station_name": "Danzey",
     "latitude": 52.3248260043,
     "longitude": -1.8208686258
   },
   "EAD": {
-    "station_name": "Earlsfield Rail Station",
+    "station_name": "Earlsfield",
     "latitude": 51.4423352541,
     "longitude": -0.1876904006
   },
   "EAG": {
-    "station_name": "Eaglescliffe Rail Station",
+    "station_name": "Eaglescliffe",
     "latitude": 54.529441791,
     "longitude": -1.3494493173
   },
   "EAL": {
-    "station_name": "Ealing Broadway Rail Station",
+    "station_name": "Ealing Broadway",
     "latitude": 51.5148407171,
     "longitude": -0.3017293164
   },
   "EAR": {
-    "station_name": "Earley Rail Station",
+    "station_name": "Earley",
     "latitude": 51.4410992799,
     "longitude": -0.9179692021
   },
   "EBA": {
-    "station_name": "Euxton Balshaw Lane Rail Station",
+    "station_name": "Euxton Balshaw Lane",
     "latitude": 53.6604940469,
     "longitude": -2.6720207861
   },
   "EBB": {
-    "station_name": "Ebbw Vale Town Rail Station",
+    "station_name": "Ebbw Vale Town",
     "latitude": 51.7766906034,
     "longitude": -3.2025853559
   },
   "EBD": {
-    "station_name": "Ebbsfleet International Rail Station",
+    "station_name": "Ebbsfleet International",
     "latitude": 51.4429711416,
     "longitude": 0.3209500322
   },
   "EBK": {
-    "station_name": "Eastbrook Rail Station",
+    "station_name": "Eastbrook",
     "latitude": 51.4376339068,
     "longitude": -3.206146908
   },
   "EBL": {
-    "station_name": "East Boldon Rail Station",
+    "station_name": "East Boldon",
     "latitude": 54.9464212649,
     "longitude": -1.4203275453
   },
   "EBN": {
-    "station_name": "Eastbourne Rail Station",
+    "station_name": "Eastbourne",
     "latitude": 50.7693712403,
     "longitude": 0.2812755597
   },
   "EBR": {
-    "station_name": "Edenbridge Rail Station",
+    "station_name": "Edenbridge",
     "latitude": 51.2084314886,
     "longitude": 0.0606723709
   },
   "EBT": {
-    "station_name": "Edenbridge Town Rail Station",
+    "station_name": "Edenbridge Town",
     "latitude": 51.2000785009,
     "longitude": 0.0671991686
   },
   "EBV": {
-    "station_name": "Ebbw Vale Parkway Rail Station",
+    "station_name": "Ebbw Vale Parkway",
     "latitude": 51.7571458261,
     "longitude": -3.1961117844
   },
   "ECC": {
-    "station_name": "Eccles Rail Station",
+    "station_name": "Eccles",
     "latitude": 53.4853736806,
     "longitude": -2.3345132824
   },
   "ECL": {
-    "station_name": "Eccleston Park Rail Station",
+    "station_name": "Eccleston Park",
     "latitude": 53.4308004759,
     "longitude": -2.7800407784
   },
   "ECP": {
-    "station_name": "Energlyn & Churchill Park Rail Station",
+    "station_name": "Energlyn & Churchill Park",
     "latitude": 51.5832131774,
     "longitude": -3.2288061419
   },
   "ECR": {
-    "station_name": "East Croydon Rail Station",
+    "station_name": "East Croydon",
     "latitude": 51.3754518482,
     "longitude": -0.0927543224
   },
   "ECS": {
-    "station_name": "Eccles Road Rail Station",
+    "station_name": "Eccles Road",
     "latitude": 52.4709032665,
     "longitude": 0.9699418209
   },
   "EDB": {
-    "station_name": "Edinburgh Rail Station",
+    "station_name": "Edinburgh",
     "latitude": 55.9523865322,
     "longitude": -3.1882291087
   },
   "EDG": {
-    "station_name": "Edge Hill Rail Station",
+    "station_name": "Edge Hill",
     "latitude": 53.402631221,
     "longitude": -2.9464830162
   },
   "EDL": {
-    "station_name": "Edale Rail Station",
+    "station_name": "Edale",
     "latitude": 53.3649856666,
     "longitude": -1.8166247959
   },
   "EDN": {
-    "station_name": "Eden Park Rail Station",
+    "station_name": "Eden Park",
     "latitude": 51.3900885752,
     "longitude": -0.0263287699
   },
   "EDP": {
-    "station_name": "Edinburgh Park Rail Station",
+    "station_name": "Edinburgh Park",
     "latitude": 55.9275440803,
     "longitude": -3.3076630256
   },
   "EDR": {
-    "station_name": "Edmonton Green Rail Station",
+    "station_name": "Edmonton Green",
     "latitude": 51.6249290203,
     "longitude": -0.0610875153
   },
   "EDW": {
-    "station_name": "East Dulwich Rail Station",
+    "station_name": "East Dulwich",
     "latitude": 51.4614932275,
     "longitude": -0.080545987
   },
   "EDY": {
-    "station_name": "East Didsbury Rail Station",
+    "station_name": "East Didsbury",
     "latitude": 53.4093226957,
     "longitude": -2.221995354
   },
   "EFF": {
-    "station_name": "Effingham Junction Rail Station",
+    "station_name": "Effingham Junction",
     "latitude": 51.2914916148,
     "longitude": -0.4199426403
   },
   "EFL": {
-    "station_name": "East Farleigh Rail Station",
+    "station_name": "East Farleigh",
     "latitude": 51.2552346504,
     "longitude": 0.484758691
   },
   "EGF": {
-    "station_name": "East Garforth Rail Station",
+    "station_name": "East Garforth",
     "latitude": 53.7919924434,
     "longitude": -1.3705405592
   },
   "EGG": {
-    "station_name": "Eggesford Rail Station",
+    "station_name": "Eggesford",
     "latitude": 50.887727229,
     "longitude": -3.8747670951
   },
   "EGH": {
-    "station_name": "Egham Rail Station",
+    "station_name": "Egham",
     "latitude": 51.4296448509,
     "longitude": -0.5464936108
   },
   "EGN": {
-    "station_name": "Eastrington Rail Station",
+    "station_name": "Eastrington",
     "latitude": 53.7551798175,
     "longitude": -0.7876353437
   },
   "EGR": {
-    "station_name": "East Grinstead Rail Station",
+    "station_name": "East Grinstead",
     "latitude": 51.1262681111,
     "longitude": -0.0178726978
   },
   "EGT": {
-    "station_name": "Egton Rail Station",
+    "station_name": "Egton",
     "latitude": 54.4374940456,
     "longitude": -0.7614806216
   },
   "EGY": {
-    "station_name": "Edinburgh Gateway Rail Station",
+    "station_name": "Edinburgh Gateway",
     "latitude": 55.940932789,
     "longitude": -3.3202500314
   },
   "EKB": {
-    "station_name": "Eskbank Rail Station",
+    "station_name": "Eskbank",
     "latitude": 55.8817963943,
     "longitude": -3.0830769228
   },
   "EKL": {
-    "station_name": "East Kilbride Rail Station",
+    "station_name": "East Kilbride",
     "latitude": 55.7659978238,
     "longitude": -4.1802138231
   },
   "ELD": {
-    "station_name": "Earlswood (Surrey) Rail Station",
+    "station_name": "Earlswood (Surrey)",
     "latitude": 51.2273248317,
     "longitude": -0.1707971701
   },
   "ELE": {
-    "station_name": "Elmers End Rail Station",
+    "station_name": "Elmers End",
     "latitude": 51.398489582,
     "longitude": -0.0495441803
   },
   "ELG": {
-    "station_name": "Elgin Rail Station",
+    "station_name": "Elgin",
     "latitude": 57.6428926912,
     "longitude": -3.3112425277
   },
   "ELO": {
-    "station_name": "Elton & Orston Rail Station",
+    "station_name": "Elton & Orston",
     "latitude": 52.9521557025,
     "longitude": -0.8555074435
   },
   "ELP": {
-    "station_name": "Ellesmere Port Rail Station",
+    "station_name": "Ellesmere Port",
     "latitude": 53.2822052615,
     "longitude": -2.8964224623
   },
   "ELR": {
-    "station_name": "Elsecar Rail Station",
+    "station_name": "Elsecar",
     "latitude": 53.4986759683,
     "longitude": -1.4274252148
   },
   "ELS": {
-    "station_name": "Elstree & Borehamwood Rail Station",
+    "station_name": "Elstree & Borehamwood",
     "latitude": 51.6530715786,
     "longitude": -0.2800577261
   },
+  "ELT": {
+    "station_name": "East Linton",
+    "latitude": 55.9856,
+    "longitude": -2.6579
+  },
   "ELW": {
-    "station_name": "Eltham Rail Station",
+    "station_name": "Eltham",
     "latitude": 51.4556421114,
     "longitude": 0.0524986776
   },
   "ELY": {
-    "station_name": "Ely Rail Station",
+    "station_name": "Ely",
     "latitude": 52.391244221,
     "longitude": 0.2668510603
   },
   "EMD": {
-    "station_name": "East Midlands Parkway Rail Station",
+    "station_name": "East Midlands Parkway",
     "latitude": 52.8625182507,
     "longitude": -1.2632265891
   },
   "EML": {
-    "station_name": "East Malling Rail Station",
+    "station_name": "East Malling",
     "latitude": 51.2858069522,
     "longitude": 0.439309906
   },
   "EMP": {
-    "station_name": "Emerson Park Rail Station",
+    "station_name": "Emerson Park",
     "latitude": 51.5686424022,
     "longitude": 0.2201396373
   },
   "EMS": {
-    "station_name": "Emsworth Rail Station",
+    "station_name": "Emsworth",
     "latitude": 50.8516027835,
     "longitude": -0.9384144303
   },
   "ENC": {
-    "station_name": "Enfield Chase Rail Station",
+    "station_name": "Enfield Chase",
     "latitude": 51.6532550128,
     "longitude": -0.0906697288
   },
   "ENF": {
-    "station_name": "Enfield Town Rail Station",
+    "station_name": "Enfield Town",
     "latitude": 51.6520265184,
     "longitude": -0.0793010146
   },
   "ENL": {
-    "station_name": "Enfield Lock Rail Station",
+    "station_name": "Enfield Lock",
     "latitude": 51.6709227126,
     "longitude": -0.0285062955
   },
   "ENT": {
-    "station_name": "Entwistle Rail Station",
+    "station_name": "Entwistle",
     "latitude": 53.6559908688,
     "longitude": -2.4145427951
   },
   "EPD": {
-    "station_name": "Epsom Downs Rail Station",
+    "station_name": "Epsom Downs",
     "latitude": 51.3236845001,
     "longitude": -0.23892976
   },
   "EPH": {
-    "station_name": "Elephant & Castle Rail Station",
+    "station_name": "Elephant & Castle",
     "latitude": 51.4940282398,
     "longitude": -0.098700214
   },
   "EPS": {
-    "station_name": "Epsom Rail Station",
+    "station_name": "Epsom",
     "latitude": 51.334389925,
     "longitude": -0.2687531384
   },
   "ERA": {
-    "station_name": "Eastham Rake Rail Station",
+    "station_name": "Eastham Rake",
     "latitude": 53.307552763,
     "longitude": -2.9811322454
   },
   "ERD": {
-    "station_name": "Erdington Rail Station",
+    "station_name": "Erdington",
     "latitude": 52.5282972975,
     "longitude": -1.8395023401
   },
   "ERH": {
-    "station_name": "Erith Rail Station",
+    "station_name": "Erith",
     "latitude": 51.481669408,
     "longitude": 0.1750812719
   },
   "ERI": {
-    "station_name": "Eridge Rail Station",
+    "station_name": "Eridge",
     "latitude": 51.0889610517,
     "longitude": 0.2014592494
   },
   "ERL": {
-    "station_name": "Earlestown Rail Station",
+    "station_name": "Earlestown",
     "latitude": 53.451151143,
     "longitude": -2.6376624607
   },
   "ESD": {
-    "station_name": "Elmstead Woods Rail Station",
+    "station_name": "Elmstead Woods",
     "latitude": 51.4171157446,
     "longitude": 0.0442997314
   },
   "ESH": {
-    "station_name": "Esher Rail Station",
+    "station_name": "Esher",
     "latitude": 51.3798880712,
     "longitude": -0.3533154601
   },
   "ESL": {
-    "station_name": "Eastleigh Rail Station",
+    "station_name": "Eastleigh",
     "latitude": 50.9692403635,
     "longitude": -1.350073969
   },
   "ESM": {
-    "station_name": "Elsenham Rail Station",
+    "station_name": "Elsenham",
     "latitude": 51.920551892,
     "longitude": 0.228097059
   },
   "EST": {
-    "station_name": "Easterhouse Rail Station",
+    "station_name": "Easterhouse",
     "latitude": 55.8597505142,
     "longitude": -4.1071641367
   },
   "ESW": {
-    "station_name": "Elmswell Rail Station",
+    "station_name": "Elmswell",
     "latitude": 52.2380555449,
     "longitude": 0.9126215916
   },
   "ETC": {
-    "station_name": "Etchingham Rail Station",
+    "station_name": "Etchingham",
     "latitude": 51.0105413018,
     "longitude": 0.4423847838
   },
   "ETL": {
-    "station_name": "East Tilbury Rail Station",
+    "station_name": "East Tilbury",
     "latitude": 51.4848306628,
     "longitude": 0.4129581196
   },
   "EUS": {
-    "station_name": "London Euston Rail Station",
+    "station_name": "London Euston",
     "latitude": 51.5281364316,
     "longitude": -0.1338981275
   },
   "EVE": {
-    "station_name": "Evesham Rail Station",
+    "station_name": "Evesham",
     "latitude": 52.0984067663,
     "longitude": -1.9473049925
   },
   "EWD": {
-    "station_name": "Earlswood (West Midlands) Rail Station",
+    "station_name": "Earlswood (West Midlands)",
     "latitude": 52.3665938407,
     "longitude": -1.861161636
   },
   "EWE": {
-    "station_name": "Ewell East Rail Station",
+    "station_name": "Ewell East",
     "latitude": 51.3452967584,
     "longitude": -0.2415048775
   },
   "EWR": {
-    "station_name": "East Worthing Rail Station",
+    "station_name": "East Worthing",
     "latitude": 50.8216357611,
     "longitude": -0.3548680158
   },
   "EWW": {
-    "station_name": "Ewell West Rail Station",
+    "station_name": "Ewell West",
     "latitude": 51.350041877,
     "longitude": -0.2569621791
   },
   "EXC": {
-    "station_name": "Exeter Central Rail Station",
+    "station_name": "Exeter Central",
     "latitude": 50.7264717379,
     "longitude": -3.5332911791
   },
   "EXD": {
-    "station_name": "Exeter St Davids Rail Station",
+    "station_name": "Exeter St Davids",
     "latitude": 50.7292625509,
     "longitude": -3.5433010662
   },
   "EXG": {
-    "station_name": "Exhibition Centre (Glasgow) Rail Station",
+    "station_name": "Exhibition Centre (Glasgow)",
     "latitude": 55.8615443927,
     "longitude": -4.2835742363
   },
   "EXM": {
-    "station_name": "Exmouth Rail Station",
+    "station_name": "Exmouth",
     "latitude": 50.6216212923,
     "longitude": -3.4149848889
   },
   "EXN": {
-    "station_name": "Exton Rail Station",
+    "station_name": "Exton",
     "latitude": 50.6682904818,
     "longitude": -3.4441097276
   },
   "EXR": {
-    "station_name": "Essex Road Rail Station",
+    "station_name": "Essex Road",
     "latitude": 51.5407057256,
     "longitude": -0.0962497405
   },
   "EXT": {
-    "station_name": "Exeter St Thomas Rail Station",
+    "station_name": "Exeter St Thomas",
     "latitude": 50.717135131,
     "longitude": -3.5388511334
   },
   "EYN": {
-    "station_name": "Eynsford Rail Station",
+    "station_name": "Eynsford",
     "latitude": 51.3627174333,
     "longitude": 0.2044201754
   },
   "FAL": {
-    "station_name": "Falmouth Docks Rail Station",
+    "station_name": "Falmouth Docks",
     "latitude": 50.1506931982,
     "longitude": -5.0560746226
   },
   "FAV": {
-    "station_name": "Faversham Rail Station",
+    "station_name": "Faversham",
     "latitude": 51.3117150831,
     "longitude": 0.8910755277
   },
   "FAZ": {
-    "station_name": "Fazakerley Rail Station",
+    "station_name": "Fazakerley",
     "latitude": 53.4690990636,
     "longitude": -2.936722397
   },
   "FBY": {
-    "station_name": "Formby Rail Station",
+    "station_name": "Formby",
     "latitude": 53.5534917106,
     "longitude": -3.0709054604
   },
   "FCN": {
-    "station_name": "Falconwood Rail Station",
+    "station_name": "Falconwood",
     "latitude": 51.4591529464,
     "longitude": 0.079330998
   },
   "FEA": {
-    "station_name": "Featherstone Rail Station",
+    "station_name": "Featherstone",
     "latitude": 53.6790826979,
     "longitude": -1.358447032
   },
   "FEL": {
-    "station_name": "Feltham Rail Station",
+    "station_name": "Feltham",
     "latitude": 51.4478965298,
     "longitude": -0.4098171801
   },
   "FEN": {
-    "station_name": "Fenny Stratford Rail Station",
+    "station_name": "Fenny Stratford",
     "latitude": 52.0000768774,
     "longitude": -0.7159762313
   },
   "FER": {
-    "station_name": "Fernhill Rail Station",
+    "station_name": "Fernhill",
     "latitude": 51.6864981097,
     "longitude": -3.3958946145
   },
   "FFA": {
-    "station_name": "Ffairfach Rail Station",
+    "station_name": "Ffairfach",
     "latitude": 51.8724808498,
     "longitude": -3.9928787809
   },
   "FFD": {
-    "station_name": "Freshford Rail Station",
+    "station_name": "Freshford",
     "latitude": 51.3420243729,
     "longitude": -2.3010063939
   },
   "FGH": {
-    "station_name": "Fishguard Harbour Rail Station",
+    "station_name": "Fishguard Harbour",
     "latitude": 52.011557061,
     "longitude": -4.985670408
   },
   "FGT": {
-    "station_name": "Faygate Rail Station",
+    "station_name": "Faygate",
     "latitude": 51.0958843958,
     "longitude": -0.2629910043
   },
   "FGW": {
-    "station_name": "Fishguard & Goodwick Rail Station",
+    "station_name": "Fishguard & Goodwick",
     "latitude": 52.0041284781,
     "longitude": -4.9948666231
   },
   "FIL": {
-    "station_name": "Filey Rail Station",
+    "station_name": "Filey",
     "latitude": 54.2098758908,
     "longitude": -0.2938654062
   },
   "FIN": {
-    "station_name": "Finstock Rail Station",
+    "station_name": "Finstock",
     "latitude": 51.8527876529,
     "longitude": -1.4693269485
   },
   "FIT": {
-    "station_name": "Filton Abbey Wood Rail Station",
+    "station_name": "Filton Abbey Wood",
     "latitude": 51.5049359236,
     "longitude": -2.5624320807
   },
   "FKC": {
-    "station_name": "Folkestone Central Rail Station",
+    "station_name": "Folkestone Central",
     "latitude": 51.0828894709,
     "longitude": 1.1695144099
   },
   "FKG": {
-    "station_name": "Falkirk Grahamston Rail Station",
+    "station_name": "Falkirk Grahamston",
     "latitude": 56.0026075153,
     "longitude": -3.7850391932
   },
   "FKK": {
-    "station_name": "Falkirk High Rail Station",
+    "station_name": "Falkirk High",
     "latitude": 55.9918091725,
     "longitude": -3.7922363145
   },
   "FKW": {
-    "station_name": "Folkestone West Rail Station",
+    "station_name": "Folkestone West",
     "latitude": 51.0845880696,
     "longitude": 1.1539352777
   },
   "FLD": {
-    "station_name": "Fauldhouse Rail Station",
+    "station_name": "Fauldhouse",
     "latitude": 55.8224687949,
     "longitude": -3.7193103999
   },
   "FLE": {
-    "station_name": "Fleet Rail Station",
+    "station_name": "Fleet",
     "latitude": 51.2906324021,
     "longitude": -0.8307895054
   },
   "FLF": {
-    "station_name": "Flowery Field Rail Station",
+    "station_name": "Flowery Field",
     "latitude": 53.4618690949,
     "longitude": -2.0810528443
   },
   "FLI": {
-    "station_name": "Flixton Rail Station",
+    "station_name": "Flixton",
     "latitude": 53.4438220233,
     "longitude": -2.3842455243
   },
   "FLM": {
-    "station_name": "Flimby Rail Station",
+    "station_name": "Flimby",
     "latitude": 54.6896927165,
     "longitude": -3.5207405823
   },
   "FLN": {
-    "station_name": "Flint Rail Station",
+    "station_name": "Flint",
     "latitude": 53.2495386637,
     "longitude": -3.1329931372
   },
   "FLT": {
-    "station_name": "Flitwick Rail Station",
+    "station_name": "Flitwick",
     "latitude": 52.0036505318,
     "longitude": -0.4952335864
   },
   "FLW": {
-    "station_name": "Fulwell Rail Station",
+    "station_name": "Fulwell",
     "latitude": 51.4339333056,
     "longitude": -0.3494462747
   },
   "FLX": {
-    "station_name": "Felixstowe Rail Station",
+    "station_name": "Felixstowe",
     "latitude": 51.9670846947,
     "longitude": 1.3504650975
   },
   "FML": {
-    "station_name": "Frimley Rail Station",
+    "station_name": "Frimley",
     "latitude": 51.3118599318,
     "longitude": -0.7469740068
   },
   "FMR": {
-    "station_name": "Falmer Rail Station",
+    "station_name": "Falmer",
     "latitude": 50.8621216711,
     "longitude": -0.0873578378
   },
   "FMT": {
-    "station_name": "Falmouth Town Rail Station",
+    "station_name": "Falmouth Town",
     "latitude": 50.1483262428,
     "longitude": -5.0649815419
   },
   "FNB": {
-    "station_name": "Farnborough (Main) Rail Station",
+    "station_name": "Farnborough (Main)",
     "latitude": 51.2966031825,
     "longitude": -0.7557080158
   },
   "FNC": {
-    "station_name": "Farncombe Rail Station",
+    "station_name": "Farncombe",
     "latitude": 51.1971482209,
     "longitude": -0.6045286271
   },
   "FNH": {
-    "station_name": "Farnham Rail Station",
+    "station_name": "Farnham",
     "latitude": 51.2119005959,
     "longitude": -0.7924099968
   },
   "FNN": {
-    "station_name": "Farnborough North Rail Station",
+    "station_name": "Farnborough North",
     "latitude": 51.3020427564,
     "longitude": -0.7430095202
   },
   "FNR": {
-    "station_name": "Farningham Road Rail Station",
+    "station_name": "Farningham Road",
     "latitude": 51.40166365,
     "longitude": 0.235479766
   },
   "FNT": {
-    "station_name": "Feniton Rail Station",
+    "station_name": "Feniton",
     "latitude": 50.7866658255,
     "longitude": -3.2854308727
   },
   "FNV": {
-    "station_name": "Furness Vale Rail Station",
+    "station_name": "Furness Vale",
     "latitude": 53.3487660512,
     "longitude": -1.9888438055
   },
   "FNW": {
-    "station_name": "Farnworth Rail Station",
+    "station_name": "Farnworth",
     "latitude": 53.5500180154,
     "longitude": -2.3878478205
   },
   "FNY": {
-    "station_name": "Finchley Road & Frognal Rail Station",
+    "station_name": "Finchley Road & Frognal",
     "latitude": 51.5502664369,
     "longitude": -0.1831154061
   },
   "FOC": {
-    "station_name": "Falls of Cruachan Rail Station",
+    "station_name": "Falls of Cruachan",
     "latitude": 56.3938689413,
     "longitude": -5.1124566704
   },
   "FOD": {
-    "station_name": "Ford Rail Station",
+    "station_name": "Ford",
     "latitude": 50.8293824048,
     "longitude": -0.5783872727
   },
   "FOG": {
-    "station_name": "Forest Gate Rail Station",
+    "station_name": "Forest Gate",
     "latitude": 51.549431694,
     "longitude": 0.0243798935
   },
   "FOH": {
-    "station_name": "Forest Hill Rail Station",
+    "station_name": "Forest Hill",
     "latitude": 51.4392780589,
     "longitude": -0.0531313997
   },
   "FOK": {
-    "station_name": "Four Oaks Rail Station",
+    "station_name": "Four Oaks",
     "latitude": 52.5797939503,
     "longitude": -1.8280248803
   },
   "FOR": {
-    "station_name": "Forres Rail Station",
+    "station_name": "Forres",
     "latitude": 57.6111680406,
     "longitude": -3.6248718523
   },
   "FOX": {
-    "station_name": "Foxfield Rail Station",
+    "station_name": "Foxfield",
     "latitude": 54.2586748544,
     "longitude": -3.216062854
   },
   "FPK": {
-    "station_name": "Finsbury Park Rail Station",
+    "station_name": "Finsbury Park",
     "latitude": 51.5643025324,
     "longitude": -0.1062590007
   },
   "FRB": {
-    "station_name": "Fairbourne Rail Station",
+    "station_name": "Fairbourne",
     "latitude": 52.6960557759,
     "longitude": -4.0494218463
   },
   "FRD": {
-    "station_name": "Frodsham Rail Station",
+    "station_name": "Frodsham",
     "latitude": 53.2958284679,
     "longitude": -2.7235668244
   },
   "FRE": {
-    "station_name": "Freshfield Rail Station",
+    "station_name": "Freshfield",
     "latitude": 53.5660676569,
     "longitude": -3.0718271848
   },
   "FRF": {
-    "station_name": "Fairfield Rail Station",
+    "station_name": "Fairfield",
     "latitude": 53.4713083714,
     "longitude": -2.1457740263
   },
   "FRI": {
-    "station_name": "Frinton-on-Sea Rail Station",
+    "station_name": "Frinton-on-Sea",
     "latitude": 51.8376925676,
     "longitude": 1.2432006998
   },
   "FRL": {
-    "station_name": "Fairlie Rail Station",
+    "station_name": "Fairlie",
     "latitude": 55.7519366963,
     "longitude": -4.8532464966
   },
   "FRM": {
-    "station_name": "Fareham Rail Station",
+    "station_name": "Fareham",
     "latitude": 50.8530232101,
     "longitude": -1.1920245124
   },
   "FRN": {
-    "station_name": "Fearn Rail Station",
+    "station_name": "Fearn",
     "latitude": 57.778126445,
     "longitude": -3.9939370006
   },
   "FRO": {
-    "station_name": "Frome Rail Station",
+    "station_name": "Frome",
     "latitude": 51.2272634789,
     "longitude": -2.3099932958
   },
   "FRR": {
-    "station_name": "Frosterley Rail Station",
+    "station_name": "Frosterley",
     "latitude": 54.7270012002,
     "longitude": -1.9644205566
   },
   "FRS": {
-    "station_name": "Forsinard Rail Station",
+    "station_name": "Forsinard",
     "latitude": 58.3568834527,
     "longitude": -3.8968870161
   },
   "FRT": {
-    "station_name": "Frant Rail Station",
+    "station_name": "Frant",
     "latitude": 51.1040247127,
     "longitude": 0.2945703279
   },
   "FRW": {
-    "station_name": "Fairwater Rail Station",
+    "station_name": "Fairwater",
     "latitude": 51.4939058847,
     "longitude": -3.2338488071
   },
   "FRY": {
-    "station_name": "Ferriby Rail Station",
+    "station_name": "Ferriby",
     "latitude": 53.7171721074,
     "longitude": -0.5078355516
   },
   "FSB": {
-    "station_name": "Fishbourne Rail Station",
+    "station_name": "Fishbourne",
     "latitude": 50.8390401424,
     "longitude": -0.8150655546
   },
   "FSG": {
-    "station_name": "Fishersgate Rail Station",
+    "station_name": "Fishersgate",
     "latitude": 50.834226328,
     "longitude": -0.2193956669
   },
   "FSK": {
-    "station_name": "Fiskerton Rail Station",
+    "station_name": "Fiskerton",
     "latitude": 53.0602929309,
     "longitude": -0.9121833385
   },
   "FST": {
-    "station_name": "London Fenchurch Street Rail Station",
+    "station_name": "London Fenchurch Street",
     "latitude": 51.5116455824,
     "longitude": -0.0788707296
   },
   "FTM": {
-    "station_name": "Fort Matilda Rail Station",
+    "station_name": "Fort Matilda",
     "latitude": 55.9590229231,
     "longitude": -4.7952474713
   },
   "FTN": {
-    "station_name": "Fratton Rail Station",
+    "station_name": "Fratton",
     "latitude": 50.7963261465,
     "longitude": -1.0739689378
   },
   "FTW": {
-    "station_name": "Fort William Rail Station",
+    "station_name": "Fort William",
     "latitude": 56.820425796,
     "longitude": -5.1061294153
   },
   "FWY": {
-    "station_name": "Five Ways Rail Station",
+    "station_name": "Five Ways",
     "latitude": 52.4711078714,
     "longitude": -1.9129492479
   },
   "FXN": {
-    "station_name": "Foxton Rail Station",
+    "station_name": "Foxton",
     "latitude": 52.1192233456,
     "longitude": 0.0563363619
   },
   "FYS": {
-    "station_name": "Ferryside Rail Station",
+    "station_name": "Ferryside",
     "latitude": 51.7683736213,
     "longitude": -4.3694828095
   },
   "FZH": {
-    "station_name": "Frizinghall Rail Station",
+    "station_name": "Frizinghall",
     "latitude": 53.8203830612,
     "longitude": -1.7690049748
   },
   "FZP": {
-    "station_name": "Furze Platt Rail Station",
+    "station_name": "Furze Platt",
     "latitude": 51.533021301,
     "longitude": -0.7284541823
   },
   "FZW": {
-    "station_name": "Fitzwilliam Rail Station",
+    "station_name": "Fitzwilliam",
     "latitude": 53.6325161611,
     "longitude": -1.3742749709
   },
   "GAL": {
-    "station_name": "Galashiels Rail Station",
+    "station_name": "Galashiels",
     "latitude": 55.618348945,
     "longitude": -2.8069043382
   },
   "GAR": {
-    "station_name": "Garrowhill Rail Station",
+    "station_name": "Garrowhill",
     "latitude": 55.8552326445,
     "longitude": -4.1294477285
   },
   "GBD": {
-    "station_name": "Gilberdyke Rail Station",
+    "station_name": "Gilberdyke",
     "latitude": 53.7479824021,
     "longitude": -0.7322489664
   },
   "GBG": {
-    "station_name": "Gorebridge Rail Station",
+    "station_name": "Gorebridge",
     "latitude": 55.8402677085,
     "longitude": -3.0465190236
   },
   "GBK": {
-    "station_name": "Greenbank Rail Station",
+    "station_name": "Greenbank",
     "latitude": 53.2514787515,
     "longitude": -2.5342692507
   },
   "GBL": {
-    "station_name": "Gainsborough Lea Road Rail Station",
+    "station_name": "Gainsborough Lea Road",
     "latitude": 53.3861086871,
     "longitude": -0.7685809379
   },
   "GBS": {
-    "station_name": "Goring-by-Sea Rail Station",
+    "station_name": "Goring-by-Sea",
     "latitude": 50.8177112854,
     "longitude": -0.4330585625
   },
   "GCH": {
-    "station_name": "Garelochhead Rail Station",
+    "station_name": "Garelochhead",
     "latitude": 56.0798548957,
     "longitude": -4.8256979183
   },
   "GCL": {
-    "station_name": "Glasgow Central Low Level Rail Station",
+    "station_name": "Glasgow Central Low Level",
     "latitude": 55.858673532,
     "longitude": -4.2584774599
   },
   "GCR": {
-    "station_name": "Gloucester Rail Station",
+    "station_name": "Gloucester",
     "latitude": 51.8655641361,
     "longitude": -2.2384843439
   },
   "GCT": {
-    "station_name": "Great Coates Rail Station",
+    "station_name": "Great Coates",
     "latitude": 53.5757759251,
     "longitude": -0.1302350444
   },
   "GCW": {
-    "station_name": "Glan Conwy Rail Station",
+    "station_name": "Glan Conwy",
     "latitude": 53.2674361965,
     "longitude": -3.797731864
   },
   "GDH": {
-    "station_name": "Gordon Hill Rail Station",
+    "station_name": "Gordon Hill",
     "latitude": 51.6633360633,
     "longitude": -0.0945839997
   },
   "GDL": {
-    "station_name": "Godley Rail Station",
+    "station_name": "Godley",
     "latitude": 53.4517179149,
     "longitude": -2.0547723093
   },
   "GDN": {
-    "station_name": "Godstone Rail Station",
+    "station_name": "Godstone",
     "latitude": 51.2181531133,
     "longitude": -0.0500583421
   },
   "GDP": {
-    "station_name": "Gidea Park Rail Station",
+    "station_name": "Gidea Park",
     "latitude": 51.5819043047,
     "longitude": 0.2059905265
   },
   "GEA": {
-    "station_name": "Gretna Green Rail Station",
+    "station_name": "Gretna Green",
     "latitude": 55.0010507027,
     "longitude": -3.0652008756
   },
   "GER": {
-    "station_name": "Gerrards Cross Rail Station",
+    "station_name": "Gerrards Cross",
     "latitude": 51.5890237128,
     "longitude": -0.5552555668
   },
   "GFD": {
-    "station_name": "Greenford Rail Station",
+    "station_name": "Greenford",
     "latitude": 51.5423307069,
     "longitude": -0.3458148281
   },
   "GFF": {
-    "station_name": "Gilfach Fargoed Rail Station",
+    "station_name": "Gilfach Fargoed",
     "latitude": 51.6842505424,
     "longitude": -3.2265776505
   },
   "GFN": {
-    "station_name": "Giffnock Rail Station",
+    "station_name": "Giffnock",
     "latitude": 55.8039838247,
     "longitude": -4.2930005917
   },
   "GGJ": {
-    "station_name": "Georgemas Junction Rail Station",
+    "station_name": "Georgemas Junction",
     "latitude": 58.5136083248,
     "longitude": -3.4521277157
   },
   "GGV": {
-    "station_name": "Gargrave Rail Station",
+    "station_name": "Gargrave",
     "latitude": 53.9784289792,
     "longitude": -2.1051749427
   },
   "GIG": {
-    "station_name": "Giggleswick Rail Station",
+    "station_name": "Giggleswick",
     "latitude": 54.0618113766,
     "longitude": -2.3028507825
   },
   "GIL": {
-    "station_name": "Gillingham (Dorset) Rail Station",
+    "station_name": "Gillingham (Dorset)",
     "latitude": 51.0340262862,
     "longitude": -2.2726193805
   },
   "GIP": {
-    "station_name": "Gipsy Hill Rail Station",
+    "station_name": "Gipsy Hill",
     "latitude": 51.424451003,
     "longitude": -0.0838100922
   },
   "GIR": {
-    "station_name": "Girvan Rail Station",
+    "station_name": "Girvan",
     "latitude": 55.2463156898,
     "longitude": -4.8483590289
   },
   "GKC": {
-    "station_name": "Greenock Central Rail Station",
+    "station_name": "Greenock Central",
     "latitude": 55.9453319247,
     "longitude": -4.7526142906
   },
   "GKW": {
-    "station_name": "Greenock West Rail Station",
+    "station_name": "Greenock West",
     "latitude": 55.9473282882,
     "longitude": -4.767813412
   },
   "GLC": {
-    "station_name": "Glasgow Central Rail Station",
+    "station_name": "Glasgow Central",
     "latitude": 55.8597496156,
     "longitude": -4.2576290605
   },
   "GLD": {
-    "station_name": "Guildford Rail Station",
+    "station_name": "Guildford",
     "latitude": 51.2369644453,
     "longitude": -0.5804043303
   },
   "GLE": {
-    "station_name": "Gleneagles Rail Station",
+    "station_name": "Gleneagles",
     "latitude": 56.2748401663,
     "longitude": -3.7311626664
   },
   "GLF": {
-    "station_name": "Glenfinnan Rail Station",
+    "station_name": "Glenfinnan",
     "latitude": 56.8723822491,
     "longitude": -5.449604955
   },
   "GLG": {
-    "station_name": "Glengarnock Rail Station",
+    "station_name": "Glengarnock",
     "latitude": 55.7388819511,
     "longitude": -4.6744823788
   },
   "GLH": {
-    "station_name": "Glasshoughton Rail Station",
+    "station_name": "Glasshoughton",
     "latitude": 53.7090594596,
     "longitude": -1.3420084086
   },
   "GLM": {
-    "station_name": "Gillingham (Kent) Rail Station",
+    "station_name": "Gillingham (Kent)",
     "latitude": 51.3865631854,
     "longitude": 0.5498787442
   },
   "GLO": {
-    "station_name": "Glossop Rail Station",
+    "station_name": "Glossop",
     "latitude": 53.4444844182,
     "longitude": -1.9490712229
   },
   "GLQ": {
-    "station_name": "Glasgow Queen Street Rail Station",
+    "station_name": "Glasgow Queen Street",
     "latitude": 55.8621817762,
     "longitude": -4.2514417118
   },
   "GLS": {
-    "station_name": "Glaisdale Rail Station",
+    "station_name": "Glaisdale",
     "latitude": 54.4393938445,
     "longitude": -0.7938035599
   },
   "GLT": {
-    "station_name": "Glenrothes with Thornton Rail Station",
+    "station_name": "Glenrothes with Thornton",
     "latitude": 56.1623481523,
     "longitude": -3.1430172976
   },
   "GLY": {
-    "station_name": "Glynde Rail Station",
+    "station_name": "Glynde",
     "latitude": 50.8591649295,
     "longitude": 0.0701049622
   },
   "GLZ": {
-    "station_name": "Glazebrook Rail Station",
+    "station_name": "Glazebrook",
     "latitude": 53.4283742205,
     "longitude": -2.459656827
   },
   "GMB": {
-    "station_name": "Grimsby Town Rail Station",
+    "station_name": "Grimsby Town",
     "latitude": 53.5634511917,
     "longitude": -0.0869883746
   },
   "GMD": {
-    "station_name": "Grimsby Docks Rail Station",
+    "station_name": "Grimsby Docks",
     "latitude": 53.5743443249,
     "longitude": -0.0756224261
   },
   "GMG": {
-    "station_name": "Garth (Bridgend) Rail Station",
+    "station_name": "Garth (Bridgend)",
     "latitude": 51.5964572422,
     "longitude": -3.6414648286
   },
   "GMN": {
-    "station_name": "Great Missenden Rail Station",
+    "station_name": "Great Missenden",
     "latitude": 51.7035218129,
     "longitude": -0.7091187725
   },
   "GMT": {
-    "station_name": "Grosmont Rail Station",
+    "station_name": "Grosmont",
     "latitude": 54.43612578,
     "longitude": -0.7249812388
   },
   "GMV": {
-    "station_name": "Great Malvern Rail Station",
+    "station_name": "Great Malvern",
     "latitude": 52.1092074558,
     "longitude": -2.3182662455
   },
   "GMY": {
-    "station_name": "Goodmayes Rail Station",
+    "station_name": "Goodmayes",
     "latitude": 51.5655781413,
     "longitude": 0.1108335454
   },
   "GNB": {
-    "station_name": "Gainsborough Central Rail Station",
+    "station_name": "Gainsborough Central",
     "latitude": 53.3996038827,
     "longitude": -0.7696962039
   },
   "GNF": {
-    "station_name": "Greenfield Rail Station",
+    "station_name": "Greenfield",
     "latitude": 53.5388735659,
     "longitude": -2.013841081
   },
   "GNH": {
-    "station_name": "Greenhithe for Bluewater Rail Station",
+    "station_name": "Greenhithe for Bluewater",
     "latitude": 51.4503693938,
     "longitude": 0.2803176704
   },
   "GNL": {
-    "station_name": "Green Lane Rail Station",
+    "station_name": "Green Lane",
     "latitude": 53.3832695481,
     "longitude": -3.0164148473
   },
   "GNR": {
-    "station_name": "Green Road Rail Station",
+    "station_name": "Green Road",
     "latitude": 54.2445321604,
     "longitude": -3.2455716728
   },
   "GNT": {
-    "station_name": "Gunton Rail Station",
+    "station_name": "Gunton",
     "latitude": 52.8663732165,
     "longitude": 1.3491365444
   },
   "GNW": {
-    "station_name": "Greenwich Rail Station",
+    "station_name": "Greenwich",
     "latitude": 51.4781335778,
     "longitude": -0.0133139144
   },
   "GOB": {
-    "station_name": "Gobowen Rail Station",
+    "station_name": "Gobowen",
     "latitude": 52.8935276407,
     "longitude": -3.0371715591
   },
   "GOD": {
-    "station_name": "Godalming Rail Station",
+    "station_name": "Godalming",
     "latitude": 51.1865810902,
     "longitude": -0.6188424046
   },
   "GOE": {
-    "station_name": "Goldthorpe Rail Station",
+    "station_name": "Goldthorpe",
     "latitude": 53.5342068606,
     "longitude": -1.3128096411
   },
   "GOF": {
-    "station_name": "Golf Street Rail Station",
+    "station_name": "Golf Street",
     "latitude": 56.4977824375,
     "longitude": -2.7195495703
   },
   "GOL": {
-    "station_name": "Golspie Rail Station",
+    "station_name": "Golspie",
     "latitude": 57.9714474115,
     "longitude": -3.9872179776
   },
   "GOM": {
-    "station_name": "Gomshall Rail Station",
+    "station_name": "Gomshall",
     "latitude": 51.2193937984,
     "longitude": -0.4418288518
   },
   "GOO": {
-    "station_name": "Goole Rail Station",
+    "station_name": "Goole",
     "latitude": 53.7049327129,
     "longitude": -0.8742176314
   },
   "GOR": {
-    "station_name": "Goring & Streatley Rail Station",
+    "station_name": "Goring & Streatley",
     "latitude": 51.5214927112,
     "longitude": -1.133029148
   },
   "GOS": {
-    "station_name": "Grange-over-Sands Rail Station",
+    "station_name": "Grange-over-Sands",
     "latitude": 54.1957302552,
     "longitude": -2.9027471889
   },
   "GOX": {
-    "station_name": "Goxhill Rail Station",
+    "station_name": "Goxhill",
     "latitude": 53.6767222975,
     "longitude": -0.3371266253
   },
   "GPK": {
-    "station_name": "Grange Park Rail Station",
+    "station_name": "Grange Park",
     "latitude": 51.6426082109,
     "longitude": -0.0973320762
   },
   "GPO": {
-    "station_name": "Gospel Oak Rail Station",
+    "station_name": "Gospel Oak",
     "latitude": 51.5553362208,
     "longitude": -0.1507445033
   },
   "GQL": {
-    "station_name": "Glasgow Queen Street Low Level Rail Station",
+    "station_name": "Glasgow Queen Street Low Level",
     "latitude": 55.8623403235,
     "longitude": -4.2506358523
   },
   "GRA": {
-    "station_name": "Grantham Rail Station",
+    "station_name": "Grantham",
     "latitude": 52.9064924179,
     "longitude": -0.6424450707
   },
   "GRB": {
-    "station_name": "Great Bentley Rail Station",
+    "station_name": "Great Bentley",
     "latitude": 51.8517695139,
     "longitude": 1.0651844079
   },
   "GRC": {
-    "station_name": "Great Chesterford Rail Station",
+    "station_name": "Great Chesterford",
     "latitude": 52.0598200469,
     "longitude": 0.1935488673
   },
   "GRF": {
-    "station_name": "Garforth Rail Station",
+    "station_name": "Garforth",
     "latitude": 53.7965926372,
     "longitude": -1.3823135001
   },
   "GRH": {
-    "station_name": "Gartcosh Rail Station",
+    "station_name": "Gartcosh",
     "latitude": 55.8856546592,
     "longitude": -4.0794827931
   },
   "GRK": {
-    "station_name": "Gourock Rail Station",
+    "station_name": "Gourock",
     "latitude": 55.962310977,
     "longitude": -4.8166374785
   },
   "GRL": {
-    "station_name": "Greenfaulds Rail Station",
+    "station_name": "Greenfaulds",
     "latitude": 55.9352259193,
     "longitude": -3.9930912233
   },
   "GRN": {
-    "station_name": "Grindleford Rail Station",
+    "station_name": "Grindleford",
     "latitude": 53.3055770449,
     "longitude": -1.6262956215
   },
   "GRP": {
-    "station_name": "Grove Park Rail Station",
+    "station_name": "Grove Park",
     "latitude": 51.4308613738,
     "longitude": 0.0217517094
   },
   "GRS": {
-    "station_name": "Garscadden Rail Station",
+    "station_name": "Garscadden",
     "latitude": 55.8876875396,
     "longitude": -4.3649893754
   },
   "GRT": {
-    "station_name": "Grateley Rail Station",
+    "station_name": "Grateley",
     "latitude": 51.1700524514,
     "longitude": -1.6207622447
   },
   "GRV": {
-    "station_name": "Gravesend Rail Station",
+    "station_name": "Gravesend",
     "latitude": 51.4413470696,
     "longitude": 0.3666726966
   },
   "GRY": {
-    "station_name": "Grays Rail Station",
+    "station_name": "Grays",
     "latitude": 51.4762461335,
     "longitude": 0.3218603146
   },
   "GSC": {
-    "station_name": "Gilshochill Rail Station",
+    "station_name": "Gilshochill",
     "latitude": 55.8973310545,
     "longitude": -4.2826700794
   },
   "GSD": {
-    "station_name": "Garsdale Rail Station",
+    "station_name": "Garsdale",
     "latitude": 54.3214395016,
     "longitude": -2.3263576927
   },
   "GSL": {
-    "station_name": "Gunnislake Rail Station",
+    "station_name": "Gunnislake",
     "latitude": 50.5160691161,
     "longitude": -4.2194356583
   },
   "GSN": {
-    "station_name": "Garston (Herts) Rail Station",
+    "station_name": "Garston (Herts)",
     "latitude": 51.6866190925,
     "longitude": -0.3817173062
   },
   "GST": {
-    "station_name": "Gathurst Rail Station",
+    "station_name": "Gathurst",
     "latitude": 53.5594164707,
     "longitude": -2.694392781
   },
   "GSW": {
-    "station_name": "Garswood Rail Station",
+    "station_name": "Garswood",
     "latitude": 53.4885342343,
     "longitude": -2.6721346367
   },
   "GSY": {
-    "station_name": "Guiseley Rail Station",
+    "station_name": "Guiseley",
     "latitude": 53.8759473312,
     "longitude": -1.7150832878
   },
   "GTA": {
-    "station_name": "Great Ayton Rail Station",
+    "station_name": "Great Ayton",
     "latitude": 54.4895819243,
     "longitude": -1.1153591094
   },
   "GTH": {
-    "station_name": "Garth (Powys) Rail Station",
+    "station_name": "Garth (Powys)",
     "latitude": 52.1332443119,
     "longitude": -3.5299153647
   },
   "GTN": {
-    "station_name": "Grangetown (Cardiff) Rail Station",
+    "station_name": "Grangetown (Cardiff)",
     "latitude": 51.4676101723,
     "longitude": -3.1897328323
   },
   "GTO": {
-    "station_name": "Gorton Rail Station",
+    "station_name": "Gorton",
     "latitude": 53.4690883466,
     "longitude": -2.1662083592
   },
   "GTR": {
-    "station_name": "Goostrey Rail Station",
+    "station_name": "Goostrey",
     "latitude": 53.2225673734,
     "longitude": -2.3264689479
   },
   "GTW": {
-    "station_name": "Gatwick Airport Rail Station",
+    "station_name": "Gatwick Airport",
     "latitude": 51.1564852744,
     "longitude": -0.1610141074
   },
   "GTY": {
-    "station_name": "Gatley Rail Station",
+    "station_name": "Gatley",
     "latitude": 53.3929193229,
     "longitude": -2.2312340568
   },
   "GUI": {
-    "station_name": "Guide Bridge Rail Station",
+    "station_name": "Guide Bridge",
     "latitude": 53.4746422166,
     "longitude": -2.1137102403
   },
   "GUN": {
-    "station_name": "Gunnersbury Rail Station",
+    "station_name": "Gunnersbury",
     "latitude": 51.4916766051,
     "longitude": -0.2752639989
   },
   "GVE": {
-    "station_name": "Garve Rail Station",
+    "station_name": "Garve",
     "latitude": 57.6130218771,
     "longitude": -4.6883911143
   },
   "GVH": {
-    "station_name": "Gravelly Hill Rail Station",
+    "station_name": "Gravelly Hill",
     "latitude": 52.5150091168,
     "longitude": -1.8525928905
   },
   "GWE": {
-    "station_name": "Gwersyllt Rail Station",
+    "station_name": "Gwersyllt",
     "latitude": 53.0725888841,
     "longitude": -3.0178887352
   },
   "GWN": {
-    "station_name": "Gowerton Rail Station",
+    "station_name": "Gowerton",
     "latitude": 51.6487287822,
     "longitude": -4.0359546516
   },
   "GYM": {
-    "station_name": "Great Yarmouth Rail Station",
+    "station_name": "Great Yarmouth",
     "latitude": 52.6121840141,
     "longitude": 1.7209095669
   },
   "GYP": {
-    "station_name": "Gypsy Lane Rail Station",
+    "station_name": "Gypsy Lane",
     "latitude": 54.5329024718,
     "longitude": -1.1794055894
   },
   "HAB": {
-    "station_name": "Habrough Rail Station",
+    "station_name": "Habrough",
     "latitude": 53.6060967313,
     "longitude": -0.2694661266
   },
   "HAC": {
-    "station_name": "Hackney Downs Rail Station",
+    "station_name": "Hackney Downs",
     "latitude": 51.548757028,
     "longitude": -0.0607923652
   },
   "HAD": {
-    "station_name": "Haddiscoe Rail Station",
+    "station_name": "Haddiscoe",
     "latitude": 52.5288110907,
     "longitude": 1.6230311744
   },
   "HAF": {
-    "station_name": "Heathrow Terminal 4 Rail Station",
+    "station_name": "Heathrow Terminal 4",
     "latitude": 51.458265962,
     "longitude": -0.4454428215
   },
   "HAG": {
-    "station_name": "Hagley Rail Station",
+    "station_name": "Hagley",
     "latitude": 52.4225023907,
     "longitude": -2.1464119812
   },
   "HAI": {
-    "station_name": "Halling Rail Station",
+    "station_name": "Halling",
     "latitude": 51.352475791,
     "longitude": 0.4449605383
   },
   "HAL": {
-    "station_name": "Hale Rail Station",
+    "station_name": "Hale",
     "latitude": 53.3787324238,
     "longitude": -2.3473557978
   },
   "HAM": {
-    "station_name": "Hamworthy Rail Station",
+    "station_name": "Hamworthy",
     "latitude": 50.7251804312,
     "longitude": -2.0193512479
   },
   "HAN": {
-    "station_name": "Hanwell Rail Station",
+    "station_name": "Hanwell",
     "latitude": 51.5118339425,
     "longitude": -0.3385615111
   },
   "HAP": {
-    "station_name": "Hatfield Peverel Rail Station",
+    "station_name": "Hatfield Peverel",
     "latitude": 51.7798704228,
     "longitude": 0.5921498316
   },
   "HAS": {
-    "station_name": "Halesworth Rail Station",
+    "station_name": "Halesworth",
     "latitude": 52.3468365087,
     "longitude": 1.505697432
   },
   "HAT": {
-    "station_name": "Hatfield (Herts) Rail Station",
+    "station_name": "Hatfield (Herts)",
     "latitude": 51.7638834885,
     "longitude": -0.215564807
   },
   "HAV": {
-    "station_name": "Havant Rail Station",
+    "station_name": "Havant",
     "latitude": 50.8544157698,
     "longitude": -0.9815958592
   },
   "HAY": {
-    "station_name": "Hayes & Harlington Rail Station",
+    "station_name": "Hayes & Harlington",
     "latitude": 51.5030948614,
     "longitude": -0.4206635166
   },
   "HAZ": {
-    "station_name": "Hazel Grove Rail Station",
+    "station_name": "Hazel Grove",
     "latitude": 53.3775580792,
     "longitude": -2.1220186129
   },
   "HBB": {
-    "station_name": "Hubberts Bridge Rail Station",
+    "station_name": "Hubberts Bridge",
     "latitude": 52.9753742831,
     "longitude": -0.1105219846
   },
   "HBD": {
-    "station_name": "Hebden Bridge Rail Station",
+    "station_name": "Hebden Bridge",
     "latitude": 53.7376009105,
     "longitude": -2.0090600757
   },
+  "HBL": {
+    "station_name": "Headbolt Lane",
+    "latitude": 53.4911,
+    "longitude": -2.8856
+  },
   "HBN": {
-    "station_name": "Hollingbourne Rail Station",
+    "station_name": "Hollingbourne",
     "latitude": 51.2651766997,
     "longitude": 0.6278786652
   },
   "HBP": {
-    "station_name": "Hornbeam Park Rail Station",
+    "station_name": "Hornbeam Park",
     "latitude": 53.9798825753,
     "longitude": -1.5268279163
   },
   "HBY": {
-    "station_name": "Hartlebury Rail Station",
+    "station_name": "Hartlebury",
     "latitude": 52.3345074098,
     "longitude": -2.2211143855
   },
   "HCB": {
-    "station_name": "Hackbridge Rail Station",
+    "station_name": "Hackbridge",
     "latitude": 51.3778692696,
     "longitude": -0.1538824466
   },
   "HCH": {
-    "station_name": "Holmes Chapel Rail Station",
+    "station_name": "Holmes Chapel",
     "latitude": 53.1989461479,
     "longitude": -2.3511385797
   },
   "HCN": {
-    "station_name": "Headcorn Rail Station",
+    "station_name": "Headcorn",
     "latitude": 51.1657113933,
     "longitude": 0.6275122421
   },
   "HCT": {
-    "station_name": "Huncoat Rail Station",
+    "station_name": "Huncoat",
     "latitude": 53.7717900997,
     "longitude": -2.3475613545
   },
   "HDB": {
-    "station_name": "Haydon Bridge Rail Station",
+    "station_name": "Haydon Bridge",
     "latitude": 54.9751799008,
     "longitude": -2.247596044
   },
   "HDE": {
-    "station_name": "Hedge End Rail Station",
+    "station_name": "Hedge End",
     "latitude": 50.9323093202,
     "longitude": -1.2944922291
   },
   "HDF": {
-    "station_name": "Hadfield Rail Station",
+    "station_name": "Hadfield",
     "latitude": 53.4607595075,
     "longitude": -1.9653179115
   },
   "HDG": {
-    "station_name": "Heald Green Rail Station",
+    "station_name": "Heald Green",
     "latitude": 53.3694305097,
     "longitude": -2.2366663043
   },
   "HDH": {
-    "station_name": "Hampstead Heath Rail Station",
+    "station_name": "Hampstead Heath",
     "latitude": 51.555210868,
     "longitude": -0.1656799709
   },
   "HDL": {
-    "station_name": "Headstone Lane Rail Station",
+    "station_name": "Headstone Lane",
     "latitude": 51.6026499985,
     "longitude": -0.3571975148
   },
   "HDM": {
-    "station_name": "Haddenham & Thame Parkway Rail Station",
+    "station_name": "Haddenham & Thame Parkway",
     "latitude": 51.7708590202,
     "longitude": -0.9421154353
   },
   "HDN": {
-    "station_name": "Harlesden Rail Station",
+    "station_name": "Harlesden",
     "latitude": 51.536289123,
     "longitude": -0.2576441501
   },
   "HDW": {
-    "station_name": "Hadley Wood Rail Station",
+    "station_name": "Hadley Wood",
     "latitude": 51.6684984541,
     "longitude": -0.1761475828
   },
   "HDY": {
-    "station_name": "Headingley Rail Station",
+    "station_name": "Headingley",
     "latitude": 53.8179883371,
     "longitude": -1.5941914379
   },
   "HEC": {
-    "station_name": "Heckington Rail Station",
+    "station_name": "Heckington",
     "latitude": 52.9773390292,
     "longitude": -0.2939371983
   },
   "HED": {
-    "station_name": "Halewood Rail Station",
+    "station_name": "Halewood",
     "latitude": 53.3644936533,
     "longitude": -2.8301342149
   },
   "HEI": {
-    "station_name": "Heighington Rail Station",
+    "station_name": "Heighington",
     "latitude": 54.5969688714,
     "longitude": -1.5817749363
   },
   "HEL": {
-    "station_name": "Hensall Rail Station",
+    "station_name": "Hensall",
     "latitude": 53.6985625439,
     "longitude": -1.1145223177
   },
   "HEN": {
-    "station_name": "Hendon Rail Station",
+    "station_name": "Hendon",
     "latitude": 51.5800693984,
     "longitude": -0.2386485815
   },
   "HER": {
-    "station_name": "Hersham Rail Station",
+    "station_name": "Hersham",
     "latitude": 51.3768090642,
     "longitude": -0.3899376365
   },
   "HES": {
-    "station_name": "Hessle Rail Station",
+    "station_name": "Hessle",
     "latitude": 53.7174547293,
     "longitude": -0.4418278411
   },
   "HEV": {
-    "station_name": "Hever Rail Station",
+    "station_name": "Hever",
     "latitude": 51.18140673,
     "longitude": 0.0950955245
   },
   "HEW": {
-    "station_name": "Heworth Rail Station",
+    "station_name": "Heworth",
     "latitude": 54.951574003,
     "longitude": -1.5557793317
   },
   "HEX": {
-    "station_name": "Hexham Rail Station",
+    "station_name": "Hexham",
     "latitude": 54.9734640115,
     "longitude": -2.0948036947
   },
   "HFD": {
-    "station_name": "Hereford Rail Station",
+    "station_name": "Hereford",
     "latitude": 52.0611692914,
     "longitude": -2.7082118767
   },
   "HFE": {
-    "station_name": "Hertford East Rail Station",
+    "station_name": "Hertford East",
     "latitude": 51.7990391609,
     "longitude": -0.0729130019
   },
   "HFN": {
-    "station_name": "Hertford North Rail Station",
+    "station_name": "Hertford North",
     "latitude": 51.7988609689,
     "longitude": -0.0917600735
   },
   "HFS": {
-    "station_name": "Hatfield & Stainforth Rail Station",
+    "station_name": "Hatfield & Stainforth",
     "latitude": 53.5887339868,
     "longitude": -1.0233819902
   },
   "HFX": {
-    "station_name": "Halifax Rail Station",
+    "station_name": "Halifax",
     "latitude": 53.7209739882,
     "longitude": -1.853576757
   },
   "HGD": {
-    "station_name": "Hungerford Rail Station",
+    "station_name": "Hungerford",
     "latitude": 51.4149070262,
     "longitude": -1.5122717583
   },
   "HGF": {
-    "station_name": "Hag Fold Rail Station",
+    "station_name": "Hag Fold",
     "latitude": 53.5338672616,
     "longitude": -2.494821366
   },
   "HGG": {
-    "station_name": "Haggerston Rail Station",
+    "station_name": "Haggerston",
     "latitude": 51.5387053397,
     "longitude": -0.0756398309
   },
   "HGM": {
-    "station_name": "Higham Rail Station",
+    "station_name": "Higham",
     "latitude": 51.4265572516,
     "longitude": 0.4663063259
   },
   "HGN": {
-    "station_name": "Hough Green Rail Station",
+    "station_name": "Hough Green",
     "latitude": 53.3724056855,
     "longitude": -2.7750665578
   },
   "HGR": {
-    "station_name": "Hither Green Rail Station",
+    "station_name": "Hither Green",
     "latitude": 51.4520235715,
     "longitude": -0.0009184787
   },
   "HGS": {
-    "station_name": "Hastings Rail Station",
+    "station_name": "Hastings",
     "latitude": 50.8578901133,
     "longitude": 0.5767707918
   },
   "HGT": {
-    "station_name": "Harrogate Rail Station",
+    "station_name": "Harrogate",
     "latitude": 53.9931903958,
     "longitude": -1.5376134519
   },
   "HGY": {
-    "station_name": "Harringay Rail Station",
+    "station_name": "Harringay",
     "latitude": 51.577359069,
     "longitude": -0.1051105218
   },
   "HHB": {
-    "station_name": "Heysham Port Rail Station",
+    "station_name": "Heysham Port",
     "latitude": 54.0331542281,
     "longitude": -2.9131111175
   },
   "HHD": {
-    "station_name": "Holyhead Rail Station",
+    "station_name": "Holyhead",
     "latitude": 53.3076995179,
     "longitude": -4.6310080997
   },
   "HHE": {
-    "station_name": "Haywards Heath Rail Station",
+    "station_name": "Haywards Heath",
     "latitude": 51.0056759707,
     "longitude": -0.105050763
   },
   "HHL": {
-    "station_name": "Heath High Level Rail Station",
+    "station_name": "Heath High Level",
     "latitude": 51.5164298424,
     "longitude": -3.181549994
   },
   "HHY": {
-    "station_name": "Highbury & Islington Rail Station",
+    "station_name": "Highbury & Islington",
     "latitude": 51.5461777019,
     "longitude": -0.103737426
   },
   "HIA": {
-    "station_name": "Hampton-in-Arden Rail Station",
+    "station_name": "Hampton-in-Arden",
     "latitude": 52.4290462911,
     "longitude": -1.69992295
   },
   "HIB": {
-    "station_name": "High Brooms Rail Station",
+    "station_name": "High Brooms",
     "latitude": 51.1494010314,
     "longitude": 0.2773589795
   },
   "HID": {
-    "station_name": "Hall i' th' Wood Rail Station",
+    "station_name": "Hall i' th' Wood",
     "latitude": 53.5974371057,
     "longitude": -2.413107867
   },
   "HIG": {
-    "station_name": "Highbridge & Burnham-on-Sea Rail Station",
+    "station_name": "Highbridge & Burnham-on-Sea",
     "latitude": 51.2181503748,
     "longitude": -2.9721630499
   },
   "HII": {
-    "station_name": "Highbury & Islington Rail Station",
+    "station_name": "Highbury & Islington",
     "latitude": 51.5460878363,
     "longitude": -0.1037411643
   },
   "HIL": {
-    "station_name": "Hillside Rail Station",
+    "station_name": "Hillside",
     "latitude": 53.6221202826,
     "longitude": -3.0247137204
   },
   "HIN": {
-    "station_name": "Hindley Rail Station",
+    "station_name": "Hindley",
     "latitude": 53.5422508577,
     "longitude": -2.575501122
   },
   "HIP": {
-    "station_name": "Highams Park Rail Station",
+    "station_name": "Highams Park",
     "latitude": 51.6083496344,
     "longitude": -0.000196266
   },
   "HIR": {
-    "station_name": "Horton-in-Ribblesdale Rail Station",
+    "station_name": "Horton-in-Ribblesdale",
     "latitude": 54.149396209,
     "longitude": -2.3020360937
   },
   "HIT": {
-    "station_name": "Hitchin Rail Station",
+    "station_name": "Hitchin",
     "latitude": 51.9532881959,
     "longitude": -0.2634564466
   },
   "HKC": {
-    "station_name": "Hackney Central Rail Station",
+    "station_name": "Hackney Central",
     "latitude": 51.5471044422,
     "longitude": -0.0560308162
   },
   "HKH": {
-    "station_name": "Hawkhead Rail Station",
+    "station_name": "Hawkhead",
     "latitude": 55.8421839094,
     "longitude": -4.3988362292
   },
   "HKM": {
-    "station_name": "Hykeham Rail Station",
+    "station_name": "Hykeham",
     "latitude": 53.1950249324,
     "longitude": -0.6001954228
   },
   "HKN": {
-    "station_name": "Hucknall Rail Station",
+    "station_name": "Hucknall",
     "latitude": 53.0383014288,
     "longitude": -1.1958079305
   },
   "HKW": {
-    "station_name": "Hackney Wick Rail Station",
+    "station_name": "Hackney Wick",
     "latitude": 51.5434103591,
     "longitude": -0.0248923154
   },
   "HLB": {
-    "station_name": "Hildenborough Rail Station",
+    "station_name": "Hildenborough",
     "latitude": 51.2144822954,
     "longitude": 0.227617147
   },
   "HLC": {
-    "station_name": "Helensburgh Central Rail Station",
+    "station_name": "Helensburgh Central",
     "latitude": 56.0041995399,
     "longitude": -4.7327385924
   },
   "HLD": {
-    "station_name": "Hellifield Rail Station",
+    "station_name": "Hellifield",
     "latitude": 54.0108742019,
     "longitude": -2.2278480504
   },
   "HLE": {
-    "station_name": "Hillington East Rail Station",
+    "station_name": "Hillington East",
     "latitude": 55.8541758548,
     "longitude": -4.3549953963
   },
   "HLF": {
-    "station_name": "Hillfoot Rail Station",
+    "station_name": "Hillfoot",
     "latitude": 55.9200849636,
     "longitude": -4.3202587624
   },
   "HLG": {
-    "station_name": "Hall Green Rail Station",
+    "station_name": "Hall Green",
     "latitude": 52.4369222096,
     "longitude": -1.8456449276
   },
   "HLI": {
-    "station_name": "Healing Rail Station",
+    "station_name": "Healing",
     "latitude": 53.5818205021,
     "longitude": -0.1606345765
   },
   "HLL": {
-    "station_name": "Heath Low Level Rail Station",
+    "station_name": "Heath Low Level",
     "latitude": 51.5156612205,
     "longitude": -3.1819768215
   },
   "HLM": {
-    "station_name": "Holmwood Rail Station",
+    "station_name": "Holmwood",
     "latitude": 51.1811903162,
     "longitude": -0.3207835997
   },
   "HLN": {
-    "station_name": "Harlington (Beds) Rail Station",
+    "station_name": "Harlington (Beds)",
     "latitude": 51.9620697513,
     "longitude": -0.4956650065
   },
   "HLR": {
-    "station_name": "Hall Road Rail Station",
+    "station_name": "Hall Road",
     "latitude": 53.4975007979,
     "longitude": -3.049624671
   },
   "HLS": {
-    "station_name": "Hilsea Rail Station",
+    "station_name": "Hilsea",
     "latitude": 50.828264455,
     "longitude": -1.0587831528
   },
   "HLU": {
-    "station_name": "Helensburgh Upper Rail Station",
+    "station_name": "Helensburgh Upper",
     "latitude": 56.0123545737,
     "longitude": -4.7297849071
   },
   "HLW": {
-    "station_name": "Hillington West Rail Station",
+    "station_name": "Hillington West",
     "latitude": 55.8560145655,
     "longitude": -4.3715655801
   },
   "HLY": {
-    "station_name": "Holytown Rail Station",
+    "station_name": "Holytown",
     "latitude": 55.8128931888,
     "longitude": -3.9739183285
   },
   "HMC": {
-    "station_name": "Hampton Court Rail Station",
+    "station_name": "Hampton Court",
     "latitude": 51.402553453,
     "longitude": -0.3427264701
   },
   "HMD": {
-    "station_name": "Hampden Park (Sussex) Rail Station",
+    "station_name": "Hampden Park (Sussex)",
     "latitude": 50.7963992867,
     "longitude": 0.2793840646
   },
   "HME": {
-    "station_name": "Hamble Rail Station",
+    "station_name": "Hamble",
     "latitude": 50.8713629565,
     "longitude": -1.3291521514
   },
   "HML": {
-    "station_name": "Hemel Hempstead Rail Station",
+    "station_name": "Hemel Hempstead",
     "latitude": 51.7423380827,
     "longitude": -0.4907522249
   },
   "HMM": {
-    "station_name": "Hammerton Rail Station",
+    "station_name": "Hammerton",
     "latitude": 53.9963447909,
     "longitude": -1.2841021471
   },
   "HMN": {
-    "station_name": "Homerton Rail Station",
+    "station_name": "Homerton",
     "latitude": 51.547011697,
     "longitude": -0.0423325837
   },
   "HMP": {
-    "station_name": "Hampton (London) Rail Station",
+    "station_name": "Hampton (London)",
     "latitude": 51.415932868,
     "longitude": -0.3720976323
   },
   "HMS": {
-    "station_name": "Helmsdale Rail Station",
+    "station_name": "Helmsdale",
     "latitude": 58.1174231841,
     "longitude": -3.6586930118
   },
   "HMT": {
-    "station_name": "Ham Street Rail Station",
+    "station_name": "Ham Street",
     "latitude": 51.0683758331,
     "longitude": 0.8545396144
   },
   "HMW": {
-    "station_name": "Hampton Wick Rail Station",
+    "station_name": "Hampton Wick",
     "latitude": 51.414522516,
     "longitude": -0.3124680243
   },
   "HMY": {
-    "station_name": "Hairmyres Rail Station",
+    "station_name": "Hairmyres",
     "latitude": 55.761959437,
     "longitude": -4.2199969848
   },
   "HNA": {
-    "station_name": "Hinton Admiral Rail Station",
+    "station_name": "Hinton Admiral",
     "latitude": 50.7526280082,
     "longitude": -1.7141197084
   },
   "HNB": {
-    "station_name": "Herne Bay Rail Station",
+    "station_name": "Herne Bay",
     "latitude": 51.364595492,
     "longitude": 1.1177553962
   },
   "HNC": {
-    "station_name": "Hamilton Central Rail Station",
+    "station_name": "Hamilton Central",
     "latitude": 55.7731886703,
     "longitude": -4.0388743726
   },
   "HND": {
-    "station_name": "Hanborough Rail Station",
+    "station_name": "Hanborough",
     "latitude": 51.8251625822,
     "longitude": -1.3735084455
   },
   "HNF": {
-    "station_name": "Hednesford Rail Station",
+    "station_name": "Hednesford",
     "latitude": 52.7101262196,
     "longitude": -2.0017747098
   },
   "HNG": {
-    "station_name": "Hengoed Rail Station",
+    "station_name": "Hengoed",
     "latitude": 51.6474099206,
     "longitude": -3.2241373274
   },
   "HNH": {
-    "station_name": "Herne Hill Rail Station",
+    "station_name": "Herne Hill",
     "latitude": 51.4533037255,
     "longitude": -0.102263463
   },
   "HNK": {
-    "station_name": "Hinckley Rail Station",
+    "station_name": "Hinckley",
     "latitude": 52.5350144159,
     "longitude": -1.3719130606
   },
   "HNL": {
-    "station_name": "Henley-in-Arden Rail Station",
+    "station_name": "Henley-in-Arden",
     "latitude": 52.2915002317,
     "longitude": -1.7839820888
   },
   "HNT": {
-    "station_name": "Huntly Rail Station",
+    "station_name": "Huntly",
     "latitude": 57.4444716353,
     "longitude": -2.7757412945
   },
   "HNW": {
-    "station_name": "Hamilton West Rail Station",
+    "station_name": "Hamilton West",
     "latitude": 55.7788548735,
     "longitude": -4.0547968763
   },
   "HNX": {
-    "station_name": "Hunts Cross Rail Station",
+    "station_name": "Hunts Cross",
     "latitude": 53.3607253407,
     "longitude": -2.8558609579
   },
   "HOC": {
-    "station_name": "Hockley Rail Station",
+    "station_name": "Hockley",
     "latitude": 51.6035599652,
     "longitude": 0.6590284828
   },
   "HOH": {
-    "station_name": "Harrow-on-the-Hill Rail Station",
+    "station_name": "Harrow-on-the-Hill",
     "latitude": 51.5791855381,
     "longitude": -0.3372032129
   },
   "HOK": {
-    "station_name": "Hook Rail Station",
+    "station_name": "Hook",
     "latitude": 51.279996325,
     "longitude": -0.9616187573
   },
   "HOL": {
-    "station_name": "Holton Heath Rail Station",
+    "station_name": "Holton Heath",
     "latitude": 50.7113964673,
     "longitude": -2.0778391092
   },
   "HON": {
-    "station_name": "Honiton Rail Station",
+    "station_name": "Honiton",
     "latitude": 50.7965702123,
     "longitude": -3.1867284121
   },
   "HOO": {
-    "station_name": "Hooton Rail Station",
+    "station_name": "Hooton",
     "latitude": 53.2972130919,
     "longitude": -2.9770090629
   },
   "HOP": {
-    "station_name": "Hope (Derbyshire) Rail Station",
+    "station_name": "Hope (Derbyshire)",
     "latitude": 53.3461251048,
     "longitude": -1.7298854225
   },
   "HOR": {
-    "station_name": "Horley Rail Station",
+    "station_name": "Horley",
     "latitude": 51.1687701925,
     "longitude": -0.1610261883
   },
   "HOT": {
-    "station_name": "Henley-on-Thames Rail Station",
+    "station_name": "Henley-on-Thames",
     "latitude": 51.5341810915,
     "longitude": -0.9001927563
   },
   "HOU": {
-    "station_name": "Hounslow Rail Station",
+    "station_name": "Hounslow",
     "latitude": 51.4619441377,
     "longitude": -0.3622557388
   },
   "HOV": {
-    "station_name": "Hove Rail Station",
+    "station_name": "Hove",
     "latitude": 50.8352085815,
     "longitude": -0.1706597369
   },
   "HOW": {
-    "station_name": "Howden Rail Station",
+    "station_name": "Howden",
     "latitude": 53.7647299348,
     "longitude": -0.8604679516
   },
   "HOX": {
-    "station_name": "Hoxton Rail Station",
+    "station_name": "Hoxton",
     "latitude": 51.5315115893,
     "longitude": -0.075655026
   },
   "HOY": {
-    "station_name": "Honley Rail Station",
+    "station_name": "Honley",
     "latitude": 53.6082419978,
     "longitude": -1.7809663313
   },
   "HOZ": {
-    "station_name": "Howwood (Renfrewshire) Rail Station",
+    "station_name": "Howwood (Renfrewshire)",
     "latitude": 55.8105581084,
     "longitude": -4.5630406539
   },
   "HPA": {
-    "station_name": "Honor Oak Park Rail Station",
+    "station_name": "Honor Oak Park",
     "latitude": 51.4499871094,
     "longitude": -0.0454798264
   },
   "HPD": {
-    "station_name": "Harpenden Rail Station",
+    "station_name": "Harpenden",
     "latitude": 51.8146501449,
     "longitude": -0.3514563418
   },
   "HPE": {
-    "station_name": "Hope (Flintshire) Rail Station",
+    "station_name": "Hope (Flintshire)",
     "latitude": 53.117371815,
     "longitude": -3.03687622
   },
   "HPL": {
-    "station_name": "Hartlepool Rail Station",
+    "station_name": "Hartlepool",
     "latitude": 54.6867644231,
     "longitude": -1.2073308234
   },
   "HPN": {
-    "station_name": "Hapton Rail Station",
+    "station_name": "Hapton",
     "latitude": 53.7816268971,
     "longitude": -2.3169116789
   },
   "HPQ": {
-    "station_name": "Harwich International Rail Station",
+    "station_name": "Harwich International",
     "latitude": 51.9473012514,
     "longitude": 1.2551547397
   },
   "HPT": {
-    "station_name": "Hopton Heath Rail Station",
+    "station_name": "Hopton Heath",
     "latitude": 52.3914278931,
     "longitude": -2.9120578549
   },
   "HRD": {
-    "station_name": "Harling Road Rail Station",
+    "station_name": "Harling Road",
     "latitude": 52.4537084708,
     "longitude": 0.9091672143
   },
+  "HRE": {
+    "station_name":"Horden",
+    "latitude": 54.763879,
+    "longitude":-1.307347
+  },
   "HRH": {
-    "station_name": "Horsham Rail Station",
+    "station_name": "Horsham",
     "latitude": 51.0660592013,
     "longitude": -0.3192431154
   },
   "HRL": {
-    "station_name": "Harlech Rail Station",
+    "station_name": "Harlech",
     "latitude": 52.8613425321,
     "longitude": -4.1091973982
   },
   "HRM": {
-    "station_name": "Harrietsham Rail Station",
+    "station_name": "Harrietsham",
     "latitude": 51.2448308208,
     "longitude": 0.6724297963
   },
   "HRN": {
-    "station_name": "Hornsey Rail Station",
+    "station_name": "Hornsey",
     "latitude": 51.5864618559,
     "longitude": -0.1119495944
   },
   "HRO": {
-    "station_name": "Harold Wood Rail Station",
+    "station_name": "Harold Wood",
     "latitude": 51.592766307,
     "longitude": 0.2331539888
   },
   "HRR": {
-    "station_name": "Harrington Rail Station",
+    "station_name": "Harrington",
     "latitude": 54.6134911874,
     "longitude": -3.5655149544
   },
   "HRS": {
-    "station_name": "Horsforth Rail Station",
+    "station_name": "Horsforth",
     "latitude": 53.8477194776,
     "longitude": -1.6302327899
   },
   "HRW": {
-    "station_name": "Harrow & Wealdstone Rail Station",
+    "station_name": "Harrow & Wealdstone",
     "latitude": 51.5921690735,
     "longitude": -0.3345489082
   },
   "HRY": {
-    "station_name": "Harringay Green Lanes Rail Station",
+    "station_name": "Harringay Green Lanes",
     "latitude": 51.5771828877,
     "longitude": -0.0981182196
   },
   "HSB": {
-    "station_name": "Helsby Rail Station",
+    "station_name": "Helsby",
     "latitude": 53.2752149638,
     "longitude": -2.7712062956
   },
   "HSC": {
-    "station_name": "Hoscar Rail Station",
+    "station_name": "Hoscar",
     "latitude": 53.5977824276,
     "longitude": -2.8044204789
   },
   "HSD": {
-    "station_name": "Hamstead (Birmingham) Rail Station",
+    "station_name": "Hamstead (Birmingham)",
     "latitude": 52.5310822389,
     "longitude": -1.9289728746
   },
   "HSG": {
-    "station_name": "Hathersage Rail Station",
+    "station_name": "Hathersage",
     "latitude": 53.3257885551,
     "longitude": -1.6517174825
   },
   "HSK": {
-    "station_name": "Hassocks Rail Station",
+    "station_name": "Hassocks",
     "latitude": 50.9246090606,
     "longitude": -0.1459258012
   },
   "HSL": {
-    "station_name": "Haslemere Rail Station",
+    "station_name": "Haslemere",
     "latitude": 51.0886414366,
     "longitude": -0.7191423803
   },
   "HST": {
-    "station_name": "High Street (Glasgow) Rail Station",
+    "station_name": "High Street (Glasgow)",
     "latitude": 55.8595578077,
     "longitude": -4.2401039264
   },
   "HSW": {
-    "station_name": "Heswall Rail Station",
+    "station_name": "Heswall",
     "latitude": 53.329731232,
     "longitude": -3.073702346
   },
   "HSY": {
-    "station_name": "Horsley Rail Station",
+    "station_name": "Horsley",
     "latitude": 51.2793430837,
     "longitude": -0.4353859424
   },
   "HTC": {
-    "station_name": "Heaton Chapel Rail Station",
+    "station_name": "Heaton Chapel",
     "latitude": 53.4255745892,
     "longitude": -2.1790400211
   },
   "HTE": {
-    "station_name": "Hatch End Rail Station",
+    "station_name": "Hatch End",
     "latitude": 51.609418318,
     "longitude": -0.3685792009
   },
   "HTF": {
-    "station_name": "Hartford Rail Station",
+    "station_name": "Hartford",
     "latitude": 53.2417720752,
     "longitude": -2.5536278419
   },
   "HTH": {
-    "station_name": "Handforth Rail Station",
+    "station_name": "Handforth",
     "latitude": 53.3465081231,
     "longitude": -2.2136326157
   },
   "HTN": {
-    "station_name": "Hatton (Warks) Rail Station",
+    "station_name": "Hatton (Warks)",
     "latitude": 52.2952909349,
     "longitude": -1.6729642026
   },
   "HTO": {
-    "station_name": "Hightown Rail Station",
+    "station_name": "Hightown",
     "latitude": 53.5251206717,
     "longitude": -3.0570655927
   },
@@ -5940,77 +5975,77 @@
     "longitude": -0.4532864637
   },
   "HTW": {
-    "station_name": "Hartwood Rail Station",
+    "station_name": "Hartwood",
     "latitude": 55.8114760965,
     "longitude": -3.8393119766
   },
   "HTY": {
-    "station_name": "Hattersley Rail Station",
+    "station_name": "Hattersley",
     "latitude": 53.4452970666,
     "longitude": -2.0403099081
   },
   "HUB": {
-    "station_name": "Hunmanby Rail Station",
+    "station_name": "Hunmanby",
     "latitude": 54.1739432859,
     "longitude": -0.3145719426
   },
   "HUD": {
-    "station_name": "Huddersfield Rail Station",
+    "station_name": "Huddersfield",
     "latitude": 53.6485157907,
     "longitude": -1.7846917017
   },
   "HUL": {
-    "station_name": "Hull Rail Station",
+    "station_name": "Hull",
     "latitude": 53.7441695387,
     "longitude": -0.3456862671
   },
   "HUN": {
-    "station_name": "Huntingdon Rail Station",
+    "station_name": "Huntingdon",
     "latitude": 52.3286615315,
     "longitude": -0.1920472657
   },
   "HUP": {
-    "station_name": "Humphrey Park Rail Station",
+    "station_name": "Humphrey Park",
     "latitude": 53.4522431612,
     "longitude": -2.3275376643
   },
   "HUR": {
-    "station_name": "Hurst Green Rail Station",
+    "station_name": "Hurst Green",
     "latitude": 51.2444268856,
     "longitude": 0.0039654468
   },
   "HUT": {
-    "station_name": "Hutton Cranswick Rail Station",
+    "station_name": "Hutton Cranswick",
     "latitude": 53.9558737241,
     "longitude": -0.433871592
   },
   "HUY": {
-    "station_name": "Huyton Rail Station",
+    "station_name": "Huyton",
     "latitude": 53.4096981525,
     "longitude": -2.8429886413
   },
   "HVF": {
-    "station_name": "Haverfordwest Rail Station",
+    "station_name": "Haverfordwest",
     "latitude": 51.8026432765,
     "longitude": -4.960235795
   },
   "HVN": {
-    "station_name": "Havenhouse Rail Station",
+    "station_name": "Havenhouse",
     "latitude": 53.1144941819,
     "longitude": 0.2731698815
   },
   "HWB": {
-    "station_name": "Hawarden Bridge Rail Station",
+    "station_name": "Hawarden Bridge",
     "latitude": 53.2180881941,
     "longitude": -3.0327167308
   },
   "HWC": {
-    "station_name": "Harwich Town Rail Station",
+    "station_name": "Harwich Town",
     "latitude": 51.9441574404,
     "longitude": 1.2867119437
   },
   "HWD": {
-    "station_name": "Hawarden Rail Station",
+    "station_name": "Hawarden",
     "latitude": 53.1853727789,
     "longitude": -3.0320807812
   },
@@ -6020,32 +6055,32 @@
     "longitude": -0.4469469959
   },
   "HWH": {
-    "station_name": "Haltwhistle Rail Station",
+    "station_name": "Haltwhistle",
     "latitude": 54.9678535356,
     "longitude": -2.4635724781
   },
   "HWI": {
-    "station_name": "Horwich Parkway Rail Station",
+    "station_name": "Horwich Parkway",
     "latitude": 53.5781205097,
     "longitude": -2.5396661144
   },
   "HWM": {
-    "station_name": "Harlow Mill Rail Station",
+    "station_name": "Harlow Mill",
     "latitude": 51.7903700355,
     "longitude": 0.1323343315
   },
   "HWN": {
-    "station_name": "Harlow Town Rail Station",
+    "station_name": "Harlow Town",
     "latitude": 51.7810744782,
     "longitude": 0.0951587231
   },
   "HWV": {
-    "station_name": "Heathrow Terminal 5 Rail Station",
+    "station_name": "Heathrow Terminal 5",
     "latitude": 51.4700517143,
     "longitude": -0.490569702
   },
   "HWW": {
-    "station_name": "How Wood (Herts) Rail Station",
+    "station_name": "How Wood (Herts)",
     "latitude": 51.7177454662,
     "longitude": -0.344647203
   },
@@ -6055,1617 +6090,1632 @@
     "longitude": -0.4893495013
   },
   "HWY": {
-    "station_name": "High Wycombe Rail Station",
+    "station_name": "High Wycombe",
     "latitude": 51.6295875603,
     "longitude": -0.7453905204
   },
   "HXM": {
-    "station_name": "Hoveton & Wroxham Rail Station",
+    "station_name": "Hoveton & Wroxham",
     "latitude": 52.715595961,
     "longitude": 1.4080190978
   },
   "HYB": {
-    "station_name": "Honeybourne Rail Station",
+    "station_name": "Honeybourne",
     "latitude": 52.1016109574,
     "longitude": -1.8337328413
   },
   "HYC": {
-    "station_name": "Hyde Central Rail Station",
+    "station_name": "Hyde Central",
     "latitude": 53.451897881,
     "longitude": -2.0852494833
   },
   "HYD": {
-    "station_name": "Heyford Rail Station",
+    "station_name": "Heyford",
     "latitude": 51.9191971629,
     "longitude": -1.2992524985
   },
   "HYH": {
-    "station_name": "Hythe (Essex) Rail Station",
+    "station_name": "Hythe (Essex)",
     "latitude": 51.885649004,
     "longitude": 0.9275572674
   },
   "HYK": {
-    "station_name": "Hoylake Rail Station",
+    "station_name": "Hoylake",
     "latitude": 53.3902262538,
     "longitude": -3.1788295823
   },
   "HYL": {
-    "station_name": "Hayle Rail Station",
+    "station_name": "Hayle",
     "latitude": 50.1855516133,
     "longitude": -5.4198876444
   },
   "HYM": {
-    "station_name": "Haymarket Rail Station",
+    "station_name": "Haymarket",
     "latitude": 55.9458020856,
     "longitude": -3.2184499798
   },
   "HYN": {
-    "station_name": "Hyndland Rail Station",
+    "station_name": "Hyndland",
     "latitude": 55.8797471979,
     "longitude": -4.314653649
   },
   "HYR": {
-    "station_name": "Haydons Road Rail Station",
+    "station_name": "Haydons Road",
     "latitude": 51.4254457568,
     "longitude": -0.188790104
   },
   "HYS": {
-    "station_name": "Hayes (Kent) Rail Station",
+    "station_name": "Hayes (Kent)",
     "latitude": 51.376332397,
     "longitude": 0.0105837729
   },
   "HYT": {
-    "station_name": "Hyde North Rail Station",
+    "station_name": "Hyde North",
     "latitude": 53.4648142912,
     "longitude": -2.0854568359
   },
   "HYW": {
-    "station_name": "Hinchley Wood Rail Station",
+    "station_name": "Hinchley Wood",
     "latitude": 51.3749950976,
     "longitude": -0.3405015776
   },
   "IBM": {
-    "station_name": "IBM (Greenock) Rail Station",
+    "station_name": "IBM (Greenock)",
     "latitude": 55.9294397123,
     "longitude": -4.8272199389
   },
   "IFD": {
-    "station_name": "Ilford Rail Station",
+    "station_name": "Ilford",
     "latitude": 51.5591169252,
     "longitude": 0.0697060332
   },
   "IFI": {
-    "station_name": "Ifield Rail Station",
+    "station_name": "Ifield",
     "latitude": 51.115616552,
     "longitude": -0.214744158
   },
   "IGD": {
-    "station_name": "Invergordon Rail Station",
+    "station_name": "Invergordon",
     "latitude": 57.6890013885,
     "longitude": -4.1748401883
   },
   "ILK": {
-    "station_name": "Ilkley Rail Station",
+    "station_name": "Ilkley",
     "latitude": 53.9247771648,
     "longitude": -1.822030732
   },
   "ILN": {
-    "station_name": "Ilkeston Rail Station",
+    "station_name": "Ilkeston",
     "latitude": 52.9796097784,
     "longitude": -1.2949283917
   },
   "IMW": {
-    "station_name": "Imperial Wharf Rail Station",
+    "station_name": "Imperial Wharf",
     "latitude": 51.4749481734,
     "longitude": -0.1827985374
   },
   "INC": {
-    "station_name": "Ince (Manchester) Rail Station",
+    "station_name": "Ince (Manchester)",
     "latitude": 53.5389257232,
     "longitude": -2.6115187679
   },
   "INE": {
-    "station_name": "Ince & Elton Rail Station",
+    "station_name": "Ince & Elton",
     "latitude": 53.2766213459,
     "longitude": -2.8165221852
   },
   "ING": {
-    "station_name": "Invergowrie Rail Station",
+    "station_name": "Invergowrie",
     "latitude": 56.4564629346,
     "longitude": -3.0574006479
   },
   "INH": {
-    "station_name": "Invershin Rail Station",
+    "station_name": "Invershin",
     "latitude": 57.9248506817,
     "longitude": -4.3994794892
   },
   "INK": {
-    "station_name": "Inverkeithing Rail Station",
+    "station_name": "Inverkeithing",
     "latitude": 56.0346707647,
     "longitude": -3.3961851331
   },
   "INP": {
-    "station_name": "Inverkip Rail Station",
+    "station_name": "Inverkip",
     "latitude": 55.906097486,
     "longitude": -4.8725658517
   },
   "INR": {
-    "station_name": "Inverurie Rail Station",
+    "station_name": "Inverurie",
     "latitude": 57.2862510473,
     "longitude": -2.3735646839
   },
   "INS": {
-    "station_name": "Insch Rail Station",
+    "station_name": "Insch",
     "latitude": 57.3374826347,
     "longitude": -2.6171148112
   },
   "INT": {
-    "station_name": "Ingatestone Rail Station",
+    "station_name": "Ingatestone",
     "latitude": 51.6670448119,
     "longitude": 0.3842732713
   },
   "INV": {
-    "station_name": "Inverness Rail Station",
+    "station_name": "Inverness",
     "latitude": 57.4798523576,
     "longitude": -4.2233591954
   },
   "IPS": {
-    "station_name": "Ipswich Rail Station",
+    "station_name": "Ipswich",
     "latitude": 52.050605185,
     "longitude": 1.1444561195
   },
   "IRL": {
-    "station_name": "Irlam Rail Station",
+    "station_name": "Irlam",
     "latitude": 53.4343243953,
     "longitude": -2.4332290912
   },
   "IRV": {
-    "station_name": "Irvine Rail Station",
+    "station_name": "Irvine",
     "latitude": 55.610870787,
     "longitude": -4.6751248885
   },
   "ISL": {
-    "station_name": "Isleworth Rail Station",
+    "station_name": "Isleworth",
     "latitude": 51.4747609931,
     "longitude": -0.3368852384
   },
   "ISP": {
-    "station_name": "Islip Rail Station",
+    "station_name": "Islip",
     "latitude": 51.8257581652,
     "longitude": -1.2381632634
   },
+  "IVA": {
+    "station_name": "Inverness Airport",
+    "latitude": 57.5335,
+    "longitude": -4.0552
+  },
   "IVR": {
-    "station_name": "Iver Rail Station",
+    "station_name": "Iver",
     "latitude": 51.5085027345,
     "longitude": -0.5067065231
   },
   "IVY": {
-    "station_name": "Ivybridge Rail Station",
+    "station_name": "Ivybridge",
     "latitude": 50.3933952288,
     "longitude": -3.9042285416
   },
   "JCH": {
-    "station_name": "James Cook University Hospital Rail Station",
+    "station_name": "James Cook University Hospital",
     "latitude": 54.552041983,
     "longitude": -1.2085837079
   },
   "JEQ": {
-    "station_name": "Jewellery Quarter Rail Station",
+    "station_name": "Jewellery Quarter",
     "latitude": 52.489447723,
     "longitude": -1.9132076451
   },
   "JHN": {
-    "station_name": "Johnstone Rail Station",
+    "station_name": "Johnstone",
     "latitude": 55.8347024844,
     "longitude": -4.5036207425
   },
   "JOH": {
-    "station_name": "Johnston (Pembrokeshire) Rail Station",
+    "station_name": "Johnston (Pembrokeshire)",
     "latitude": 51.7567579295,
     "longitude": -4.9963630908
   },
   "JOR": {
-    "station_name": "Jordanhill Rail Station",
+    "station_name": "Jordanhill",
     "latitude": 55.882699515,
     "longitude": -4.3249029293
   },
   "KBC": {
-    "station_name": "Kinbrace Rail Station",
+    "station_name": "Kinbrace",
     "latitude": 58.2582968272,
     "longitude": -3.9412133227
   },
   "KBF": {
-    "station_name": "Kirkby-in-Furness Rail Station",
+    "station_name": "Kirkby-in-Furness",
     "latitude": 54.2327161445,
     "longitude": -3.1873760397
   },
   "KBK": {
-    "station_name": "Kents Bank Rail Station",
+    "station_name": "Kents Bank",
     "latitude": 54.172910528,
     "longitude": -2.9252290041
   },
   "KBN": {
-    "station_name": "Kilburn High Road Rail Station",
+    "station_name": "Kilburn High Road",
     "latitude": 51.5372777601,
     "longitude": -0.1922126859
   },
   "KBW": {
-    "station_name": "Knebworth Rail Station",
+    "station_name": "Knebworth",
     "latitude": 51.8668603588,
     "longitude": -0.1872649131
   },
   "KBX": {
-    "station_name": "Kirby Cross Rail Station",
+    "station_name": "Kirby Cross",
     "latitude": 51.841408258,
     "longitude": 1.2150236403
   },
   "KCK": {
-    "station_name": "Knockholt Rail Station",
+    "station_name": "Knockholt",
     "latitude": 51.3457884371,
     "longitude": 0.1308739721
   },
   "KDB": {
-    "station_name": "Kidbrooke Rail Station",
+    "station_name": "Kidbrooke",
     "latitude": 51.4621199896,
     "longitude": 0.0275232797
   },
   "KDG": {
-    "station_name": "Kidsgrove Rail Station",
+    "station_name": "Kidsgrove",
     "latitude": 53.0865804703,
     "longitude": -2.2448159035
   },
   "KDY": {
-    "station_name": "Kirkcaldy Rail Station",
+    "station_name": "Kirkcaldy",
     "latitude": 56.1120505901,
     "longitude": -3.1670300049
   },
   "KEH": {
-    "station_name": "Keith Rail Station",
+    "station_name": "Keith",
     "latitude": 57.5508815659,
     "longitude": -2.9540692665
   },
   "KEI": {
-    "station_name": "Keighley Rail Station",
+    "station_name": "Keighley",
     "latitude": 53.8679755061,
     "longitude": -1.9016526329
   },
   "KEL": {
-    "station_name": "Kelvedon Rail Station",
+    "station_name": "Kelvedon",
     "latitude": 51.8407101631,
     "longitude": 0.7024132856
   },
   "KEM": {
-    "station_name": "Kemble Rail Station",
+    "station_name": "Kemble",
     "latitude": 51.6769974883,
     "longitude": -2.0228096226
   },
   "KEN": {
-    "station_name": "Kendal Rail Station",
+    "station_name": "Kendal",
     "latitude": 54.3321036266,
     "longitude": -2.7396488466
   },
   "KET": {
-    "station_name": "Kettering Rail Station",
+    "station_name": "Kettering",
     "latitude": 52.3935680461,
     "longitude": -0.7315471328
   },
   "KEY": {
-    "station_name": "Keyham Rail Station",
+    "station_name": "Keyham",
     "latitude": 50.3898643425,
     "longitude": -4.1796285768
   },
   "KGE": {
-    "station_name": "Kingsknowe Rail Station",
+    "station_name": "Kingsknowe",
     "latitude": 55.9188071296,
     "longitude": -3.2649651648
   },
   "KGH": {
-    "station_name": "Kinghorn Rail Station",
+    "station_name": "Kinghorn",
     "latitude": 56.0693308155,
     "longitude": -3.1741555055
   },
   "KGL": {
-    "station_name": "Kings Langley Rail Station",
+    "station_name": "Kings Langley",
     "latitude": 51.7063602029,
     "longitude": -0.4384002341
   },
   "KGM": {
-    "station_name": "Kingham Rail Station",
+    "station_name": "Kingham",
     "latitude": 51.9022564168,
     "longitude": -1.6287732881
   },
   "KGN": {
-    "station_name": "Kings Nympton Rail Station",
+    "station_name": "Kings Nympton",
     "latitude": 50.936065096,
     "longitude": -3.9054316221
   },
   "KGP": {
-    "station_name": "Kings Park Rail Station",
+    "station_name": "Kings Park",
     "latitude": 55.8195373532,
     "longitude": -4.2465028963
   },
   "KGS": {
-    "station_name": "Kings Sutton Rail Station",
+    "station_name": "Kings Sutton",
     "latitude": 52.021359878,
     "longitude": -1.2809139108
   },
   "KGT": {
-    "station_name": "Kilgetty Rail Station",
+    "station_name": "Kilgetty",
     "latitude": 51.7321146696,
     "longitude": -4.7151861813
   },
   "KGX": {
-    "station_name": "London Kings Cross Rail Station",
+    "station_name": "London Kings Cross",
     "latitude": 51.5308836375,
     "longitude": -0.1229002946
   },
   "KID": {
-    "station_name": "Kidderminster Rail Station",
+    "station_name": "Kidderminster",
     "latitude": 52.3844946608,
     "longitude": -2.2384665613
   },
   "KIL": {
-    "station_name": "Kildonan Rail Station",
+    "station_name": "Kildonan",
     "latitude": 58.1707935283,
     "longitude": -3.8691107621
   },
   "KIN": {
-    "station_name": "Kingussie Rail Station",
+    "station_name": "Kingussie",
     "latitude": 57.0777663698,
     "longitude": -4.0521889967
   },
   "KIR": {
-    "station_name": "Kirkby Rail Station",
+    "station_name": "Kirkby",
     "latitude": 53.4862048537,
     "longitude": -2.9028281809
   },
   "KIT": {
-    "station_name": "Kintbury Rail Station",
+    "station_name": "Kintbury",
     "latitude": 51.4025186724,
     "longitude": -1.4459730106
   },
   "KIV": {
-    "station_name": "Kiveton Bridge Rail Station",
+    "station_name": "Kiveton Bridge",
     "latitude": 53.3409764694,
     "longitude": -1.2671800273
   },
   "KKB": {
-    "station_name": "Kirkby in Ashfield Rail Station",
+    "station_name": "Kirkby in Ashfield",
     "latitude": 53.1001156743,
     "longitude": -1.2530543087
   },
   "KKD": {
-    "station_name": "Kirkdale Rail Station",
+    "station_name": "Kirkdale",
     "latitude": 53.4409136231,
     "longitude": -2.9811163636
   },
   "KKH": {
-    "station_name": "Kirkhill Rail Station",
+    "station_name": "Kirkhill",
     "latitude": 55.8139079243,
     "longitude": -4.1670911014
   },
   "KKM": {
-    "station_name": "Kirkham & Wesham Rail Station",
+    "station_name": "Kirkham & Wesham",
     "latitude": 53.7869285701,
     "longitude": -2.8829376626
   },
   "KKN": {
-    "station_name": "Kirknewton Rail Station",
+    "station_name": "Kirknewton",
     "latitude": 55.8886849182,
     "longitude": -3.4325077075
   },
   "KKS": {
-    "station_name": "Kirk Sandall Rail Station",
+    "station_name": "Kirk Sandall",
     "latitude": 53.5638967616,
     "longitude": -1.074065509
   },
   "KLD": {
-    "station_name": "Kildale Rail Station",
+    "station_name": "Kildale",
     "latitude": 54.4777686824,
     "longitude": -1.0681580089
   },
   "KLF": {
-    "station_name": "Kirkstall Forge Rail Station",
+    "station_name": "Kirkstall Forge",
     "latitude": 53.8237339338,
     "longitude": -1.6224823291
   },
   "KLM": {
-    "station_name": "Kilmaurs Rail Station",
+    "station_name": "Kilmaurs",
     "latitude": 55.6372048041,
     "longitude": -4.530470324
   },
   "KLN": {
-    "station_name": "Kings Lynn Rail Station",
+    "station_name": "Kings Lynn",
     "latitude": 52.7539444878,
     "longitude": 0.4034623052
   },
   "KLY": {
-    "station_name": "Kenley Rail Station",
+    "station_name": "Kenley",
     "latitude": 51.3247744025,
     "longitude": -0.1008992757
   },
   "KMH": {
-    "station_name": "Kempston Hardwick Rail Station",
+    "station_name": "Kempston Hardwick",
     "latitude": 52.0922280746,
     "longitude": -0.503891956
   },
   "KMK": {
-    "station_name": "Kilmarnock Rail Station",
+    "station_name": "Kilmarnock",
     "latitude": 55.6121152355,
     "longitude": -4.4986646202
   },
   "KML": {
-    "station_name": "Kemsley Rail Station",
+    "station_name": "Kemsley",
     "latitude": 51.3624400702,
     "longitude": 0.7353874775
   },
   "KMP": {
-    "station_name": "Kempton Park Rail Station",
+    "station_name": "Kempton Park",
     "latitude": 51.4209818235,
     "longitude": -0.4097301104
   },
   "KMS": {
-    "station_name": "Kemsing Rail Station",
+    "station_name": "Kemsing",
     "latitude": 51.2971839907,
     "longitude": 0.2474553811
   },
   "KNA": {
-    "station_name": "Knaresborough Rail Station",
+    "station_name": "Knaresborough",
     "latitude": 54.0090375731,
     "longitude": -1.4704220018
   },
   "KND": {
-    "station_name": "Kingswood Rail Station",
+    "station_name": "Kingswood",
     "latitude": 51.2947217871,
     "longitude": -0.2112222297
   },
   "KNE": {
-    "station_name": "Kennett Rail Station",
+    "station_name": "Kennett",
     "latitude": 52.2772786496,
     "longitude": 0.490492211
   },
   "KNF": {
-    "station_name": "Knutsford Rail Station",
+    "station_name": "Knutsford",
     "latitude": 53.3018050357,
     "longitude": -2.3717892715
   },
   "KNG": {
-    "station_name": "Kingston Rail Station",
+    "station_name": "Kingston",
     "latitude": 51.412749207,
     "longitude": -0.3011440528
   },
   "KNI": {
-    "station_name": "Knighton Rail Station",
+    "station_name": "Knighton",
     "latitude": 52.3450836187,
     "longitude": -3.0421947541
   },
   "KNL": {
-    "station_name": "Kensal Green Rail Station",
+    "station_name": "Kensal Green",
     "latitude": 51.5305403206,
     "longitude": -0.225063468
   },
   "KNN": {
-    "station_name": "Kings Norton Rail Station",
+    "station_name": "Kings Norton",
     "latitude": 52.4143035181,
     "longitude": -1.9323192635
   },
   "KNO": {
-    "station_name": "Knottingley Rail Station",
+    "station_name": "Knottingley",
     "latitude": 53.7065538515,
     "longitude": -1.2591815208
   },
   "KNR": {
-    "station_name": "Kensal Rise Rail Station",
+    "station_name": "Kensal Rise",
     "latitude": 51.5345542153,
     "longitude": -0.2199327512
   },
   "KNS": {
-    "station_name": "Kennishead Rail Station",
+    "station_name": "Kennishead",
     "latitude": 55.813309436,
     "longitude": -4.3252321959
   },
   "KNT": {
-    "station_name": "Kenton Rail Station",
+    "station_name": "Kenton",
     "latitude": 51.581801686,
     "longitude": -0.3169583454
   },
   "KNU": {
-    "station_name": "Knucklas Rail Station",
+    "station_name": "Knucklas",
     "latitude": 52.3598728116,
     "longitude": -3.0968778892
   },
   "KNW": {
-    "station_name": "Kenilworth Rail Station",
+    "station_name": "Kenilworth",
     "latitude": 52.3427193518,
     "longitude": -1.5727265434
   },
   "KPA": {
-    "station_name": "Kensington (Olympia) Rail Station",
+    "station_name": "Kensington (Olympia)",
     "latitude": 51.4978982211,
     "longitude": -0.2103405047
   },
   "KPT": {
-    "station_name": "Kilpatrick Rail Station",
+    "station_name": "Kilpatrick",
     "latitude": 55.9246935335,
     "longitude": -4.4533967721
   },
   "KRK": {
-    "station_name": "Kirkconnel Rail Station",
+    "station_name": "Kirkconnel",
     "latitude": 55.3883045795,
     "longitude": -3.9984909836
   },
   "KSL": {
-    "station_name": "Kearsley Rail Station",
+    "station_name": "Kearsley",
     "latitude": 53.5441534939,
     "longitude": -2.3751177475
   },
   "KSN": {
-    "station_name": "Kearsney Rail Station",
+    "station_name": "Kearsney",
     "latitude": 51.1493801653,
     "longitude": 1.2720927524
   },
   "KSW": {
-    "station_name": "Kirkby Stephen Rail Station",
+    "station_name": "Kirkby Stephen",
     "latitude": 54.4548647986,
     "longitude": -2.3686012903
   },
   "KTH": {
-    "station_name": "Kent House Rail Station",
+    "station_name": "Kent House",
     "latitude": 51.4122125796,
     "longitude": -0.0452213855
   },
   "KTL": {
-    "station_name": "Kirton Lindsey Rail Station",
+    "station_name": "Kirton Lindsey",
     "latitude": 53.4848601103,
     "longitude": -0.5939161226
   },
   "KTN": {
-    "station_name": "Kentish Town Rail Station",
+    "station_name": "Kentish Town",
     "latitude": 51.550495644,
     "longitude": -0.1403392037
   },
+  "KTR":{
+    "station_name":"Kintore",
+    "latitude":57.243611,
+    "longitude": -2.350278
+  },
   "KTW": {
-    "station_name": "Kentish Town West Rail Station",
+    "station_name": "Kentish Town West",
     "latitude": 51.546548457,
     "longitude": -0.1466298744
   },
   "KVD": {
-    "station_name": "Kelvindale Rail Station",
+    "station_name": "Kelvindale",
     "latitude": 55.8935487999,
     "longitude": -4.3095577512
   },
   "KVP": {
-    "station_name": "Kiveton Park Rail Station",
+    "station_name": "Kiveton Park",
     "latitude": 53.3367337933,
     "longitude": -1.2398447759
   },
   "KWB": {
-    "station_name": "Kew Bridge Rail Station",
+    "station_name": "Kew Bridge",
     "latitude": 51.489511729,
     "longitude": -0.287085417
   },
   "KWD": {
-    "station_name": "Kirkwood Rail Station",
+    "station_name": "Kirkwood",
     "latitude": 55.8541826133,
     "longitude": -4.0483868931
   },
   "KWG": {
-    "station_name": "Kew Gardens Rail Station",
+    "station_name": "Kew Gardens",
     "latitude": 51.4770717225,
     "longitude": -0.2850311799
   },
   "KWL": {
-    "station_name": "Kidwelly Rail Station",
+    "station_name": "Kidwelly",
     "latitude": 51.7343478013,
     "longitude": -4.3170097512
   },
   "KWN": {
-    "station_name": "Kilwinning Rail Station",
+    "station_name": "Kilwinning",
     "latitude": 55.6559470119,
     "longitude": -4.7099979638
   },
   "KYL": {
-    "station_name": "Kyle of Lochalsh Rail Station",
+    "station_name": "Kyle of Lochalsh",
     "latitude": 57.2797467149,
     "longitude": -5.7138003131
   },
   "KYN": {
-    "station_name": "Keynsham Rail Station",
+    "station_name": "Keynsham",
     "latitude": 51.4179728415,
     "longitude": -2.495628895
   },
   "LAC": {
-    "station_name": "Lancing Rail Station",
+    "station_name": "Lancing",
     "latitude": 50.8270743359,
     "longitude": -0.3230828778
   },
   "LAD": {
-    "station_name": "Ladywell Rail Station",
+    "station_name": "Ladywell",
     "latitude": 51.4562424895,
     "longitude": -0.0190151041
   },
   "LAG": {
-    "station_name": "Langwith - Whaley Thorns Rail Station",
+    "station_name": "Langwith - Whaley Thorns",
     "latitude": 53.2318581892,
     "longitude": -1.2093421054
   },
   "LAI": {
-    "station_name": "Laindon Rail Station",
+    "station_name": "Laindon",
     "latitude": 51.5675245473,
     "longitude": 0.4243193409
   },
   "LAK": {
-    "station_name": "Lakenheath Rail Station",
+    "station_name": "Lakenheath",
     "latitude": 52.4474170039,
     "longitude": 0.535221579
   },
   "LAM": {
-    "station_name": "Lamphey Rail Station",
+    "station_name": "Lamphey",
     "latitude": 51.6671952632,
     "longitude": -4.8732909776
   },
   "LAN": {
-    "station_name": "Lancaster Rail Station",
+    "station_name": "Lancaster",
     "latitude": 54.0487386625,
     "longitude": -2.8074539872
   },
   "LAP": {
-    "station_name": "Lapford Rail Station",
+    "station_name": "Lapford",
     "latitude": 50.8569928871,
     "longitude": -3.8106600905
   },
   "LAR": {
-    "station_name": "Largs Rail Station",
+    "station_name": "Largs",
     "latitude": 55.7927371132,
     "longitude": -4.8671774606
   },
   "LAS": {
-    "station_name": "Llansamlet Rail Station",
+    "station_name": "Llansamlet",
     "latitude": 51.661506083,
     "longitude": -3.8847019198
   },
   "LAU": {
-    "station_name": "Laurencekirk Rail Station",
+    "station_name": "Laurencekirk",
     "latitude": 56.8363340087,
     "longitude": -2.4659318685
   },
   "LAW": {
-    "station_name": "Landywood Rail Station",
+    "station_name": "Landywood",
     "latitude": 52.656554762,
     "longitude": -2.0207214262
   },
   "LAY": {
-    "station_name": "Layton (Lancs) Rail Station",
+    "station_name": "Layton (Lancs)",
     "latitude": 53.8352807966,
     "longitude": -3.0299856202
   },
   "LBG": {
-    "station_name": "London Bridge Rail Station",
+    "station_name": "London Bridge",
     "latitude": 51.5050187718,
     "longitude": -0.0860663187
   },
   "LBK": {
-    "station_name": "Long Buckby Rail Station",
+    "station_name": "Long Buckby",
     "latitude": 52.2947305797,
     "longitude": -1.0864517232
   },
   "LBO": {
-    "station_name": "Loughborough (Leics) Rail Station",
+    "station_name": "Loughborough (Leics)",
     "latitude": 52.7789730706,
     "longitude": -1.1959223029
   },
   "LBR": {
-    "station_name": "Llanbedr Rail Station",
+    "station_name": "Llanbedr",
     "latitude": 52.8208652563,
     "longitude": -4.1102042575
   },
   "LBT": {
-    "station_name": "Larbert Rail Station",
+    "station_name": "Larbert",
     "latitude": 56.0226975731,
     "longitude": -3.8305736309
   },
   "LBZ": {
-    "station_name": "Leighton Buzzard Rail Station",
+    "station_name": "Leighton Buzzard",
     "latitude": 51.9163138347,
     "longitude": -0.6769823167
   },
   "LCC": {
-    "station_name": "Lochluichart Rail Station",
+    "station_name": "Lochluichart",
     "latitude": 57.621737692,
     "longitude": -4.8090441141
   },
   "LCG": {
-    "station_name": "Lochgelly Rail Station",
+    "station_name": "Lochgelly",
     "latitude": 56.1353217097,
     "longitude": -3.312938865
   },
   "LCK": {
-    "station_name": "Lockwood Rail Station",
+    "station_name": "Lockwood",
     "latitude": 53.634746673,
     "longitude": -1.8007918923
   },
   "LCL": {
-    "station_name": "Lochailort Rail Station",
+    "station_name": "Lochailort",
     "latitude": 56.8809423369,
     "longitude": -5.6633772414
   },
   "LCN": {
-    "station_name": "Lincoln Central Rail Station",
+    "station_name": "Lincoln Central",
     "latitude": 53.2261072888,
     "longitude": -0.5399222885
   },
   "LCS": {
-    "station_name": "Locheilside Rail Station",
+    "station_name": "Locheilside",
     "latitude": 56.8553882734,
     "longitude": -5.2900225827
   },
   "LDN": {
-    "station_name": "Llandanwg Rail Station",
+    "station_name": "Llandanwg",
     "latitude": 52.8361759873,
     "longitude": -4.1238635913
   },
   "LDS": {
-    "station_name": "Leeds Rail Station",
+    "station_name": "Leeds",
     "latitude": 53.7956409037,
     "longitude": -1.5480300934
   },
   "LDY": {
-    "station_name": "Ladybank Rail Station",
+    "station_name": "Ladybank",
     "latitude": 56.2737723207,
     "longitude": -3.1222761516
   },
   "LEA": {
-    "station_name": "Leagrave Rail Station",
+    "station_name": "Leagrave",
     "latitude": 51.9051657736,
     "longitude": -0.4584767531
   },
   "LEB": {
-    "station_name": "Lea Bridge Rail Station",
+    "station_name": "Lea Bridge",
     "latitude": 51.5665477908,
     "longitude": -0.0366456064
   },
   "LED": {
-    "station_name": "Ledbury Rail Station",
+    "station_name": "Ledbury",
     "latitude": 52.0452583249,
     "longitude": -2.4258582991
   },
   "LEE": {
-    "station_name": "Lee Rail Station",
+    "station_name": "Lee",
     "latitude": 51.4497532361,
     "longitude": 0.0135186891
   },
   "LEG": {
-    "station_name": "Lea Green Rail Station",
+    "station_name": "Lea Green",
     "latitude": 53.4268240445,
     "longitude": -2.7249767465
   },
   "LEH": {
-    "station_name": "Lea Hall Rail Station",
+    "station_name": "Lea Hall",
     "latitude": 52.480655776,
     "longitude": -1.7860055303
   },
   "LEI": {
-    "station_name": "Leicester Rail Station",
+    "station_name": "Leicester",
     "latitude": 52.6314416999,
     "longitude": -1.1252675699
   },
   "LEL": {
-    "station_name": "Lelant Rail Station",
+    "station_name": "Lelant",
     "latitude": 50.1841132154,
     "longitude": -5.4365983681
   },
   "LEM": {
-    "station_name": "Leyton Midland Road Rail Station",
+    "station_name": "Leyton Midland Road",
     "latitude": 51.5697256477,
     "longitude": -0.0080229844
   },
   "LEN": {
-    "station_name": "Lenham Rail Station",
+    "station_name": "Lenham",
     "latitude": 51.2344839559,
     "longitude": 0.7077894244
   },
   "LEO": {
-    "station_name": "Leominster Rail Station",
+    "station_name": "Leominster",
     "latitude": 52.2256915912,
     "longitude": -2.730340766
   },
   "LER": {
-    "station_name": "Leytonstone High Road Rail Station",
+    "station_name": "Leytonstone High Road",
     "latitude": 51.5635545296,
     "longitude": 0.0084437379
   },
   "LES": {
-    "station_name": "Leigh-on-Sea Rail Station",
+    "station_name": "Leigh-on-Sea",
     "latitude": 51.5412752344,
     "longitude": 0.6404394965
   },
   "LET": {
-    "station_name": "Letchworth Rail Station",
+    "station_name": "Letchworth",
     "latitude": 51.9799709665,
     "longitude": -0.2292371062
   },
   "LEU": {
-    "station_name": "Leuchars Rail Station",
+    "station_name": "Leuchars",
     "latitude": 56.3750925172,
     "longitude": -2.8937163252
   },
   "LEW": {
-    "station_name": "Lewisham Rail Station",
+    "station_name": "Lewisham",
     "latitude": 51.4656900464,
     "longitude": -0.0139988836
   },
   "LEY": {
-    "station_name": "Leyland Rail Station",
+    "station_name": "Leyland",
     "latitude": 53.6988690686,
     "longitude": -2.6871416367
   },
   "LFD": {
-    "station_name": "Lingfield Rail Station",
+    "station_name": "Lingfield",
     "latitude": 51.1764479512,
     "longitude": -0.0071377353
   },
   "LGB": {
-    "station_name": "Langbank Rail Station",
+    "station_name": "Langbank",
     "latitude": 55.9245116809,
     "longitude": -4.5852569156
   },
   "LGD": {
-    "station_name": "Lingwood Rail Station",
+    "station_name": "Lingwood",
     "latitude": 52.6221259547,
     "longitude": 1.4899676829
   },
   "LGE": {
-    "station_name": "Long Eaton Rail Station",
+    "station_name": "Long Eaton",
     "latitude": 52.8850051381,
     "longitude": -1.287515035
   },
   "LGF": {
-    "station_name": "Longfield Rail Station",
+    "station_name": "Longfield",
     "latitude": 51.3961528278,
     "longitude": 0.3003927726
   },
   "LGG": {
-    "station_name": "Langley Green Rail Station",
+    "station_name": "Langley Green",
     "latitude": 52.4938847738,
     "longitude": -2.0049580874
   },
   "LGJ": {
-    "station_name": "Loughborough Junction Rail Station",
+    "station_name": "Loughborough Junction",
     "latitude": 51.4662966456,
     "longitude": -0.1021564205
   },
   "LGK": {
-    "station_name": "Longbeck Rail Station",
+    "station_name": "Longbeck",
     "latitude": 54.5892295098,
     "longitude": -1.0304881067
   },
   "LGM": {
-    "station_name": "Langley Mill Rail Station",
+    "station_name": "Langley Mill",
     "latitude": 53.0180775906,
     "longitude": -1.3312416884
   },
   "LGN": {
-    "station_name": "Longton Rail Station",
+    "station_name": "Longton",
     "latitude": 52.9899681856,
     "longitude": -2.1370099565
   },
   "LGO": {
-    "station_name": "Llangynllo Rail Station",
+    "station_name": "Llangynllo",
     "latitude": 52.3496362697,
     "longitude": -3.1613704736
   },
   "LGS": {
-    "station_name": "Langside Rail Station",
+    "station_name": "Langside",
     "latitude": 55.8211269753,
     "longitude": -4.2773259977
   },
   "LGW": {
-    "station_name": "Langwathby Rail Station",
+    "station_name": "Langwathby",
     "latitude": 54.6943634202,
     "longitude": -2.6636891905
   },
   "LHA": {
-    "station_name": "Loch Awe Rail Station",
+    "station_name": "Loch Awe",
     "latitude": 56.4020023455,
     "longitude": -5.0419541347
   },
   "LHD": {
-    "station_name": "Leatherhead Rail Station",
+    "station_name": "Leatherhead",
     "latitude": 51.2988144436,
     "longitude": -0.3332088593
   },
   "LHE": {
-    "station_name": "Loch Eil Outward Bound Rail Station",
+    "station_name": "Loch Eil Outward Bound",
     "latitude": 56.8552494299,
     "longitude": -5.1915632271
   },
   "LHM": {
-    "station_name": "Lealholm Rail Station",
+    "station_name": "Lealholm",
     "latitude": 54.4606042623,
     "longitude": -0.8257310498
   },
   "LHO": {
-    "station_name": "Langho Rail Station",
+    "station_name": "Langho",
     "latitude": 53.8048444025,
     "longitude": -2.4486582114
   },
   "LHR": {
-    "station_name": "Heathrow Terminals 1-3 Rail Station",
+    "station_name": "Heathrow Terminals 1-3",
     "latitude": 51.4714046459,
     "longitude": -0.4543126778
   },
   "LHS": {
-    "station_name": "Limehouse Rail Station",
+    "station_name": "Limehouse",
     "latitude": 51.5125361684,
     "longitude": -0.0397760782
   },
   "LHW": {
-    "station_name": "Lochwinnoch Rail Station",
+    "station_name": "Lochwinnoch",
     "latitude": 55.7871497964,
     "longitude": -4.6160573245
   },
   "LIC": {
-    "station_name": "Lichfield City Rail Station",
+    "station_name": "Lichfield City",
     "latitude": 52.6801615881,
     "longitude": -1.8254127247
   },
   "LID": {
-    "station_name": "Lidlington Rail Station",
+    "station_name": "Lidlington",
     "latitude": 52.0415453254,
     "longitude": -0.5589061726
   },
   "LIF": {
-    "station_name": "Lichfield Trent Valley High Level Rail Station",
+    "station_name": "Lichfield Trent Valley High Level",
     "latitude": 52.6869091229,
     "longitude": -1.8002367619
   },
   "LIH": {
-    "station_name": "Leigh (Kent) Rail Station",
+    "station_name": "Leigh (Kent)",
     "latitude": 51.1938967547,
     "longitude": 0.2105218236
   },
   "LIN": {
-    "station_name": "Linlithgow Rail Station",
+    "station_name": "Linlithgow",
     "latitude": 55.9764464658,
     "longitude": -3.5958472904
   },
   "LIP": {
-    "station_name": "Liphook Rail Station",
+    "station_name": "Liphook",
     "latitude": 51.0713092222,
     "longitude": -0.8002098038
   },
   "LIS": {
-    "station_name": "Liss Rail Station",
+    "station_name": "Liss",
     "latitude": 51.0435640733,
     "longitude": -0.8928497986
   },
   "LIT": {
-    "station_name": "Littlehampton Rail Station",
+    "station_name": "Littlehampton",
     "latitude": 50.8100978499,
     "longitude": -0.5459719624
   },
   "LIV": {
-    "station_name": "Liverpool Lime Street Rail Station",
+    "station_name": "Liverpool Lime Street",
     "latitude": 53.4073236407,
     "longitude": -2.977726082
   },
   "LKE": {
-    "station_name": "Lake (Isle of Wight) Rail Station",
+    "station_name": "Lake (Isle of Wight)",
     "latitude": 50.6464632785,
     "longitude": -1.1663386012
   },
   "LLA": {
-    "station_name": "Llanaber Rail Station",
+    "station_name": "Llanaber",
     "latitude": 52.7415174068,
     "longitude": -4.0771833809
   },
   "LLC": {
-    "station_name": "Llandecwyn Rail Station",
+    "station_name": "Llandecwyn",
     "latitude": 52.9206985859,
     "longitude": -4.0570419611
   },
   "LLD": {
-    "station_name": "Llandudno Rail Station",
+    "station_name": "Llandudno",
     "latitude": 53.320931375,
     "longitude": -3.8270045937
   },
   "LLE": {
-    "station_name": "Llanelli Rail Station",
+    "station_name": "Llanelli",
     "latitude": 51.6738710202,
     "longitude": -4.1613259947
   },
   "LLF": {
-    "station_name": "Llanfairfechan Rail Station",
+    "station_name": "Llanfairfechan",
     "latitude": 53.2573026611,
     "longitude": -3.9832073298
   },
   "LLG": {
-    "station_name": "Llangadog Rail Station",
+    "station_name": "Llangadog",
     "latitude": 51.9402195807,
     "longitude": -3.8931635456
   },
   "LLH": {
-    "station_name": "Llangennech Rail Station",
+    "station_name": "Llangennech",
     "latitude": 51.6911401855,
     "longitude": -4.0789505342
   },
   "LLI": {
-    "station_name": "Llandybie Rail Station",
+    "station_name": "Llandybie",
     "latitude": 51.8210413519,
     "longitude": -4.0036670781
   },
   "LLJ": {
-    "station_name": "Llandudno Junction Rail Station",
+    "station_name": "Llandudno Junction",
     "latitude": 53.283958434,
     "longitude": -3.8091060573
   },
   "LLL": {
-    "station_name": "Llandeilo Rail Station",
+    "station_name": "Llandeilo",
     "latitude": 51.8853508121,
     "longitude": -3.9869089385
   },
   "LLM": {
-    "station_name": "Llangammarch Rail Station",
+    "station_name": "Llangammarch",
     "latitude": 52.1143061939,
     "longitude": -3.5548258245
   },
   "LLN": {
-    "station_name": "Llandaf Rail Station",
+    "station_name": "Llandaf",
     "latitude": 51.5084380797,
     "longitude": -3.2286220121
   },
   "LLO": {
-    "station_name": "Llandrindod Rail Station",
+    "station_name": "Llandrindod",
     "latitude": 52.2423682996,
     "longitude": -3.3791453356
   },
   "LLR": {
-    "station_name": "Llanharan Rail Station",
+    "station_name": "Llanharan",
     "latitude": 51.5375863272,
     "longitude": -3.4407911115
   },
   "LLS": {
-    "station_name": "Llanishen Rail Station",
+    "station_name": "Llanishen",
     "latitude": 51.532745927,
     "longitude": -3.1819878738
   },
   "LLT": {
-    "station_name": "Llanbister Road Rail Station",
+    "station_name": "Llanbister Road",
     "latitude": 52.3364359032,
     "longitude": -3.2134226095
   },
   "LLV": {
-    "station_name": "Llandovery Rail Station",
+    "station_name": "Llandovery",
     "latitude": 51.995319454,
     "longitude": -3.8028430574
   },
   "LLW": {
-    "station_name": "Llwyngwril Rail Station",
+    "station_name": "Llwyngwril",
     "latitude": 52.6667959978,
     "longitude": -4.0876869996
   },
   "LLY": {
-    "station_name": "Llwynypia Rail Station",
+    "station_name": "Llwynypia",
     "latitude": 51.6340038599,
     "longitude": -3.4535242203
   },
   "LMR": {
-    "station_name": "Low Moor Rail Station",
+    "station_name": "Low Moor",
     "latitude": 53.7499403782,
     "longitude": -1.7534074129
   },
   "LMS": {
-    "station_name": "Leamington Spa Rail Station",
+    "station_name": "Leamington Spa",
     "latitude": 52.284503537,
     "longitude": -1.5361991242
   },
   "LNB": {
-    "station_name": "Llanbradach Rail Station",
+    "station_name": "Llanbradach",
     "latitude": 51.6032561222,
     "longitude": -3.2330580594
   },
   "LND": {
-    "station_name": "Longniddry Rail Station",
+    "station_name": "Longniddry",
     "latitude": 55.9764783228,
     "longitude": -2.8883472596
   },
   "LNG": {
-    "station_name": "Longcross Rail Station",
+    "station_name": "Longcross",
     "latitude": 51.3851709311,
     "longitude": -0.5945509208
   },
   "LNK": {
-    "station_name": "Lanark Rail Station",
+    "station_name": "Lanark",
     "latitude": 55.673604759,
     "longitude": -3.7732799051
   },
   "LNR": {
-    "station_name": "Llanwrda Rail Station",
+    "station_name": "Llanwrda",
     "latitude": 51.9625935234,
     "longitude": -3.8716896629
   },
   "LNW": {
-    "station_name": "Llanwrtyd Rail Station",
+    "station_name": "Llanwrtyd",
     "latitude": 52.1047187961,
     "longitude": -3.632173997
   },
   "LNY": {
-    "station_name": "Langley (Berks) Rail Station",
+    "station_name": "Langley (Berks)",
     "latitude": 51.5080622586,
     "longitude": -0.5417374982
   },
   "LNZ": {
-    "station_name": "Lenzie Rail Station",
+    "station_name": "Lenzie",
     "latitude": 55.9213119495,
     "longitude": -4.1538778824
   },
   "LOB": {
-    "station_name": "Longbridge Rail Station",
+    "station_name": "Longbridge",
     "latitude": 52.3964311105,
     "longitude": -1.981283672
   },
   "LOC": {
-    "station_name": "Lockerbie Rail Station",
+    "station_name": "Lockerbie",
     "latitude": 55.1230561909,
     "longitude": -3.353531624
   },
   "LOF": {
-    "station_name": "London Fields Rail Station",
+    "station_name": "London Fields",
     "latitude": 51.5411524205,
     "longitude": -0.0577263865
   },
   "LOH": {
-    "station_name": "Lostock Hall Rail Station",
+    "station_name": "Lostock Hall",
     "latitude": 53.7242588593,
     "longitude": -2.6874800806
   },
   "LOO": {
-    "station_name": "Looe Rail Station",
+    "station_name": "Looe",
     "latitude": 50.3592096258,
     "longitude": -4.4561992266
   },
   "LOS": {
-    "station_name": "Lostwithiel Rail Station",
+    "station_name": "Lostwithiel",
     "latitude": 50.4071639994,
     "longitude": -4.6660056695
   },
   "LOT": {
-    "station_name": "Lostock Rail Station",
+    "station_name": "Lostock",
     "latitude": 53.572942054,
     "longitude": -2.4942651922
   },
   "LOW": {
-    "station_name": "Lowdham Rail Station",
+    "station_name": "Lowdham",
     "latitude": 53.0063029264,
     "longitude": -0.9984155088
   },
   "LPG": {
-    "station_name": "Llanfairpwll Rail Station",
+    "station_name": "Llanfairpwll",
     "latitude": 53.2209605021,
     "longitude": -4.2092216486
   },
   "LPR": {
-    "station_name": "Long Preston Rail Station",
+    "station_name": "Long Preston",
     "latitude": 54.0168488895,
     "longitude": -2.255595159
   },
   "LPT": {
-    "station_name": "Longport Rail Station",
+    "station_name": "Longport",
     "latitude": 53.0418973325,
     "longitude": -2.2164483623
   },
   "LPW": {
-    "station_name": "Lapworth Rail Station",
+    "station_name": "Lapworth",
     "latitude": 52.3422646161,
     "longitude": -1.7256819125
   },
   "LPY": {
-    "station_name": "Liverpool South Parkway Rail Station",
+    "station_name": "Liverpool South Parkway",
     "latitude": 53.3577585374,
     "longitude": -2.8891427297
   },
   "LRB": {
-    "station_name": "London Road (Brighton) Rail Station",
+    "station_name": "London Road (Brighton)",
     "latitude": 50.8366553421,
     "longitude": -0.1364746723
   },
   "LRD": {
-    "station_name": "London Road (Guildford) Rail Station",
+    "station_name": "London Road (Guildford)",
     "latitude": 51.2406441935,
     "longitude": -0.565047885
   },
   "LRG": {
-    "station_name": "Lairg Rail Station",
+    "station_name": "Lairg",
     "latitude": 58.0018108151,
     "longitude": -4.3998916637
   },
   "LRH": {
-    "station_name": "Larkhall Rail Station",
+    "station_name": "Larkhall",
     "latitude": 55.7385910664,
     "longitude": -3.9754997252
   },
   "LSK": {
-    "station_name": "Liskeard Rail Station",
+    "station_name": "Liskeard",
     "latitude": 50.4468508005,
     "longitude": -4.4696103937
   },
   "LSN": {
-    "station_name": "Livingston North Rail Station",
+    "station_name": "Livingston North",
     "latitude": 55.9013777549,
     "longitude": -3.5443460776
   },
   "LST": {
-    "station_name": "London Liverpool Street Rail Station",
+    "station_name": "London Liverpool Street",
     "latitude": 51.5179909029,
     "longitude": -0.0813998966
   },
   "LSW": {
-    "station_name": "Leasowe Rail Station",
+    "station_name": "Leasowe",
     "latitude": 53.4080616471,
     "longitude": -3.0995918732
   },
   "LSY": {
-    "station_name": "Lower Sydenham Rail Station",
+    "station_name": "Lower Sydenham",
     "latitude": 51.4248284049,
     "longitude": -0.0333195275
   },
   "LTG": {
-    "station_name": "Lostock Gralam Rail Station",
+    "station_name": "Lostock Gralam",
     "latitude": 53.2676790034,
     "longitude": -2.4652014465
   },
   "LTH": {
-    "station_name": "Llanhilleth Rail Station",
+    "station_name": "Llanhilleth",
     "latitude": 51.7003015567,
     "longitude": -3.1351956439
   },
   "LTK": {
-    "station_name": "Little Kimble Rail Station",
+    "station_name": "Little Kimble",
     "latitude": 51.7522355985,
     "longitude": -0.8084296111
   },
   "LTL": {
-    "station_name": "Littleborough Rail Station",
+    "station_name": "Littleborough",
     "latitude": 53.6430095698,
     "longitude": -2.0946505145
   },
   "LTM": {
-    "station_name": "Lytham Rail Station",
+    "station_name": "Lytham",
     "latitude": 53.7392940824,
     "longitude": -2.9640373329
   },
   "LTN": {
-    "station_name": "Luton Airport Parkway Rail Station",
+    "station_name": "Luton Airport Parkway",
     "latitude": 51.8724440314,
     "longitude": -0.3958564573
   },
   "LTP": {
-    "station_name": "Littleport Rail Station",
+    "station_name": "Littleport",
     "latitude": 52.4623961349,
     "longitude": 0.3165814324
   },
   "LTS": {
-    "station_name": "Lelant Saltings Rail Station",
+    "station_name": "Lelant Saltings",
     "latitude": 50.1787654627,
     "longitude": -5.4409776419
   },
   "LTT": {
-    "station_name": "Little Sutton Rail Station",
+    "station_name": "Little Sutton",
     "latitude": 53.2855291567,
     "longitude": -2.9432922123
   },
   "LTV": {
-    "station_name": "Lichfield Trent Valley Rail Station",
+    "station_name": "Lichfield Trent Valley",
     "latitude": 52.686909098,
     "longitude": -1.8002219684
   },
   "LUD": {
-    "station_name": "Ludlow Rail Station",
+    "station_name": "Ludlow",
     "latitude": 52.3712898598,
     "longitude": -2.7162155608
   },
   "LUT": {
-    "station_name": "Luton Rail Station",
+    "station_name": "Luton",
     "latitude": 51.882311449,
     "longitude": -0.4140156557
   },
   "LUX": {
-    "station_name": "Luxulyan Rail Station",
+    "station_name": "Luxulyan",
     "latitude": 50.3900215765,
     "longitude": -4.7474248225
   },
   "LVC": {
-    "station_name": "Liverpool Central Rail Station",
+    "station_name": "Liverpool Central",
     "latitude": 53.4046152032,
     "longitude": -2.9791681938
   },
   "LVG": {
-    "station_name": "Livingston South Rail Station",
+    "station_name": "Livingston South",
     "latitude": 55.8716872521,
     "longitude": -3.5015651841
   },
   "LVJ": {
-    "station_name": "Liverpool James Street Rail Station",
+    "station_name": "Liverpool James Street",
     "latitude": 53.4047793126,
     "longitude": -2.9919576763
   },
   "LVL": {
-    "station_name": "Liverpool Lime Street Low Level Rail Station",
+    "station_name": "Liverpool Lime Street Low Level",
     "latitude": 53.4082223458,
     "longitude": -2.9777466846
   },
   "LVM": {
-    "station_name": "Levenshulme Rail Station",
+    "station_name": "Levenshulme",
     "latitude": 53.44417758,
     "longitude": -2.1926682497
   },
   "LVN": {
-    "station_name": "Littlehaven Rail Station",
+    "station_name": "Littlehaven",
     "latitude": 51.0797455182,
     "longitude": -0.3079538284
   },
   "LVT": {
-    "station_name": "Lisvane & Thornhill Rail Station",
+    "station_name": "Lisvane & Thornhill",
     "latitude": 51.5445785441,
     "longitude": -3.1856117371
   },
   "LWH": {
-    "station_name": "Lawrence Hill Rail Station",
+    "station_name": "Lawrence Hill",
     "latitude": 51.4580082791,
     "longitude": -2.5644309056
   },
   "LWM": {
-    "station_name": "Llantwit Major Rail Station",
+    "station_name": "Llantwit Major",
     "latitude": 51.4097453635,
     "longitude": -3.4816304262
   },
   "LWR": {
-    "station_name": "Llanrwst Rail Station",
+    "station_name": "Llanrwst",
     "latitude": 53.1388647884,
     "longitude": -3.7944055622
   },
   "LWS": {
-    "station_name": "Lewes Rail Station",
+    "station_name": "Lewes",
     "latitude": 50.8706247466,
     "longitude": 0.0113583341
   },
   "LWT": {
-    "station_name": "Lowestoft Rail Station",
+    "station_name": "Lowestoft",
     "latitude": 52.4744616279,
     "longitude": 1.7497332362
   },
   "LYC": {
-    "station_name": "Lympstone Commando Rail Station",
+    "station_name": "Lympstone Commando",
     "latitude": 50.6622243505,
     "longitude": -3.4408532407
   },
   "LYD": {
-    "station_name": "Lydney Rail Station",
+    "station_name": "Lydney",
     "latitude": 51.7141382304,
     "longitude": -2.5308648278
   },
   "LYE": {
-    "station_name": "Lye (West Midlands) Rail Station",
+    "station_name": "Lye (West Midlands)",
     "latitude": 52.4599348586,
     "longitude": -2.1159231742
   },
   "LYM": {
-    "station_name": "Lympstone Village Rail Station",
+    "station_name": "Lympstone Village",
     "latitude": 50.6482800194,
     "longitude": -3.4310201406
   },
   "LYP": {
-    "station_name": "Lymington Pier Rail Station",
+    "station_name": "Lymington Pier",
     "latitude": 50.7582891862,
     "longitude": -1.5294384152
   },
   "LYT": {
-    "station_name": "Lymington Town Rail Station",
+    "station_name": "Lymington Town",
     "latitude": 50.7609009488,
     "longitude": -1.5371535429
   },
   "LZB": {
-    "station_name": "Lazonby & Kirkoswald Rail Station",
+    "station_name": "Lazonby & Kirkoswald",
     "latitude": 54.7504423613,
     "longitude": -2.7032136037
   },
   "MAC": {
-    "station_name": "Macclesfield Rail Station",
+    "station_name": "Macclesfield",
     "latitude": 53.2593576131,
     "longitude": -2.1219791655
   },
   "MAG": {
-    "station_name": "Maghull Rail Station",
+    "station_name": "Maghull",
     "latitude": 53.5064842654,
     "longitude": -2.930851711
   },
   "MAI": {
-    "station_name": "Maidenhead Rail Station",
+    "station_name": "Maidenhead",
     "latitude": 51.5186697833,
     "longitude": -0.7226423149
   },
   "MAL": {
-    "station_name": "Malden Manor Rail Station",
+    "station_name": "Malden Manor",
     "latitude": 51.3847271859,
     "longitude": -0.2612506017
   },
   "MAN": {
-    "station_name": "Manchester Piccadilly Rail Station",
+    "station_name": "Manchester Piccadilly",
     "latitude": 53.4773757207,
     "longitude": -2.2309078024
   },
   "MAO": {
-    "station_name": "Martins Heron Rail Station",
+    "station_name": "Martins Heron",
     "latitude": 51.4074107796,
     "longitude": -0.7243793482
   },
   "MAR": {
-    "station_name": "Margate Rail Station",
+    "station_name": "Margate",
     "latitude": 51.385433445,
     "longitude": 1.37202976
   },
   "MAS": {
-    "station_name": "Manors Rail Station",
+    "station_name": "Manors",
     "latitude": 54.9727702733,
     "longitude": -1.6047541665
   },
   "MAT": {
-    "station_name": "Matlock Rail Station",
+    "station_name": "Matlock",
     "latitude": 53.1384242777,
     "longitude": -1.5589084294
   },
   "MAU": {
-    "station_name": "Mauldeth Road Rail Station",
+    "station_name": "Mauldeth Road",
     "latitude": 53.4330757412,
     "longitude": -2.2092498987
   },
   "MAX": {
-    "station_name": "Maxwell Park Rail Station",
+    "station_name": "Maxwell Park",
     "latitude": 55.8377227182,
     "longitude": -4.2886774595
   },
   "MAY": {
-    "station_name": "Maybole Rail Station",
+    "station_name": "Maybole",
     "latitude": 55.3547389681,
     "longitude": -4.6852666045
   },
   "MBK": {
-    "station_name": "Millbrook (Hants) Rail Station",
+    "station_name": "Millbrook (Hants)",
     "latitude": 50.9114857016,
     "longitude": -1.433834394
   },
+  "MBT": {
+    "station_name": "Marsh Barton",
+    "latitude": 50.704,
+    "longitude": -3.521
+  },
   "MBR": {
-    "station_name": "Middlesbrough Rail Station",
+    "station_name": "Middlesbrough",
     "latitude": 54.5791171412,
     "longitude": -1.2347318713
   },
   "MCB": {
-    "station_name": "Moulsecoomb Rail Station",
+    "station_name": "Moulsecoomb",
     "latitude": 50.846714382,
     "longitude": -0.1188141333
   },
   "MCE": {
-    "station_name": "Metrocentre Rail Station",
+    "station_name": "Metrocentre",
     "latitude": 54.9587542761,
     "longitude": -1.6656377117
   },
   "MCH": {
-    "station_name": "March Rail Station",
+    "station_name": "March",
     "latitude": 52.5599099766,
     "longitude": 0.0912162426
   },
   "MCM": {
-    "station_name": "Morecambe Rail Station",
+    "station_name": "Morecambe",
     "latitude": 54.0703284997,
     "longitude": -2.8693058453
   },
   "MCN": {
-    "station_name": "Machynlleth Rail Station",
+    "station_name": "Machynlleth",
     "latitude": 52.5951498424,
     "longitude": -3.8545361215
   },
   "MCO": {
-    "station_name": "Manchester Oxford Road Rail Station",
+    "station_name": "Manchester Oxford Road",
     "latitude": 53.4740463537,
     "longitude": -2.2419934877
   },
   "MCV": {
-    "station_name": "Manchester Victoria Rail Station",
+    "station_name": "Manchester Victoria",
     "latitude": 53.4874823915,
     "longitude": -2.2425968806
   },
   "MDB": {
-    "station_name": "Maidstone Barracks Rail Station",
+    "station_name": "Maidstone Barracks",
     "latitude": 51.27716692,
     "longitude": 0.5139899352
   },
   "MDE": {
-    "station_name": "Maidstone East Rail Station",
+    "station_name": "Maidstone East",
     "latitude": 51.2778275358,
     "longitude": 0.5213244253
   },
   "MDG": {
-    "station_name": "Midgham Rail Station",
+    "station_name": "Midgham",
     "latitude": 51.3959731964,
     "longitude": -1.1776918335
   },
   "MDL": {
-    "station_name": "Middlewood Rail Station",
+    "station_name": "Middlewood",
     "latitude": 53.3599736747,
     "longitude": -2.083352764
   },
   "MDN": {
-    "station_name": "Maiden Newton Rail Station",
+    "station_name": "Maiden Newton",
     "latitude": 50.7799951951,
     "longitude": -2.5694292738
   },
   "MDS": {
-    "station_name": "Morden South Rail Station",
+    "station_name": "Morden South",
     "latitude": 51.3961136271,
     "longitude": -0.1994364409
   },
   "MDW": {
-    "station_name": "Maidstone West Rail Station",
+    "station_name": "Maidstone West",
     "latitude": 51.2704636478,
     "longitude": 0.515803579
   },
   "MEC": {
-    "station_name": "Meols Cop Rail Station",
+    "station_name": "Meols Cop",
     "latitude": 53.6462862013,
     "longitude": -2.9758023054
   },
   "MEL": {
-    "station_name": "Meldreth Rail Station",
+    "station_name": "Meldreth",
     "latitude": 52.0907259969,
     "longitude": 0.0089697848
   },
   "MEN": {
-    "station_name": "Menheniot Rail Station",
+    "station_name": "Menheniot",
     "latitude": 50.4262142257,
     "longitude": -4.4092572868
   },
   "MEO": {
-    "station_name": "Meols Rail Station",
+    "station_name": "Meols",
     "latitude": 53.3994554549,
     "longitude": -3.1542676173
   },
   "MEP": {
-    "station_name": "Meopham Rail Station",
+    "station_name": "Meopham",
     "latitude": 51.3864213569,
     "longitude": 0.3569805515
   },
   "MER": {
-    "station_name": "Merthyr Tydfil Rail Station",
+    "station_name": "Merthyr Tydfil",
     "latitude": 51.7446246906,
     "longitude": -3.3772616186
   },
   "MES": {
-    "station_name": "Melton (Suffolk) Rail Station",
+    "station_name": "Melton (Suffolk)",
     "latitude": 52.1044529456,
     "longitude": 1.3382667481
   },
   "MEV": {
-    "station_name": "Merthyr Vale Rail Station",
+    "station_name": "Merthyr Vale",
     "latitude": 51.6866484889,
     "longitude": -3.3365879829
   },
   "MEW": {
-    "station_name": "Maesteg (Ewenny Road) Rail Station",
+    "station_name": "Maesteg (Ewenny Road)",
     "latitude": 51.6053431085,
     "longitude": -3.6490064767
   },
   "MEX": {
-    "station_name": "Mexborough Rail Station",
+    "station_name": "Mexborough",
     "latitude": 53.4910099658,
     "longitude": -1.2885625776
   },
   "MEY": {
-    "station_name": "Merryton Rail Station",
+    "station_name": "Merryton",
     "latitude": 55.7487021227,
     "longitude": -3.9782420669
   },
   "MFA": {
-    "station_name": "Morfa Mawddach Rail Station",
+    "station_name": "Morfa Mawddach",
     "latitude": 52.7071419715,
     "longitude": -4.032178053
   },
@@ -7675,1302 +7725,1312 @@
     "longitude": -4.0842164454
   },
   "MFF": {
-    "station_name": "Minffordd Rail Station",
+    "station_name": "Minffordd",
     "latitude": 52.926145345,
     "longitude": -4.0849726521
   },
   "MFH": {
-    "station_name": "Milford Haven Rail Station",
+    "station_name": "Milford Haven",
     "latitude": 51.7149845991,
     "longitude": -5.0410051649
   },
   "MFL": {
-    "station_name": "Mount Florida Rail Station",
+    "station_name": "Mount Florida",
     "latitude": 55.8265491352,
     "longitude": -4.2611173526
   },
   "MFT": {
-    "station_name": "Mansfield Rail Station",
+    "station_name": "Mansfield",
     "latitude": 53.1421177161,
     "longitude": -1.1984319382
   },
   "MGM": {
-    "station_name": "Metheringham Rail Station",
+    "station_name": "Metheringham",
     "latitude": 53.1389012206,
     "longitude": -0.3914492699
   },
   "MGN": {
-    "station_name": "Marston Green Rail Station",
+    "station_name": "Marston Green",
     "latitude": 52.4672018911,
     "longitude": -1.7556002472
   },
   "MHM": {
-    "station_name": "Merstham Rail Station",
+    "station_name": "Merstham",
     "latitude": 51.2641512942,
     "longitude": -0.1502004055
   },
   "MHR": {
-    "station_name": "Market Harborough Rail Station",
+    "station_name": "Market Harborough",
     "latitude": 52.4797370398,
     "longitude": -0.9093194703
   },
   "MHS": {
-    "station_name": "Meadowhall Rail Station",
+    "station_name": "Meadowhall",
     "latitude": 53.4174828257,
     "longitude": -1.4128516936
   },
   "MIA": {
-    "station_name": "Manchester Airport Rail Station",
+    "station_name": "Manchester Airport",
     "latitude": 53.365056148,
     "longitude": -2.2729784791
   },
   "MIC": {
-    "station_name": "Micheldever Rail Station",
+    "station_name": "Micheldever",
     "latitude": 51.1823883025,
     "longitude": -1.260662184
   },
   "MIH": {
-    "station_name": "Mills Hill (Manchester) Rail Station",
+    "station_name": "Mills Hill (Manchester)",
     "latitude": 53.5513245844,
     "longitude": -2.1715108069
   },
   "MIJ": {
-    "station_name": "Mitcham Junction Rail Station",
+    "station_name": "Mitcham Junction",
     "latitude": 51.392947391,
     "longitude": -0.1577313094
   },
   "MIK": {
-    "station_name": "Micklefield Rail Station",
+    "station_name": "Micklefield",
     "latitude": 53.7888521389,
     "longitude": -1.3267968915
   },
   "MIL": {
-    "station_name": "Mill Hill Broadway Rail Station",
+    "station_name": "Mill Hill Broadway",
     "latitude": 51.6130940209,
     "longitude": -0.2492158407
   },
   "MIM": {
-    "station_name": "Moreton-in-Marsh Rail Station",
+    "station_name": "Moreton-in-Marsh",
     "latitude": 51.9922896467,
     "longitude": -1.700369111
   },
   "MIN": {
-    "station_name": "Milliken Park Rail Station",
+    "station_name": "Milliken Park",
     "latitude": 55.8251055368,
     "longitude": -4.5333409179
   },
   "MIR": {
-    "station_name": "Mirfield Rail Station",
+    "station_name": "Mirfield",
     "latitude": 53.6714142168,
     "longitude": -1.6925478902
   },
   "MIS": {
-    "station_name": "Mistley Rail Station",
+    "station_name": "Mistley",
     "latitude": 51.9436415764,
     "longitude": 1.081430084
   },
   "MKC": {
-    "station_name": "Milton Keynes Central Rail Station",
+    "station_name": "Milton Keynes Central",
     "latitude": 52.0342970583,
     "longitude": -0.7741256561
   },
   "MKM": {
-    "station_name": "Melksham Rail Station",
+    "station_name": "Melksham",
     "latitude": 51.3798186441,
     "longitude": -2.1444920323
   },
   "MKR": {
-    "station_name": "Market Rasen Rail Station",
+    "station_name": "Market Rasen",
     "latitude": 53.3839344671,
     "longitude": -0.3369000957
   },
   "MKT": {
-    "station_name": "Marks Tey Rail Station",
+    "station_name": "Marks Tey",
     "latitude": 51.8809486375,
     "longitude": 0.7833551606
   },
   "MLB": {
-    "station_name": "Millbrook (Beds) Rail Station",
+    "station_name": "Millbrook (Beds)",
     "latitude": 52.0538457297,
     "longitude": -0.5326807632
   },
   "MLD": {
-    "station_name": "Mouldsworth Rail Station",
+    "station_name": "Mouldsworth",
     "latitude": 53.2318188478,
     "longitude": -2.7322232144
   },
   "MLF": {
-    "station_name": "Milford (Surrey) Rail Station",
+    "station_name": "Milford (Surrey)",
     "latitude": 51.1633133767,
     "longitude": -0.6369282874
   },
   "MLG": {
-    "station_name": "Mallaig Rail Station",
+    "station_name": "Mallaig",
     "latitude": 57.005965587,
     "longitude": -5.8295792296
   },
   "MLH": {
-    "station_name": "Mill Hill (Lancs) Rail Station",
+    "station_name": "Mill Hill (Lancs)",
     "latitude": 53.7354717311,
     "longitude": -2.5017331794
   },
   "MLM": {
-    "station_name": "Millom Rail Station",
+    "station_name": "Millom",
     "latitude": 54.2108302797,
     "longitude": -3.2710839419
   },
   "MLN": {
-    "station_name": "Milngavie Rail Station",
+    "station_name": "Milngavie",
     "latitude": 55.9413575022,
     "longitude": -4.3145648876
   },
   "MLT": {
-    "station_name": "Malton Rail Station",
+    "station_name": "Malton",
     "latitude": 54.1320917413,
     "longitude": -0.7972330574
   },
   "MLW": {
-    "station_name": "Marlow Rail Station",
+    "station_name": "Marlow",
     "latitude": 51.5709950142,
     "longitude": -0.7664123608
   },
   "MLY": {
-    "station_name": "Morley Rail Station",
+    "station_name": "Morley",
     "latitude": 53.7499375883,
     "longitude": -1.5909802981
   },
   "MMO": {
-    "station_name": "Melton Mowbray Rail Station",
+    "station_name": "Melton Mowbray",
     "latitude": 52.7610494909,
     "longitude": -0.8858623625
   },
   "MNC": {
-    "station_name": "Markinch Rail Station",
+    "station_name": "Markinch",
     "latitude": 56.201006454,
     "longitude": -3.1307887208
   },
   "MNE": {
-    "station_name": "Manea Rail Station",
+    "station_name": "Manea",
     "latitude": 52.4978548877,
     "longitude": 0.1777139789
   },
   "MNG": {
-    "station_name": "Manningtree Rail Station",
+    "station_name": "Manningtree",
     "latitude": 51.9490620543,
     "longitude": 1.0452697914
   },
+  "MNS":{
+    "station_name": "Maghull North",
+    "latitude": 53.5167,
+    "longitude": -2.9213
+  },
   "MNN": {
-    "station_name": "Menston Rail Station",
+    "station_name": "Menston",
     "latitude": 53.8923520984,
     "longitude": -1.7355135499
   },
   "MNP": {
-    "station_name": "Manor Park Rail Station",
+    "station_name": "Manor Park",
     "latitude": 51.5524760236,
     "longitude": 0.0463682122
   },
   "MNR": {
-    "station_name": "Manor Road Rail Station",
+    "station_name": "Manor Road",
     "latitude": 53.394793603,
     "longitude": -3.1714362959
   },
   "MOB": {
-    "station_name": "Mobberley Rail Station",
+    "station_name": "Mobberley",
     "latitude": 53.3291537972,
     "longitude": -2.3336642593
   },
   "MOG": {
-    "station_name": "Moorgate Rail Station",
+    "station_name": "Moorgate",
     "latitude": 51.5184914149,
     "longitude": -0.0889174169
   },
   "MON": {
-    "station_name": "Monifieth Rail Station",
+    "station_name": "Monifieth",
     "latitude": 56.4801011269,
     "longitude": -2.8182514848
   },
   "MOO": {
-    "station_name": "Muir of Ord Rail Station",
+    "station_name": "Muir of Ord",
     "latitude": 57.5178284795,
     "longitude": -4.460230876
   },
   "MOR": {
-    "station_name": "Mortimer Rail Station",
+    "station_name": "Mortimer",
     "latitude": 51.3720775119,
     "longitude": -1.0354903866
   },
   "MOS": {
-    "station_name": "Moss Side Rail Station",
+    "station_name": "Moss Side",
     "latitude": 53.764988776,
     "longitude": -2.9429318748
   },
   "MOT": {
-    "station_name": "Motspur Park Rail Station",
+    "station_name": "Motspur Park",
     "latitude": 51.3951937788,
     "longitude": -0.2395071447
   },
   "MPK": {
-    "station_name": "Mosspark Rail Station",
+    "station_name": "Mosspark",
     "latitude": 55.8408228806,
     "longitude": -4.3482777791
   },
   "MPL": {
-    "station_name": "Marple Rail Station",
+    "station_name": "Marple",
     "latitude": 53.4007069655,
     "longitude": -2.0572623816
   },
   "MPT": {
-    "station_name": "Morpeth Rail Station",
+    "station_name": "Morpeth",
     "latitude": 55.1623793108,
     "longitude": -1.6830875765
   },
   "MRB": {
-    "station_name": "Manorbier Rail Station",
+    "station_name": "Manorbier",
     "latitude": 51.6601657701,
     "longitude": -4.7918631589
   },
   "MRD": {
-    "station_name": "Morchard Road Rail Station",
+    "station_name": "Morchard Road",
     "latitude": 50.831888433,
     "longitude": -3.7763856573
   },
   "MRF": {
-    "station_name": "Moorfields Rail Station",
+    "station_name": "Moorfields",
     "latitude": 53.408577563,
     "longitude": -2.9891877739
   },
   "MRN": {
-    "station_name": "Marden Rail Station",
+    "station_name": "Marden",
     "latitude": 51.1751727189,
     "longitude": 0.4931989357
   },
   "MRP": {
-    "station_name": "Moorthorpe Rail Station",
+    "station_name": "Moorthorpe",
     "latitude": 53.5950120583,
     "longitude": -1.3049494779
   },
   "MRR": {
-    "station_name": "Morar Rail Station",
+    "station_name": "Morar",
     "latitude": 56.9696962652,
     "longitude": -5.8218995718
   },
   "MRS": {
-    "station_name": "Monks Risborough Rail Station",
+    "station_name": "Monks Risborough",
     "latitude": 51.7357654911,
     "longitude": -0.8293110058
   },
   "MRT": {
-    "station_name": "Moreton (Merseyside) Rail Station",
+    "station_name": "Moreton (Merseyside)",
     "latitude": 53.4072225806,
     "longitude": -3.1134999967
   },
+  "MRW": {
+    "station_name": "Meridian Water",
+    "latitude": 51.61,
+    "longitude": -0.0501
+  },
   "MRY": {
-    "station_name": "Maryport Rail Station",
+    "station_name": "Maryport",
     "latitude": 54.71132475,
     "longitude": -3.4940750264
   },
   "MSD": {
-    "station_name": "Moorside Rail Station",
+    "station_name": "Moorside",
     "latitude": 53.516289171,
     "longitude": -2.351797693
   },
   "MSH": {
-    "station_name": "Mossley Hill Rail Station",
+    "station_name": "Mossley Hill",
     "latitude": 53.3790525198,
     "longitude": -2.9154430601
   },
   "MSK": {
-    "station_name": "Marske Rail Station",
+    "station_name": "Marske",
     "latitude": 54.5874288395,
     "longitude": -1.0189249961
   },
   "MSL": {
-    "station_name": "Mossley (Manchester) Rail Station",
+    "station_name": "Mossley (Manchester)",
     "latitude": 53.5149938702,
     "longitude": -2.0412799663
   },
   "MSN": {
-    "station_name": "Marsden Rail Station",
+    "station_name": "Marsden",
     "latitude": 53.6031989506,
     "longitude": -1.9307489058
   },
   "MSO": {
-    "station_name": "Moston Rail Station",
+    "station_name": "Moston",
     "latitude": 53.5234344757,
     "longitude": -2.1710210757
   },
   "MSR": {
-    "station_name": "Minster Rail Station",
+    "station_name": "Minster",
     "latitude": 51.3291791939,
     "longitude": 1.3172443102
   },
   "MSS": {
-    "station_name": "Moses Gate Rail Station",
+    "station_name": "Moses Gate",
     "latitude": 53.5559962598,
     "longitude": -2.4011861486
   },
   "MST": {
-    "station_name": "Maesteg Rail Station",
+    "station_name": "Maesteg",
     "latitude": 51.6099392672,
     "longitude": -3.6546614792
   },
   "MSW": {
-    "station_name": "Mansfield Woodhouse Rail Station",
+    "station_name": "Mansfield Woodhouse",
     "latitude": 53.1635798405,
     "longitude": -1.201846595
   },
   "MTA": {
-    "station_name": "Mountain Ash Rail Station",
+    "station_name": "Mountain Ash",
     "latitude": 51.6813336784,
     "longitude": -3.3763534667
   },
   "MTB": {
-    "station_name": "Matlock Bath Rail Station",
+    "station_name": "Matlock Bath",
     "latitude": 53.1223708532,
     "longitude": -1.5567564386
   },
   "MTC": {
-    "station_name": "Mitcham Eastfields Rail Station",
+    "station_name": "Mitcham Eastfields",
     "latitude": 51.4077364814,
     "longitude": -0.1546204515
   },
   "MTG": {
-    "station_name": "Mottingham Rail Station",
+    "station_name": "Mottingham",
     "latitude": 51.4402167384,
     "longitude": 0.0500802261
   },
   "MTH": {
-    "station_name": "Motherwell Rail Station",
+    "station_name": "Motherwell",
     "latitude": 55.7916692892,
     "longitude": -3.9943169398
   },
   "MTL": {
-    "station_name": "Mortlake Rail Station",
+    "station_name": "Mortlake",
     "latitude": 51.468085138,
     "longitude": -0.2670827547
   },
   "MTM": {
-    "station_name": "Martin Mill Rail Station",
+    "station_name": "Martin Mill",
     "latitude": 51.1706839505,
     "longitude": 1.3482479873
   },
   "MTN": {
-    "station_name": "Moreton (Dorset) Rail Station",
+    "station_name": "Moreton (Dorset)",
     "latitude": 50.7010195625,
     "longitude": -2.3134461541
   },
   "MTO": {
-    "station_name": "Marton Rail Station",
+    "station_name": "Marton",
     "latitude": 54.5443541756,
     "longitude": -1.1984988205
   },
   "MTP": {
-    "station_name": "Montpelier Rail Station",
+    "station_name": "Montpelier",
     "latitude": 51.4683464285,
     "longitude": -2.5886872075
   },
   "MTS": {
-    "station_name": "Montrose Rail Station",
+    "station_name": "Montrose",
     "latitude": 56.7127857624,
     "longitude": -2.4720806987
   },
   "MTV": {
-    "station_name": "Mount Vernon Rail Station",
+    "station_name": "Mount Vernon",
     "latitude": 55.84019612,
     "longitude": -4.133656173
   },
   "MUB": {
-    "station_name": "Musselburgh Rail Station",
+    "station_name": "Musselburgh",
     "latitude": 55.9335850009,
     "longitude": -3.0732054363
   },
   "MUF": {
-    "station_name": "Manchester United FC Rail Station",
+    "station_name": "Manchester United FC",
     "latitude": 53.4622084856,
     "longitude": -2.290652901
   },
   "MUI": {
-    "station_name": "Muirend Rail Station",
+    "station_name": "Muirend",
     "latitude": 55.8094528886,
     "longitude": -4.274377937
   },
   "MVL": {
-    "station_name": "Malvern Link Rail Station",
+    "station_name": "Malvern Link",
     "latitude": 52.1254773107,
     "longitude": -2.3195074315
   },
   "MYB": {
-    "station_name": "London Marylebone Rail Station",
+    "station_name": "London Marylebone",
     "latitude": 51.522523885,
     "longitude": -0.1628859644
   },
   "MYH": {
-    "station_name": "Maryhill Rail Station",
+    "station_name": "Maryhill",
     "latitude": 55.8976237197,
     "longitude": -4.3007303486
   },
   "MYL": {
-    "station_name": "Maryland Rail Station",
+    "station_name": "Maryland",
     "latitude": 51.5460813657,
     "longitude": 0.005842588
   },
   "MYT": {
-    "station_name": "Mytholmroyd Rail Station",
+    "station_name": "Mytholmroyd",
     "latitude": 53.7290162532,
     "longitude": -1.9814271564
   },
   "MZH": {
-    "station_name": "Maze Hill Rail Station",
+    "station_name": "Maze Hill",
     "latitude": 51.4826233713,
     "longitude": 0.0029400062
   },
   "NAN": {
-    "station_name": "Nantwich Rail Station",
+    "station_name": "Nantwich",
     "latitude": 53.0635867383,
     "longitude": -2.5189592102
   },
   "NAR": {
-    "station_name": "Narberth Rail Station",
+    "station_name": "Narberth",
     "latitude": 51.7993779002,
     "longitude": -4.7272043319
   },
   "NAY": {
-    "station_name": "Newton Aycliffe Rail Station",
+    "station_name": "Newton Aycliffe",
     "latitude": 54.6137111141,
     "longitude": -1.5896555578
   },
   "NBA": {
-    "station_name": "New Barnet Rail Station",
+    "station_name": "New Barnet",
     "latitude": 51.6485757882,
     "longitude": -0.1729714788
   },
   "NBC": {
-    "station_name": "New Beckenham Rail Station",
+    "station_name": "New Beckenham",
     "latitude": 51.416767136,
     "longitude": -0.0352474454
   },
   "NBE": {
-    "station_name": "Newbridge Rail Station",
+    "station_name": "Newbridge",
     "latitude": 51.665815285,
     "longitude": -3.1428939856
   },
   "NBN": {
-    "station_name": "New Brighton Rail Station",
+    "station_name": "New Brighton",
     "latitude": 53.437415844,
     "longitude": -3.0479632359
   },
   "NBR": {
-    "station_name": "Narborough Rail Station",
+    "station_name": "Narborough",
     "latitude": 52.5713097683,
     "longitude": -1.2033367857
   },
   "NBT": {
-    "station_name": "Norbiton Rail Station",
+    "station_name": "Norbiton",
     "latitude": 51.4123555216,
     "longitude": -0.2840028162
   },
   "NBW": {
-    "station_name": "North Berwick Rail Station",
+    "station_name": "North Berwick",
     "latitude": 56.0570302209,
     "longitude": -2.7307472989
   },
   "NBY": {
-    "station_name": "Newbury Rail Station",
+    "station_name": "Newbury",
     "latitude": 51.397647103,
     "longitude": -1.3228424921
   },
   "NCE": {
-    "station_name": "New Clee Rail Station",
+    "station_name": "New Clee",
     "latitude": 53.5744020885,
     "longitude": -0.0608183009
   },
   "NCK": {
-    "station_name": "New Cumnock Rail Station",
+    "station_name": "New Cumnock",
     "latitude": 55.4027409338,
     "longitude": -4.1843292426
   },
   "NCL": {
-    "station_name": "Newcastle Rail Station",
+    "station_name": "Newcastle",
     "latitude": 54.9684070401,
     "longitude": -1.6172925574
   },
   "NCM": {
-    "station_name": "North Camp Rail Station",
+    "station_name": "North Camp",
     "latitude": 51.2757921453,
     "longitude": -0.731181183
   },
   "NCO": {
-    "station_name": "Newcourt Rail Station",
+    "station_name": "Newcourt",
     "latitude": 50.7050286867,
     "longitude": -3.4727977721
   },
   "NCT": {
-    "station_name": "Newark Castle Rail Station",
+    "station_name": "Newark Castle",
     "latitude": 53.080022402,
     "longitude": -0.8131567694
   },
   "NDL": {
-    "station_name": "North Dulwich Rail Station",
+    "station_name": "North Dulwich",
     "latitude": 51.4545089621,
     "longitude": -0.0878918236
   },
   "NEG": {
-    "station_name": "Newtongrange Rail Station",
+    "station_name": "Newtongrange",
     "latitude": 55.8669914004,
     "longitude": -3.0693694316
   },
   "NEH": {
-    "station_name": "New Eltham Rail Station",
+    "station_name": "New Eltham",
     "latitude": 51.4380580221,
     "longitude": 0.0705593927
   },
   "NEI": {
-    "station_name": "Neilston Rail Station",
+    "station_name": "Neilston",
     "latitude": 55.7830319543,
     "longitude": -4.4269370486
   },
   "NEL": {
-    "station_name": "Nelson Rail Station",
+    "station_name": "Nelson",
     "latitude": 53.8350188567,
     "longitude": -2.2137611849
   },
   "NEM": {
-    "station_name": "New Malden Rail Station",
+    "station_name": "New Malden",
     "latitude": 51.4040722425,
     "longitude": -0.2559166562
   },
   "NES": {
-    "station_name": "Neston Rail Station",
+    "station_name": "Neston",
     "latitude": 53.2918652932,
     "longitude": -3.0630755474
   },
   "NET": {
-    "station_name": "Netherfield Rail Station",
+    "station_name": "Netherfield",
     "latitude": 52.9614294437,
     "longitude": -1.0798460669
   },
   "NEW": {
-    "station_name": "Newcraighall Rail Station",
+    "station_name": "Newcraighall",
     "latitude": 55.9331154017,
     "longitude": -3.0908472906
   },
   "NFA": {
-    "station_name": "North Fambridge Rail Station",
+    "station_name": "North Fambridge",
     "latitude": 51.6485874442,
     "longitude": 0.6816868594
   },
   "NFD": {
-    "station_name": "Northfield Rail Station",
+    "station_name": "Northfield",
     "latitude": 52.408205022,
     "longitude": -1.9658445265
   },
   "NFL": {
-    "station_name": "Northfleet Rail Station",
+    "station_name": "Northfleet",
     "latitude": 51.4458444738,
     "longitude": 0.3243627291
   },
   "NFN": {
-    "station_name": "Nafferton Rail Station",
+    "station_name": "Nafferton",
     "latitude": 54.0112409619,
     "longitude": -0.3860877568
   },
   "NGT": {
-    "station_name": "Newington Rail Station",
+    "station_name": "Newington",
     "latitude": 51.3533404814,
     "longitude": 0.6686002778
   },
   "NHD": {
-    "station_name": "Nunhead Rail Station",
+    "station_name": "Nunhead",
     "latitude": 51.4668266219,
     "longitude": -0.0522470725
   },
   "NHE": {
-    "station_name": "New Hythe Rail Station",
+    "station_name": "New Hythe",
     "latitude": 51.3130005132,
     "longitude": 0.4549583652
   },
   "NHL": {
-    "station_name": "New Holland Rail Station",
+    "station_name": "New Holland",
     "latitude": 53.7019404883,
     "longitude": -0.3602195506
   },
   "NIT": {
-    "station_name": "Nitshill Rail Station",
+    "station_name": "Nitshill",
     "latitude": 55.8119290151,
     "longitude": -4.3599440893
   },
   "NLN": {
-    "station_name": "New Lane Rail Station",
+    "station_name": "New Lane",
     "latitude": 53.611676421,
     "longitude": -2.8677150822
   },
   "NLR": {
-    "station_name": "North Llanrwst Rail Station",
+    "station_name": "North Llanrwst",
     "latitude": 53.1438364668,
     "longitude": -3.8027318185
   },
   "NLS": {
-    "station_name": "Nailsea & Backwell Rail Station",
+    "station_name": "Nailsea & Backwell",
     "latitude": 51.4194043932,
     "longitude": -2.750638165
   },
   "NLT": {
-    "station_name": "Northolt Park Rail Station",
+    "station_name": "Northolt Park",
     "latitude": 51.5575391716,
     "longitude": -0.3594445305
   },
   "NLW": {
-    "station_name": "Newton-le-Willows Rail Station",
+    "station_name": "Newton-le-Willows",
     "latitude": 53.4530749987,
     "longitude": -2.6135973334
   },
   "NMC": {
-    "station_name": "New Mills Central Rail Station",
+    "station_name": "New Mills Central",
     "latitude": 53.3648560934,
     "longitude": -2.0056703312
   },
   "NMK": {
-    "station_name": "Newmarket Rail Station",
+    "station_name": "Newmarket",
     "latitude": 52.2379580874,
     "longitude": 0.4062358785
   },
   "NMN": {
-    "station_name": "New Mills Newtown Rail Station",
+    "station_name": "New Mills Newtown",
     "latitude": 53.3596424903,
     "longitude": -2.0085245142
   },
   "NMP": {
-    "station_name": "Northampton Rail Station",
+    "station_name": "Northampton",
     "latitude": 52.2375139145,
     "longitude": -0.906638854
   },
   "NMT": {
-    "station_name": "Needham Market Rail Station",
+    "station_name": "Needham Market",
     "latitude": 52.1526036565,
     "longitude": 1.0552904861
   },
   "NNG": {
-    "station_name": "Newark North Gate Rail Station",
+    "station_name": "Newark North Gate",
     "latitude": 53.0817767766,
     "longitude": -0.7998511914
   },
   "NNP": {
-    "station_name": "Ninian Park Rail Station",
+    "station_name": "Ninian Park",
     "latitude": 51.4766151237,
     "longitude": -3.2017026277
   },
   "NNT": {
-    "station_name": "Nunthorpe Rail Station",
+    "station_name": "Nunthorpe",
     "latitude": 54.5278916561,
     "longitude": -1.1694623307
   },
   "NOA": {
-    "station_name": "Newton-on-Ayr Rail Station",
+    "station_name": "Newton-on-Ayr",
     "latitude": 55.4740529017,
     "longitude": -4.6258056575
   },
   "NOR": {
-    "station_name": "Normanton Rail Station",
+    "station_name": "Normanton",
     "latitude": 53.7005346086,
     "longitude": -1.4234040424
   },
   "NOT": {
-    "station_name": "Nottingham Rail Station",
+    "station_name": "Nottingham",
     "latitude": 52.9470929341,
     "longitude": -1.1463789462
   },
   "NPD": {
-    "station_name": "New Pudsey Rail Station",
+    "station_name": "New Pudsey",
     "latitude": 53.8044975251,
     "longitude": -1.6807968849
   },
   "NQU": {
-    "station_name": "North Queensferry Rail Station",
+    "station_name": "North Queensferry",
     "latitude": 56.0124941531,
     "longitude": -3.394582615
   },
   "NQY": {
-    "station_name": "Newquay Rail Station",
+    "station_name": "Newquay",
     "latitude": 50.415084133,
     "longitude": -5.0756989533
   },
   "NRB": {
-    "station_name": "Norbury Rail Station",
+    "station_name": "Norbury",
     "latitude": 51.4114439365,
     "longitude": -0.1219000953
   },
   "NRC": {
-    "station_name": "Newbury Racecourse Rail Station",
+    "station_name": "Newbury Racecourse",
     "latitude": 51.3984581516,
     "longitude": -1.3077799439
   },
   "NRD": {
-    "station_name": "North Road Rail Station",
+    "station_name": "North Road",
     "latitude": 54.5362092283,
     "longitude": -1.5539587211
   },
   "NRN": {
-    "station_name": "Nairn Rail Station",
+    "station_name": "Nairn",
     "latitude": 57.5802287419,
     "longitude": -3.871999953
   },
   "NRT": {
-    "station_name": "Nethertown Rail Station",
+    "station_name": "Nethertown",
     "latitude": 54.4564242911,
     "longitude": -3.5658366589
   },
   "NRW": {
-    "station_name": "Norwich Rail Station",
+    "station_name": "Norwich",
     "latitude": 52.6271764442,
     "longitude": 1.3068436175
   },
   "NSB": {
-    "station_name": "Normans Bay Rail Station",
+    "station_name": "Normans Bay",
     "latitude": 50.8260972868,
     "longitude": 0.3894907962
   },
   "NSD": {
-    "station_name": "Newstead Rail Station",
+    "station_name": "Newstead",
     "latitude": 53.0699991881,
     "longitude": -1.221784818
   },
   "NSG": {
-    "station_name": "New Southgate Rail Station",
+    "station_name": "New Southgate",
     "latitude": 51.6141146074,
     "longitude": -0.1430125641
   },
   "NSH": {
-    "station_name": "North Sheen Rail Station",
+    "station_name": "North Sheen",
     "latitude": 51.4651527407,
     "longitude": -0.2878532427
   },
   "NTA": {
-    "station_name": "Newton Abbot Rail Station",
+    "station_name": "Newton Abbot",
     "latitude": 50.5295709354,
     "longitude": -3.5991818536
   },
   "NTB": {
-    "station_name": "Norton Bridge Rail Station",
+    "station_name": "Norton Bridge",
     "latitude": 52.8667125875,
     "longitude": -2.1905418489
   },
   "NTC": {
-    "station_name": "Newton St Cyres Rail Station",
+    "station_name": "Newton St Cyres",
     "latitude": 50.7789165834,
     "longitude": -3.589404542
   },
   "NTH": {
-    "station_name": "Neath Rail Station",
+    "station_name": "Neath",
     "latitude": 51.6623638663,
     "longitude": -3.8072343482
   },
   "NTL": {
-    "station_name": "Netley Rail Station",
+    "station_name": "Netley",
     "latitude": 50.8748975168,
     "longitude": -1.3418931628
   },
   "NTN": {
-    "station_name": "Newton (S Lanarks) Rail Station",
+    "station_name": "Newton (S Lanarks)",
     "latitude": 55.8187724129,
     "longitude": -4.1330414607
   },
   "NTR": {
-    "station_name": "Northallerton Rail Station",
+    "station_name": "Northallerton",
     "latitude": 54.3330824604,
     "longitude": -1.4412825015
   },
   "NUF": {
-    "station_name": "Nutfield Rail Station",
+    "station_name": "Nutfield",
     "latitude": 51.2268096258,
     "longitude": -0.1325049602
   },
   "NUM": {
-    "station_name": "Northumberland Park Rail Station",
+    "station_name": "Northumberland Park",
     "latitude": 51.6019688995,
     "longitude": -0.0539069251
   },
   "NUN": {
-    "station_name": "Nuneaton Rail Station",
+    "station_name": "Nuneaton",
     "latitude": 52.5263860835,
     "longitude": -1.4638662754
   },
   "NUT": {
-    "station_name": "Nutbourne Rail Station",
+    "station_name": "Nutbourne",
     "latitude": 50.8460585998,
     "longitude": -0.8829282409
   },
   "NVH": {
-    "station_name": "Newhaven Harbour Rail Station",
+    "station_name": "Newhaven Harbour",
     "latitude": 50.7897843615,
     "longitude": 0.0550205943
   },
   "NVN": {
-    "station_name": "Newhaven Town Rail Station",
+    "station_name": "Newhaven Town",
     "latitude": 50.7948486315,
     "longitude": 0.0549731113
   },
   "NVR": {
-    "station_name": "Navigation Road Rail Station",
+    "station_name": "Navigation Road",
     "latitude": 53.3953905024,
     "longitude": -2.3434169235
   },
   "NWA": {
-    "station_name": "North Walsham Rail Station",
+    "station_name": "North Walsham",
     "latitude": 52.8169121918,
     "longitude": 1.3844751173
   },
   "NWB": {
-    "station_name": "North Wembley Rail Station",
+    "station_name": "North Wembley",
     "latitude": 51.5625961704,
     "longitude": -0.3039615425
   },
   "NWD": {
-    "station_name": "Norwood Junction Rail Station",
+    "station_name": "Norwood Junction",
     "latitude": 51.397016964,
     "longitude": -0.0751960155
   },
   "NWE": {
-    "station_name": "Newport (Essex) Rail Station",
+    "station_name": "Newport (Essex)",
     "latitude": 51.9798767674,
     "longitude": 0.2151664222
   },
   "NWI": {
-    "station_name": "Northwich Rail Station",
+    "station_name": "Northwich",
     "latitude": 53.2614653974,
     "longitude": -2.4969157221
   },
   "NWM": {
-    "station_name": "New Milton Rail Station",
+    "station_name": "New Milton",
     "latitude": 50.7557417759,
     "longitude": -1.657805844
   },
   "NWN": {
-    "station_name": "Newton for Hyde Rail Station",
+    "station_name": "Newton for Hyde",
     "latitude": 53.4563946328,
     "longitude": -2.0671424184
   },
   "NWP": {
-    "station_name": "Newport (S Wales) Rail Station",
+    "station_name": "Newport (S Wales)",
     "latitude": 51.5887891555,
     "longitude": -3.0005496511
   },
   "NWR": {
-    "station_name": "Newtonmore Rail Station",
+    "station_name": "Newtonmore",
     "latitude": 57.0591301765,
     "longitude": -4.1191037522
   },
   "NWT": {
-    "station_name": "Newtown (Powys) Rail Station",
+    "station_name": "Newtown (Powys)",
     "latitude": 52.5123270805,
     "longitude": -3.3113949158
   },
   "NWX": {
-    "station_name": "New Cross ELL Rail Station",
+    "station_name": "New Cross ELL",
     "latitude": 51.4763425048,
     "longitude": -0.0324150961
   },
   "NXG": {
-    "station_name": "New Cross Gate ELL Rail Station",
+    "station_name": "New Cross Gate ELL",
     "latitude": 51.4751271677,
     "longitude": -0.0403876579
   },
   "OBN": {
-    "station_name": "Oban Rail Station",
+    "station_name": "Oban",
     "latitude": 56.4124709629,
     "longitude": -5.4739093886
   },
   "OCK": {
-    "station_name": "Ockendon Rail Station",
+    "station_name": "Ockendon",
     "latitude": 51.5219914043,
     "longitude": 0.290497263
   },
   "OHL": {
-    "station_name": "Old Hill Rail Station",
+    "station_name": "Old Hill",
     "latitude": 52.470947074,
     "longitude": -2.0561848613
   },
   "OKE": {
-    "station_name": "Okehampton Rail Station",
+    "station_name": "Okehampton",
     "latitude": 50.7323709771,
     "longitude": -3.9962371646
   },
   "OKL": {
-    "station_name": "Oakleigh Park Rail Station",
+    "station_name": "Oakleigh Park",
     "latitude": 51.637679136,
     "longitude": -0.1661837043
   },
   "OKM": {
-    "station_name": "Oakham Rail Station",
+    "station_name": "Oakham",
     "latitude": 52.6722323623,
     "longitude": -0.7341607803
   },
   "OKN": {
-    "station_name": "Oakengates Rail Station",
+    "station_name": "Oakengates",
     "latitude": 52.6934109391,
     "longitude": -2.4501927064
   },
   "OLD": {
-    "station_name": "Old Street Rail Station",
+    "station_name": "Old Street",
     "latitude": 51.5258317895,
     "longitude": -0.0885090187
   },
   "OLF": {
-    "station_name": "Oldfield Park Rail Station",
+    "station_name": "Oldfield Park",
     "latitude": 51.3792256566,
     "longitude": -2.3805068483
   },
   "OLT": {
-    "station_name": "Olton Rail Station",
+    "station_name": "Olton",
     "latitude": 52.438524483,
     "longitude": -1.8043032158
   },
   "OLY": {
-    "station_name": "Ockley Rail Station",
+    "station_name": "Ockley",
     "latitude": 51.1515064148,
     "longitude": -0.3359877818
   },
   "OMS": {
-    "station_name": "Ormskirk Rail Station",
+    "station_name": "Ormskirk",
     "latitude": 53.56928696,
     "longitude": -2.8811915199
   },
   "OPK": {
-    "station_name": "Orrell Park Rail Station",
+    "station_name": "Orrell Park",
     "latitude": 53.4619123452,
     "longitude": -2.9633147359
   },
   "OPY": {
-    "station_name": "Oxford Parkway Rail Station",
+    "station_name": "Oxford Parkway",
     "latitude": 51.8040758686,
     "longitude": -1.2744681129
   },
   "ORE": {
-    "station_name": "Ore Rail Station",
+    "station_name": "Ore",
     "latitude": 50.8669427332,
     "longitude": 0.591596612
   },
   "ORN": {
-    "station_name": "Old Roan Rail Station",
+    "station_name": "Old Roan",
     "latitude": 53.4869093953,
     "longitude": -2.9510705094
   },
   "ORP": {
-    "station_name": "Orpington Rail Station",
+    "station_name": "Orpington",
     "latitude": 51.3732951318,
     "longitude": 0.0891167615
   },
   "ORR": {
-    "station_name": "Orrell Rail Station",
+    "station_name": "Orrell",
     "latitude": 53.530325904,
     "longitude": -2.7088376683
   },
   "OTF": {
-    "station_name": "Otford Rail Station",
+    "station_name": "Otford",
     "latitude": 51.313155145,
     "longitude": 0.1968058758
   },
   "OUN": {
-    "station_name": "Oulton Broad North Rail Station",
+    "station_name": "Oulton Broad North",
     "latitude": 52.4777844841,
     "longitude": 1.7157356055
   },
   "OUS": {
-    "station_name": "Oulton Broad South Rail Station",
+    "station_name": "Oulton Broad South",
     "latitude": 52.4696271149,
     "longitude": 1.7076837204
   },
   "OUT": {
-    "station_name": "Outwood Rail Station",
+    "station_name": "Outwood",
     "latitude": 53.7153018923,
     "longitude": -1.5104034645
   },
   "OVE": {
-    "station_name": "Overpool Rail Station",
+    "station_name": "Overpool",
     "latitude": 53.2840618342,
     "longitude": -2.9240604888
   },
   "OVR": {
-    "station_name": "Overton Rail Station",
+    "station_name": "Overton",
     "latitude": 51.2542901889,
     "longitude": -1.2592504239
   },
   "OXF": {
-    "station_name": "Oxford Rail Station",
+    "station_name": "Oxford",
     "latitude": 51.753499533,
     "longitude": -1.2701353856
   },
   "OXN": {
-    "station_name": "Oxenholme Lake District Rail Station",
+    "station_name": "Oxenholme Lake District",
     "latitude": 54.3049347745,
     "longitude": -2.7218718643
   },
   "OXS": {
-    "station_name": "Oxshott Rail Station",
+    "station_name": "Oxshott",
     "latitude": 51.3363929984,
     "longitude": -0.3623961961
   },
   "OXT": {
-    "station_name": "Oxted Rail Station",
+    "station_name": "Oxted",
     "latitude": 51.2579045834,
     "longitude": -0.0048073736
   },
   "PAD": {
-    "station_name": "London Paddington Rail Station",
+    "station_name": "London Paddington",
     "latitude": 51.515995347,
     "longitude": -0.1761493939
   },
   "PAL": {
-    "station_name": "Palmers Green Rail Station",
+    "station_name": "Palmers Green",
     "latitude": 51.6183152407,
     "longitude": -0.1104116731
   },
   "PAN": {
-    "station_name": "Pangbourne Rail Station",
+    "station_name": "Pangbourne",
     "latitude": 51.4854011729,
     "longitude": -1.0904500754
   },
   "PAR": {
-    "station_name": "Par Rail Station",
+    "station_name": "Par",
     "latitude": 50.3553115511,
     "longitude": -4.7047163536
   },
   "PAT": {
-    "station_name": "Patricroft Rail Station",
+    "station_name": "Patricroft",
     "latitude": 53.4847921621,
     "longitude": -2.3582432532
   },
   "PBL": {
-    "station_name": "Parbold Rail Station",
+    "station_name": "Parbold",
     "latitude": 53.5907686118,
     "longitude": -2.7707477548
   },
   "PBO": {
-    "station_name": "Peterborough Rail Station",
+    "station_name": "Peterborough",
     "latitude": 52.5749924034,
     "longitude": -0.2498227798
   },
   "PBR": {
-    "station_name": "Potters Bar Rail Station",
+    "station_name": "Potters Bar",
     "latitude": 51.6970695641,
     "longitude": -0.1925817236
   },
   "PBY": {
-    "station_name": "Pembrey & Burry Port Rail Station",
+    "station_name": "Pembrey & Burry Port",
     "latitude": 51.6835326809,
     "longitude": -4.2478649262
   },
   "PCD": {
-    "station_name": "Pencoed Rail Station",
+    "station_name": "Pencoed",
     "latitude": 51.5246083186,
     "longitude": -3.5004926045
   },
   "PCN": {
-    "station_name": "Paisley Canal Rail Station",
+    "station_name": "Paisley Canal",
     "latitude": 55.8400708211,
     "longitude": -4.4241022116
   },
   "PDG": {
-    "station_name": "Padgate Rail Station",
+    "station_name": "Padgate",
     "latitude": 53.4058038948,
     "longitude": -2.5568110117
   },
   "PDW": {
-    "station_name": "Paddock Wood Rail Station",
+    "station_name": "Paddock Wood",
     "latitude": 51.1822633724,
     "longitude": 0.3891775302
   },
   "PEA": {
-    "station_name": "Peartree Rail Station",
+    "station_name": "Peartree",
     "latitude": 52.8970116224,
     "longitude": -1.4732098615
   },
   "PEB": {
-    "station_name": "Pevensey Bay Rail Station",
+    "station_name": "Pevensey Bay",
     "latitude": 50.8174539615,
     "longitude": 0.3429353987
   },
   "PEG": {
-    "station_name": "Pegswood Rail Station",
+    "station_name": "Pegswood",
     "latitude": 55.1781320707,
     "longitude": -1.6441787746
   },
   "PEM": {
-    "station_name": "Pemberton Rail Station",
+    "station_name": "Pemberton",
     "latitude": 53.5304214463,
     "longitude": -2.6703543304
   },
   "PEN": {
-    "station_name": "Penarth Rail Station",
+    "station_name": "Penarth",
     "latitude": 51.4358873168,
     "longitude": -3.1744496863
   },
   "PER": {
-    "station_name": "Penrhiwceiber Rail Station",
+    "station_name": "Penrhiwceiber",
     "latitude": 51.6699251561,
     "longitude": -3.3599562105
   },
   "PES": {
-    "station_name": "Pensarn (Gwynedd) Rail Station",
+    "station_name": "Pensarn (Gwynedd)",
     "latitude": 52.8307204357,
     "longitude": -4.1121665744
   },
   "PET": {
-    "station_name": "Petts Wood Rail Station",
+    "station_name": "Petts Wood",
     "latitude": 51.3886176381,
     "longitude": 0.0745066346
   },
   "PEV": {
-    "station_name": "Pevensey & Westham Rail Station",
+    "station_name": "Pevensey & Westham",
     "latitude": 50.8157924588,
     "longitude": 0.3248360436
   },
   "PEW": {
-    "station_name": "Pewsey Rail Station",
+    "station_name": "Pewsey",
     "latitude": 51.342188386,
     "longitude": -1.7706654384
   },
   "PFL": {
-    "station_name": "Purfleet Rail Station",
+    "station_name": "Purfleet",
     "latitude": 51.4810119817,
     "longitude": 0.2367953506
   },
   "PFM": {
-    "station_name": "Pontefract Monkhill Rail Station",
+    "station_name": "Pontefract Monkhill",
     "latitude": 53.6990008028,
     "longitude": -1.3036919442
   },
   "PFR": {
-    "station_name": "Pontefract Baghill Rail Station",
+    "station_name": "Pontefract Baghill",
     "latitude": 53.6918982987,
     "longitude": -1.3033551435
   },
   "PFY": {
-    "station_name": "Poulton-le-Fylde Rail Station",
+    "station_name": "Poulton-le-Fylde",
     "latitude": 53.8484388445,
     "longitude": -2.9906188413
   },
   "PGM": {
-    "station_name": "Pengam Rail Station",
+    "station_name": "Pengam",
     "latitude": 51.6704563039,
     "longitude": -3.2301095675
   },
   "PGN": {
-    "station_name": "Paignton Rail Station",
+    "station_name": "Paignton",
     "latitude": 50.4347023859,
     "longitude": -3.5648917612
   },
   "PHG": {
-    "station_name": "Penhelig Rail Station",
+    "station_name": "Penhelig",
     "latitude": 52.5457006306,
     "longitude": -4.0350346008
   },
   "PHR": {
-    "station_name": "Penshurst Rail Station",
+    "station_name": "Penshurst",
     "latitude": 51.1973335413,
     "longitude": 0.1734986012
   },
   "PIL": {
-    "station_name": "Pilning Rail Station",
+    "station_name": "Pilning",
     "latitude": 51.5566244695,
     "longitude": -2.6271165239
   },
   "PIN": {
-    "station_name": "Pinhoe Rail Station",
+    "station_name": "Pinhoe",
     "latitude": 50.7377726757,
     "longitude": -3.469346888
   },
   "PIT": {
-    "station_name": "Pitlochry Rail Station",
+    "station_name": "Pitlochry",
     "latitude": 56.7024883256,
     "longitude": -3.7355677144
   },
   "PKG": {
-    "station_name": "Penkridge Rail Station",
+    "station_name": "Penkridge",
     "latitude": 52.723513524,
     "longitude": -2.1192894969
   },
   "PKS": {
-    "station_name": "Parkstone (Dorset) Rail Station",
+    "station_name": "Parkstone (Dorset)",
     "latitude": 50.7229662137,
     "longitude": -1.9479483493
   },
   "PKT": {
-    "station_name": "Park Street Rail Station",
+    "station_name": "Park Street",
     "latitude": 51.7254616475,
     "longitude": -0.3402531493
   },
   "PLC": {
-    "station_name": "Pluckley Rail Station",
+    "station_name": "Pluckley",
     "latitude": 51.1564699354,
     "longitude": 0.7474262223
   },
   "PLD": {
-    "station_name": "Portslade Rail Station",
+    "station_name": "Portslade",
     "latitude": 50.8356743968,
     "longitude": -0.2053088577
   },
   "PLE": {
-    "station_name": "Pollokshields East Rail Station",
+    "station_name": "Pollokshields East",
     "latitude": 55.8410609323,
     "longitude": -4.2685885077
   },
   "PLG": {
-    "station_name": "Polegate Rail Station",
+    "station_name": "Polegate",
     "latitude": 50.8212387544,
     "longitude": 0.2451683916
   },
   "PLK": {
-    "station_name": "Plockton Rail Station",
+    "station_name": "Plockton",
     "latitude": 57.333539976,
     "longitude": -5.6659881238
   },
   "PLM": {
-    "station_name": "Plumley Rail Station",
+    "station_name": "Plumley",
     "latitude": 53.2746886444,
     "longitude": -2.419660194
   },
   "PLN": {
-    "station_name": "Portlethen Rail Station",
+    "station_name": "Portlethen",
     "latitude": 57.0613593651,
     "longitude": -2.1266196251
   },
   "PLS": {
-    "station_name": "Pleasington Rail Station",
+    "station_name": "Pleasington",
     "latitude": 53.7309724834,
     "longitude": -2.5441212488
   },
   "PLT": {
-    "station_name": "Pontlottyn Rail Station",
+    "station_name": "Pontlottyn",
     "latitude": 51.7466343204,
     "longitude": -3.2789665322
   },
   "PLU": {
-    "station_name": "Plumstead Rail Station",
+    "station_name": "Plumstead",
     "latitude": 51.4897937032,
     "longitude": 0.0842834892
   },
   "PLW": {
-    "station_name": "Pollokshields West Rail Station",
+    "station_name": "Pollokshields West",
     "latitude": 55.8376933127,
     "longitude": -4.2757390394
   },
   "PLY": {
-    "station_name": "Plymouth Rail Station",
+    "station_name": "Plymouth",
     "latitude": 50.3778114758,
     "longitude": -4.1433494979
   },
   "PMA": {
-    "station_name": "Portsmouth Arms Rail Station",
+    "station_name": "Portsmouth Arms",
     "latitude": 50.9569944809,
     "longitude": -3.9506012138
   },
   "PMB": {
-    "station_name": "Pembroke Rail Station",
+    "station_name": "Pembroke",
     "latitude": 51.6729545258,
     "longitude": -4.9060582576
   },
   "PMD": {
-    "station_name": "Pembroke Dock Rail Station",
+    "station_name": "Pembroke Dock",
     "latitude": 51.693923213,
     "longitude": -4.9380817217
   },
@@ -8980,1372 +9040,1382 @@
     "longitude": -4.1268252563
   },
   "PMH": {
-    "station_name": "Portsmouth Harbour Rail Station",
+    "station_name": "Portsmouth Harbour",
     "latitude": 50.7969498727,
     "longitude": -1.1078273211
   },
   "PMP": {
-    "station_name": "Plumpton Rail Station",
+    "station_name": "Plumpton",
     "latitude": 50.9286565684,
     "longitude": -0.0601544007
   },
   "PMR": {
-    "station_name": "Peckham Rye Rail Station",
+    "station_name": "Peckham Rye",
     "latitude": 51.470033016,
     "longitude": -0.0693887302
   },
   "PMS": {
-    "station_name": "Portsmouth & Southsea Rail Station",
+    "station_name": "Portsmouth & Southsea",
     "latitude": 50.7984827623,
     "longitude": -1.0908977098
   },
   "PMT": {
-    "station_name": "Polmont Rail Station",
+    "station_name": "Polmont",
     "latitude": 55.9847314785,
     "longitude": -3.7149654171
   },
   "PMW": {
-    "station_name": "Penmaenmawr Rail Station",
+    "station_name": "Penmaenmawr",
     "latitude": 53.2704805077,
     "longitude": -3.9235150995
   },
   "PNA": {
-    "station_name": "Penally Rail Station",
+    "station_name": "Penally",
     "latitude": 51.6589262669,
     "longitude": -4.7220868534
   },
   "PNE": {
-    "station_name": "Penge East Rail Station",
+    "station_name": "Penge East",
     "latitude": 51.4193314862,
     "longitude": -0.0541945966
   },
   "PNF": {
-    "station_name": "Penyffordd Rail Station",
+    "station_name": "Penyffordd",
     "latitude": 53.1431032633,
     "longitude": -3.0548384851
   },
   "PNL": {
-    "station_name": "Pannal Rail Station",
+    "station_name": "Pannal",
     "latitude": 53.9583379183,
     "longitude": -1.5334728227
   },
   "PNM": {
-    "station_name": "Penmere Rail Station",
+    "station_name": "Penmere",
     "latitude": 50.1503163602,
     "longitude": -5.0832395818
   },
   "PNR": {
-    "station_name": "Penrith North Lakes Rail Station",
+    "station_name": "Penrith North Lakes",
     "latitude": 54.6618111812,
     "longitude": -2.7588851525
   },
   "PNS": {
-    "station_name": "Penistone Rail Station",
+    "station_name": "Penistone",
     "latitude": 53.5255620634,
     "longitude": -1.6227817865
   },
   "PNW": {
-    "station_name": "Penge West Rail Station",
+    "station_name": "Penge West",
     "latitude": 51.4175527378,
     "longitude": -0.060813969
   },
   "PNY": {
-    "station_name": "Pen-y-Bont Rail Station",
+    "station_name": "Pen-y-Bont",
     "latitude": 52.2739523227,
     "longitude": -3.3219364345
   },
   "PNZ": {
-    "station_name": "Penzance Rail Station",
+    "station_name": "Penzance",
     "latitude": 50.1216622978,
     "longitude": -5.5326194274
   },
   "POK": {
-    "station_name": "Pokesdown Rail Station",
+    "station_name": "Pokesdown",
     "latitude": 50.7310753298,
     "longitude": -1.8250944808
   },
   "POL": {
-    "station_name": "Polsloe Bridge Rail Station",
+    "station_name": "Polsloe Bridge",
     "latitude": 50.7312683809,
     "longitude": -3.5019615191
   },
   "PON": {
-    "station_name": "Ponders End Rail Station",
+    "station_name": "Ponders End",
     "latitude": 51.642255947,
     "longitude": -0.0350543162
   },
   "POO": {
-    "station_name": "Poole Rail Station",
+    "station_name": "Poole",
     "latitude": 50.7194165218,
     "longitude": -1.9833107381
   },
   "POP": {
-    "station_name": "Poppleton Rail Station",
+    "station_name": "Poppleton",
     "latitude": 53.9759137087,
     "longitude": -1.1486052224
   },
   "POR": {
-    "station_name": "Porth Rail Station",
+    "station_name": "Porth",
     "latitude": 51.6125376458,
     "longitude": -3.4071988908
   },
   "POT": {
-    "station_name": "Pontefract Tanshelf Rail Station",
+    "station_name": "Pontefract Tanshelf",
     "latitude": 53.6941449221,
     "longitude": -1.3189173719
   },
   "PPD": {
-    "station_name": "Pontypridd Rail Station",
+    "station_name": "Pontypridd",
     "latitude": 51.5993702973,
     "longitude": -3.3413865323
   },
   "PPK": {
-    "station_name": "Possilpark & Parkhouse Rail Station",
+    "station_name": "Possilpark & Parkhouse",
     "latitude": 55.8901379173,
     "longitude": -4.2584986291
   },
   "PPL": {
-    "station_name": "Pontypool & New Inn Rail Station",
+    "station_name": "Pontypool & New Inn",
     "latitude": 51.6979651222,
     "longitude": -3.0142431288
   },
   "PRA": {
-    "station_name": "Prestwick Intl Airport Rail Station",
+    "station_name": "Prestwick Intl Airport",
     "latitude": 55.5090345152,
     "longitude": -4.6141499438
   },
   "PRB": {
-    "station_name": "Prestbury Rail Station",
+    "station_name": "Prestbury",
     "latitude": 53.2933984529,
     "longitude": -2.1454808763
   },
   "PRE": {
-    "station_name": "Preston Rail Station",
+    "station_name": "Preston",
     "latitude": 53.7568736745,
     "longitude": -2.7081248286
   },
   "PRH": {
-    "station_name": "Penrhyndeudraeth Rail Station",
+    "station_name": "Penrhyndeudraeth",
     "latitude": 52.9288395107,
     "longitude": -4.0645697821
   },
   "PRL": {
-    "station_name": "Prittlewell Rail Station",
+    "station_name": "Prittlewell",
     "latitude": 51.5506897273,
     "longitude": 0.7107053733
   },
   "PRN": {
-    "station_name": "Parton Rail Station",
+    "station_name": "Parton",
     "latitude": 54.5703745223,
     "longitude": -3.5808010214
   },
   "PRP": {
-    "station_name": "Preston Park Rail Station",
+    "station_name": "Preston Park",
     "latitude": 50.8459365038,
     "longitude": -0.1551401939
   },
   "PRR": {
-    "station_name": "Princes Risborough Rail Station",
+    "station_name": "Princes Risborough",
     "latitude": 51.717862811,
     "longitude": -0.8438584339
   },
   "PRS": {
-    "station_name": "Prees Rail Station",
+    "station_name": "Prees",
     "latitude": 52.8993178144,
     "longitude": -2.6896604773
   },
   "PRT": {
-    "station_name": "Prestatyn Rail Station",
+    "station_name": "Prestatyn",
     "latitude": 53.3365131812,
     "longitude": -3.4071329997
   },
   "PRU": {
-    "station_name": "Prudhoe Rail Station",
+    "station_name": "Prudhoe",
     "latitude": 54.9658336963,
     "longitude": -1.8648762701
   },
   "PRW": {
-    "station_name": "Perranwell Rail Station",
+    "station_name": "Perranwell",
     "latitude": 50.2165660708,
     "longitude": -5.1121161477
   },
   "PRY": {
-    "station_name": "Perry Barr Rail Station",
+    "station_name": "Perry Barr",
     "latitude": 52.5164989542,
     "longitude": -1.9019553886
   },
   "PSC": {
-    "station_name": "Prescot Rail Station",
+    "station_name": "Prescot",
     "latitude": 53.4235727522,
     "longitude": -2.7991706418
   },
   "PSE": {
-    "station_name": "Pitsea Rail Station",
+    "station_name": "Pitsea",
     "latitude": 51.5603607427,
     "longitude": 0.5063210544
   },
   "PSH": {
-    "station_name": "Pershore Rail Station",
+    "station_name": "Pershore",
     "latitude": 52.1305654583,
     "longitude": -2.071529789
   },
   "PSL": {
-    "station_name": "Port Sunlight Rail Station",
+    "station_name": "Port Sunlight",
     "latitude": 53.3492661166,
     "longitude": -2.9980290994
   },
   "PSN": {
-    "station_name": "Parson Street Rail Station",
+    "station_name": "Parson Street",
     "latitude": 51.4333162228,
     "longitude": -2.6077452159
   },
   "PST": {
-    "station_name": "Prestonpans Rail Station",
+    "station_name": "Prestonpans",
     "latitude": 55.9530925088,
     "longitude": -2.9747721637
   },
   "PSW": {
-    "station_name": "Polesworth Rail Station",
+    "station_name": "Polesworth",
     "latitude": 52.6258478025,
     "longitude": -1.6105322867
   },
   "PTA": {
-    "station_name": "Port Talbot Parkway Rail Station",
+    "station_name": "Port Talbot Parkway",
     "latitude": 51.5917198989,
     "longitude": -3.7813309651
   },
   "PTB": {
-    "station_name": "Pentre-Bach Rail Station",
+    "station_name": "Pentre-Bach",
     "latitude": 51.7250170652,
     "longitude": -3.3623321925
   },
   "PTC": {
-    "station_name": "Portchester Rail Station",
+    "station_name": "Portchester",
     "latitude": 50.8487383979,
     "longitude": -1.1242258208
   },
   "PTD": {
-    "station_name": "Pontarddulais Rail Station",
+    "station_name": "Pontarddulais",
     "latitude": 51.717625303,
     "longitude": -4.0455653141
   },
   "PTF": {
-    "station_name": "Pantyffynnon Rail Station",
+    "station_name": "Pantyffynnon",
     "latitude": 51.7788828692,
     "longitude": -3.997449154
   },
   "PTG": {
-    "station_name": "Port Glasgow Rail Station",
+    "station_name": "Port Glasgow",
     "latitude": 55.9335070293,
     "longitude": -4.6898064686
   },
   "PTH": {
-    "station_name": "Perth Rail Station",
+    "station_name": "Perth",
     "latitude": 56.3920836665,
     "longitude": -3.439696225
   },
   "PTK": {
-    "station_name": "Partick Rail Station",
+    "station_name": "Partick",
     "latitude": 55.8698812708,
     "longitude": -4.3087915388
   },
   "PTL": {
-    "station_name": "Priesthill & Darnley Rail Station",
+    "station_name": "Priesthill & Darnley",
     "latitude": 55.8121655063,
     "longitude": -4.3428803656
   },
   "PTM": {
-    "station_name": "Porthmadog Rail Station",
+    "station_name": "Porthmadog",
     "latitude": 52.9309305535,
     "longitude": -4.1344534631
   },
   "PTR": {
-    "station_name": "Petersfield Rail Station",
+    "station_name": "Petersfield",
     "latitude": 51.0067187319,
     "longitude": -0.941119933
   },
   "PTT": {
-    "station_name": "Patterton Rail Station",
+    "station_name": "Patterton",
     "latitude": 55.7906049425,
     "longitude": -4.335284571
   },
   "PTW": {
-    "station_name": "Prestwick Rail Station",
+    "station_name": "Prestwick",
     "latitude": 55.5016967612,
     "longitude": -4.6151361015
   },
   "PUL": {
-    "station_name": "Pulborough Rail Station",
+    "station_name": "Pulborough",
     "latitude": 50.957350444,
     "longitude": -0.5165342741
   },
   "PUO": {
-    "station_name": "Purley Oaks Rail Station",
+    "station_name": "Purley Oaks",
     "latitude": 51.347043203,
     "longitude": -0.0988301854
   },
   "PUR": {
-    "station_name": "Purley Rail Station",
+    "station_name": "Purley",
     "latitude": 51.3375762777,
     "longitude": -0.1140096477
   },
   "PUT": {
-    "station_name": "Putney Rail Station",
+    "station_name": "Putney",
     "latitude": 51.4613011865,
     "longitude": -0.2164509784
   },
   "PWE": {
-    "station_name": "Pollokshaws East Rail Station",
+    "station_name": "Pollokshaws East",
     "latitude": 55.8246345854,
     "longitude": -4.2868710374
   },
   "PWL": {
-    "station_name": "Pwllheli Rail Station",
+    "station_name": "Pwllheli",
     "latitude": 52.8878498612,
     "longitude": -4.4167062643
   },
   "PWW": {
-    "station_name": "Pollokshaws West Rail Station",
+    "station_name": "Pollokshaws West",
     "latitude": 55.8238204955,
     "longitude": -4.3015915299
   },
   "PWY": {
-    "station_name": "Patchway Rail Station",
+    "station_name": "Patchway",
     "latitude": 51.5259301005,
     "longitude": -2.5626913928
   },
   "PYC": {
-    "station_name": "Pontyclun Rail Station",
+    "station_name": "Pontyclun",
     "latitude": 51.523767301,
     "longitude": -3.3929297459
   },
   "PYE": {
-    "station_name": "Pye Corner Rail Station",
+    "station_name": "Pye Corner",
     "latitude": 51.581475726,
     "longitude": -3.0412190166
   },
   "PYG": {
-    "station_name": "Paisley Gilmour Street Rail Station",
+    "station_name": "Paisley Gilmour Street",
     "latitude": 55.8473432284,
     "longitude": -4.4244912616
   },
   "PYJ": {
-    "station_name": "Paisley St James Rail Station",
+    "station_name": "Paisley St James",
     "latitude": 55.8521114555,
     "longitude": -4.4424274654
   },
   "PYL": {
-    "station_name": "Pyle Rail Station",
+    "station_name": "Pyle",
     "latitude": 51.5257356235,
     "longitude": -3.6980690341
   },
   "PYN": {
-    "station_name": "Penryn Rail Station",
+    "station_name": "Penryn",
     "latitude": 50.1706984329,
     "longitude": -5.111654776
   },
   "PYP": {
-    "station_name": "Pont-y-Pant Rail Station",
+    "station_name": "Pont-y-Pant",
     "latitude": 53.0651459792,
     "longitude": -3.8627254729
   },
   "PYT": {
-    "station_name": "Poynton Rail Station",
+    "station_name": "Poynton",
     "latitude": 53.350399608,
     "longitude": -2.1344099238
   },
   "QBR": {
-    "station_name": "Queenborough Rail Station",
+    "station_name": "Queenborough",
     "latitude": 51.4156380311,
     "longitude": 0.7496958334
   },
   "QPK": {
-    "station_name": "Queens Park (Glasgow) Rail Station",
+    "station_name": "Queens Park (Glasgow)",
     "latitude": 55.8352982505,
     "longitude": -4.26673566
   },
   "QPW": {
-    "station_name": "Queens Park (London) Rail Station",
+    "station_name": "Queens Park (London)",
     "latitude": 51.5339663794,
     "longitude": -0.2049603036
   },
   "QRB": {
-    "station_name": "Queenstown Road (Battersea) Rail Station",
+    "station_name": "Queenstown Road (Battersea)",
     "latitude": 51.4749670081,
     "longitude": -0.146653366
   },
   "QRP": {
-    "station_name": "Queens Road Peckham Rail Station",
+    "station_name": "Queens Road Peckham",
     "latitude": 51.4735650429,
     "longitude": -0.057287956
   },
   "QUI": {
-    "station_name": "Quintrell Downs Rail Station",
+    "station_name": "Quintrell Downs",
     "latitude": 50.404043309,
     "longitude": -5.0285359493
   },
   "QYD": {
-    "station_name": "Quakers Yard Rail Station",
+    "station_name": "Quakers Yard",
     "latitude": 51.6607282285,
     "longitude": -3.3228133757
   },
   "RAD": {
-    "station_name": "Radley Rail Station",
+    "station_name": "Radley",
     "latitude": 51.6862085244,
     "longitude": -1.2404640226
   },
   "RAI": {
-    "station_name": "Rainham (Kent) Rail Station",
+    "station_name": "Rainham (Kent)",
     "latitude": 51.3663043788,
     "longitude": 0.6113657109
   },
   "RAM": {
-    "station_name": "Ramsgate Rail Station",
+    "station_name": "Ramsgate",
     "latitude": 51.3408101248,
     "longitude": 1.4064935542
   },
   "RAN": {
-    "station_name": "Rannoch Rail Station",
+    "station_name": "Rannoch",
     "latitude": 56.6860287779,
     "longitude": -4.5768596363
   },
   "RAU": {
-    "station_name": "Rauceby Rail Station",
+    "station_name": "Rauceby",
     "latitude": 52.9852250505,
     "longitude": -0.4566002495
   },
   "RAV": {
-    "station_name": "Ravenglass Rail Station",
+    "station_name": "Ravenglass",
     "latitude": 54.355714451,
     "longitude": -3.4088152992
   },
   "RAY": {
-    "station_name": "Raynes Park Rail Station",
+    "station_name": "Raynes Park",
     "latitude": 51.4091709872,
     "longitude": -0.2301271492
   },
   "RBR": {
-    "station_name": "Robertsbridge Rail Station",
+    "station_name": "Robertsbridge",
     "latitude": 50.9849282663,
     "longitude": 0.468811527
   },
   "RBS": {
-    "station_name": "British Steel Redcar Rail Station",
+    "station_name": "British Steel Redcar",
     "latitude": 54.6099002966,
     "longitude": -1.1126759256
   },
   "RBU": {
-    "station_name": "Reading Rail Station",
+    "station_name": "Reading",
     "latitude": 51.4581455251,
     "longitude": -0.9716410129
   },
   "RCA": {
-    "station_name": "Risca & Pontymister Rail Station",
+    "station_name": "Risca & Pontymister",
     "latitude": 51.6058480469,
     "longitude": -3.0922175896
   },
   "RCC": {
-    "station_name": "Redcar Central Rail Station",
+    "station_name": "Redcar Central",
     "latitude": 54.6162371859,
     "longitude": -1.0708827236
   },
   "RCD": {
-    "station_name": "Rochdale Rail Station",
+    "station_name": "Rochdale",
     "latitude": 53.6103213876,
     "longitude": -2.1535226045
   },
   "RCE": {
-    "station_name": "Redcar East Rail Station",
+    "station_name": "Redcar East",
     "latitude": 54.6092632648,
     "longitude": -1.0523074152
   },
   "RDA": {
-    "station_name": "Redland Rail Station",
+    "station_name": "Redland",
     "latitude": 51.4683833784,
     "longitude": -2.5991255269
   },
   "RDB": {
-    "station_name": "Redbridge (Hants) Rail Station",
+    "station_name": "Redbridge (Hants)",
     "latitude": 50.919929763,
     "longitude": -1.4701514648
   },
   "RDC": {
-    "station_name": "Redditch Rail Station",
+    "station_name": "Redditch",
     "latitude": 52.3063386466,
     "longitude": -1.9452414363
   },
   "RDD": {
-    "station_name": "Riddlesdown Rail Station",
+    "station_name": "Riddlesdown",
     "latitude": 51.3324835004,
     "longitude": -0.0993606073
   },
   "RDF": {
-    "station_name": "Radcliffe (Notts) Rail Station",
+    "station_name": "Radcliffe (Notts)",
     "latitude": 52.948803948,
     "longitude": -1.0373248467
   },
   "RDG": {
-    "station_name": "Reading Rail Station",
+    "station_name": "Reading",
     "latitude": 51.4587857311,
     "longitude": -0.9718425502
   },
   "RDH": {
-    "station_name": "Redhill Rail Station",
+    "station_name": "Redhill",
     "latitude": 51.2401977624,
     "longitude": -0.1658743282
   },
   "RDM": {
-    "station_name": "Riding Mill Rail Station",
+    "station_name": "Riding Mill",
     "latitude": 54.9487414454,
     "longitude": -1.9715645429
   },
   "RDN": {
-    "station_name": "Reddish North Rail Station",
+    "station_name": "Reddish North",
     "latitude": 53.4494263145,
     "longitude": -2.1562533084
   },
   "RDR": {
-    "station_name": "Radyr Rail Station",
+    "station_name": "Radyr",
     "latitude": 51.5163222796,
     "longitude": -3.2483627755
   },
   "RDS": {
-    "station_name": "Reddish South Rail Station",
+    "station_name": "Reddish South",
     "latitude": 53.4359402108,
     "longitude": -2.15876271
   },
   "RDT": {
-    "station_name": "Radlett Rail Station",
+    "station_name": "Radlett",
     "latitude": 51.6851911564,
     "longitude": -0.3172197627
   },
   "RDW": {
-    "station_name": "Reading West Rail Station",
+    "station_name": "Reading West",
     "latitude": 51.4555007173,
     "longitude": -0.9901085456
   },
   "REC": {
-    "station_name": "Rectory Road Rail Station",
+    "station_name": "Rectory Road",
     "latitude": 51.5585021691,
     "longitude": -0.0682408077
   },
   "RED": {
-    "station_name": "Redruth Rail Station",
+    "station_name": "Redruth",
     "latitude": 50.2332412948,
     "longitude": -5.2259636066
   },
   "REE": {
-    "station_name": "Reedham (Norfolk) Rail Station",
+    "station_name": "Reedham (Norfolk)",
     "latitude": 52.5645273067,
     "longitude": 1.5596750305
   },
   "REI": {
-    "station_name": "Reigate Rail Station",
+    "station_name": "Reigate",
     "latitude": 51.241955247,
     "longitude": -0.2037998793
   },
   "REL": {
-    "station_name": "Retford Low Level Rail Station",
+    "station_name": "Retford Low Level",
     "latitude": 53.314084796,
     "longitude": -0.944772788
   },
   "RET": {
-    "station_name": "Retford Rail Station",
+    "station_name": "Retford",
     "latitude": 53.3151729691,
     "longitude": -0.9478832051
   },
   "RFD": {
-    "station_name": "Rochford Rail Station",
+    "station_name": "Rochford",
     "latitude": 51.5817322678,
     "longitude": 0.7023320206
   },
   "RFY": {
-    "station_name": "Rock Ferry Rail Station",
+    "station_name": "Rock Ferry",
     "latitude": 53.3726649286,
     "longitude": -3.0108263238
   },
   "RGL": {
-    "station_name": "Rugeley Trent Valley Rail Station",
+    "station_name": "Rugeley Trent Valley",
     "latitude": 52.7696708266,
     "longitude": -1.9298468285
   },
   "RGT": {
-    "station_name": "Rugeley Town Rail Station",
+    "station_name": "Rugeley Town",
     "latitude": 52.7543925458,
     "longitude": -1.9368345411
   },
   "RGW": {
-    "station_name": "Ramsgreave & Wilpshire Rail Station",
+    "station_name": "Ramsgreave & Wilpshire",
     "latitude": 53.7797887472,
     "longitude": -2.4781340362
   },
   "RHD": {
-    "station_name": "Ribblehead Rail Station",
+    "station_name": "Ribblehead",
     "latitude": 54.2058547832,
     "longitude": -2.3608596376
   },
   "RHI": {
-    "station_name": "Rhiwbina Rail Station",
+    "station_name": "Rhiwbina",
     "latitude": 51.5211795118,
     "longitude": -3.2139748912
   },
   "RHL": {
-    "station_name": "Rhyl Rail Station",
+    "station_name": "Rhyl",
     "latitude": 53.3184382534,
     "longitude": -3.4891071986
   },
   "RHM": {
-    "station_name": "Reedham (Surrey) Rail Station",
+    "station_name": "Reedham (Surrey)",
     "latitude": 51.3311168831,
     "longitude": -0.1233901081
   },
   "RHO": {
-    "station_name": "Rhosneigr Rail Station",
+    "station_name": "Rhosneigr",
     "latitude": 53.234853792,
     "longitude": -4.5066484672
   },
   "RHY": {
-    "station_name": "Rhymney Rail Station",
+    "station_name": "Rhymney",
     "latitude": 51.7588400163,
     "longitude": -3.2893087685
   },
   "RIA": {
-    "station_name": "Rhoose Rail Station",
+    "station_name": "Rhoose",
     "latitude": 51.3870636406,
     "longitude": -3.3493952024
   },
   "RIC": {
-    "station_name": "Rickmansworth Rail Station",
+    "station_name": "Rickmansworth",
     "latitude": 51.6402484957,
     "longitude": -0.4732613263
   },
   "RID": {
-    "station_name": "Ridgmont Rail Station",
+    "station_name": "Ridgmont",
     "latitude": 52.0264115351,
     "longitude": -0.5945346786
   },
   "RIL": {
-    "station_name": "Rice Lane Rail Station",
+    "station_name": "Rice Lane",
     "latitude": 53.4577855134,
     "longitude": -2.9623176912
   },
   "RIS": {
-    "station_name": "Rishton Rail Station",
+    "station_name": "Rishton",
     "latitude": 53.7638280488,
     "longitude": -2.4201573255
   },
   "RKT": {
-    "station_name": "Ruskington Rail Station",
+    "station_name": "Ruskington",
     "latitude": 53.0414843853,
     "longitude": -0.3807571306
   },
   "RLG": {
-    "station_name": "Rayleigh Rail Station",
+    "station_name": "Rayleigh",
     "latitude": 51.5892966358,
     "longitude": 0.6000099485
   },
   "RLN": {
-    "station_name": "Rowlands Castle Rail Station",
+    "station_name": "Rowlands Castle",
     "latitude": 50.8921618565,
     "longitude": -0.9574550113
   },
   "RMB": {
-    "station_name": "Roman Bridge Rail Station",
+    "station_name": "Roman Bridge",
     "latitude": 53.0444294912,
     "longitude": -3.9216535234
   },
   "RMC": {
-    "station_name": "Rotherham Central Rail Station",
+    "station_name": "Rotherham Central",
     "latitude": 53.4322702249,
     "longitude": -1.3604360441
   },
   "RMD": {
-    "station_name": "Richmond (London) Rail Station",
+    "station_name": "Richmond (London)",
     "latitude": 51.4630586084,
     "longitude": -0.3015359438
   },
   "RMF": {
-    "station_name": "Romford Rail Station",
+    "station_name": "Romford",
     "latitude": 51.5748295085,
     "longitude": 0.1832643102
   },
   "RML": {
-    "station_name": "Romiley Rail Station",
+    "station_name": "Romiley",
     "latitude": 53.4140264045,
     "longitude": -2.0893251906
   },
   "RNF": {
-    "station_name": "Rainford Rail Station",
+    "station_name": "Rainford",
     "latitude": 53.5171200074,
     "longitude": -2.7894686817
   },
   "RNH": {
-    "station_name": "Rainhill Rail Station",
+    "station_name": "Rainhill",
     "latitude": 53.4171359422,
     "longitude": -2.7663996705
   },
   "RNM": {
-    "station_name": "Rainham (London) Rail Station",
+    "station_name": "Rainham (London)",
     "latitude": 51.5167228766,
     "longitude": 0.1906626283
   },
   "RNR": {
-    "station_name": "Roughton Road Rail Station",
+    "station_name": "Roughton Road",
     "latitude": 52.9180468243,
     "longitude": 1.2998131699
   },
   "ROB": {
-    "station_name": "Roby Rail Station",
+    "station_name": "Roby",
     "latitude": 53.4100553223,
     "longitude": -2.8559333314
   },
   "ROC": {
-    "station_name": "Roche Rail Station",
+    "station_name": "Roche",
     "latitude": 50.4185298804,
     "longitude": -4.8302395116
   },
   "ROE": {
-    "station_name": "Rotherhithe Rail Station",
+    "station_name": "Rotherhithe",
     "latitude": 51.5008159021,
     "longitude": -0.0520222921
   },
   "ROG": {
-    "station_name": "Rogart Rail Station",
+    "station_name": "Rogart",
     "latitude": 57.9886951233,
     "longitude": -4.1581880614
   },
   "ROL": {
-    "station_name": "Rolleston Rail Station",
+    "station_name": "Rolleston",
     "latitude": 53.0653022003,
     "longitude": -0.8996705436
   },
   "ROM": {
-    "station_name": "Romsey Rail Station",
+    "station_name": "Romsey",
     "latitude": 50.992520078,
     "longitude": -1.4931337195
   },
   "ROO": {
-    "station_name": "Roose Rail Station",
+    "station_name": "Roose",
     "latitude": 54.115171803,
     "longitude": -3.1945656127
   },
   "ROR": {
-    "station_name": "Rogerstone Rail Station",
+    "station_name": "Rogerstone",
     "latitude": 51.595617413,
     "longitude": -3.0666186229
   },
   "ROS": {
-    "station_name": "Rosyth Rail Station",
+    "station_name": "Rosyth",
     "latitude": 56.0455112188,
     "longitude": -3.4273031727
   },
   "ROW": {
-    "station_name": "Rowley Regis Rail Station",
+    "station_name": "Rowley Regis",
     "latitude": 52.4773392229,
     "longitude": -2.0308690726
   },
   "RRB": {
-    "station_name": "Ryder Brow Rail Station",
+    "station_name": "Ryder Brow",
     "latitude": 53.4565936753,
     "longitude": -2.1730866723
   },
+  "RRN":{
+    "station_name":"Robroyston",
+    "latitude":55.887581,
+    "longitude": -4.172291
+  },
   "RSG": {
-    "station_name": "Rose Grove Rail Station",
+    "station_name": "Rose Grove",
     "latitude": 53.786206105,
     "longitude": -2.2827968156
   },
+  "RSN": {
+    "station_name": "Reston",
+    "latitude": 55.8506,
+    "longitude": -2.1972
+  },
   "RSH": {
-    "station_name": "Rose Hill Marple Rail Station",
+    "station_name": "Rose Hill Marple",
     "latitude": 53.3962378581,
     "longitude": -2.0765205539
   },
   "RTN": {
-    "station_name": "Renton Rail Station",
+    "station_name": "Renton",
     "latitude": 55.9704230841,
     "longitude": -4.5861084015
   },
   "RTR": {
-    "station_name": "Rochester Rail Station",
+    "station_name": "Rochester",
     "latitude": 51.385547102,
     "longitude": 0.5103102845
   },
   "RUA": {
-    "station_name": "Ruabon Rail Station",
+    "station_name": "Ruabon",
     "latitude": 52.9871483927,
     "longitude": -3.0431380968
   },
   "RUE": {
-    "station_name": "Runcorn East Rail Station",
+    "station_name": "Runcorn East",
     "latitude": 53.3275817336,
     "longitude": -2.6656977069
   },
   "RUF": {
-    "station_name": "Rufford Rail Station",
+    "station_name": "Rufford",
     "latitude": 53.6344771165,
     "longitude": -2.8078404066
   },
   "RUG": {
-    "station_name": "Rugby Rail Station",
+    "station_name": "Rugby",
     "latitude": 52.379109602,
     "longitude": -1.2504711992
   },
   "RUN": {
-    "station_name": "Runcorn Rail Station",
+    "station_name": "Runcorn",
     "latitude": 53.3387090613,
     "longitude": -2.7392524151
   },
   "RUS": {
-    "station_name": "Ruswarp Rail Station",
+    "station_name": "Ruswarp",
     "latitude": 54.4702038934,
     "longitude": -0.6277880896
   },
   "RUT": {
-    "station_name": "Rutherglen Rail Station",
+    "station_name": "Rutherglen",
     "latitude": 55.8305867225,
     "longitude": -4.2120903916
   },
   "RVB": {
-    "station_name": "Ravensbourne Rail Station",
+    "station_name": "Ravensbourne",
     "latitude": 51.4141860649,
     "longitude": -0.0075306056
   },
   "RVN": {
-    "station_name": "Ravensthorpe Rail Station",
+    "station_name": "Ravensthorpe",
     "latitude": 53.6755379752,
     "longitude": -1.6555824307
   },
   "RWC": {
-    "station_name": "Rawcliffe Rail Station",
+    "station_name": "Rawcliffe",
     "latitude": 53.689059382,
     "longitude": -0.9608672824
   },
   "RYB": {
-    "station_name": "Roy Bridge Rail Station",
+    "station_name": "Roy Bridge",
     "latitude": 56.8883464006,
     "longitude": -4.837231331
   },
   "RYD": {
-    "station_name": "Ryde Esplanade Rail Station",
+    "station_name": "Ryde Esplanade",
     "latitude": 50.732855472,
     "longitude": -1.1596052649
   },
   "RYE": {
-    "station_name": "Rye Rail Station",
+    "station_name": "Rye",
     "latitude": 50.9523651368,
     "longitude": 0.7307262415
   },
   "RYH": {
-    "station_name": "Rye House Rail Station",
+    "station_name": "Rye House",
     "latitude": 51.7694168549,
     "longitude": 0.0056554285
   },
   "RYN": {
-    "station_name": "Roydon Rail Station",
+    "station_name": "Roydon",
     "latitude": 51.7754907565,
     "longitude": 0.0362787847
   },
   "RYP": {
-    "station_name": "Ryde Pier Head Rail Station",
+    "station_name": "Ryde Pier Head",
     "latitude": 50.7391721946,
     "longitude": -1.160115731
   },
   "RYR": {
-    "station_name": "Ryde St Johns Road Rail Station",
+    "station_name": "Ryde St Johns Road",
     "latitude": 50.7243531538,
     "longitude": -1.1565554546
   },
   "RYS": {
-    "station_name": "Royston Rail Station",
+    "station_name": "Royston",
     "latitude": 52.0530886425,
     "longitude": -0.0268926227
   },
   "SAA": {
-    "station_name": "St Albans Abbey Rail Station",
+    "station_name": "St Albans Abbey",
     "latitude": 51.7447373797,
     "longitude": -0.3425457907
   },
   "SAB": {
-    "station_name": "Smallbrook Junction Rail Station",
+    "station_name": "Smallbrook Junction",
     "latitude": 50.7110892621,
     "longitude": -1.1541879058
   },
   "SAC": {
-    "station_name": "St Albans City Rail Station",
+    "station_name": "St Albans City",
     "latitude": 51.7504771115,
     "longitude": -0.3275149609
   },
   "SAD": {
-    "station_name": "Sandwell & Dudley Rail Station",
+    "station_name": "Sandwell & Dudley",
     "latitude": 52.508672806,
     "longitude": -2.0115900516
   },
   "SAE": {
-    "station_name": "Saltaire Rail Station",
+    "station_name": "Saltaire",
     "latitude": 53.8385061525,
     "longitude": -1.7904830974
   },
   "SAF": {
-    "station_name": "Salfords (Surrey) Rail Station",
+    "station_name": "Salfords (Surrey)",
     "latitude": 51.2017437324,
     "longitude": -0.1624625843
   },
   "SAH": {
-    "station_name": "Salhouse Rail Station",
+    "station_name": "Salhouse",
     "latitude": 52.6755989185,
     "longitude": 1.3914382836
   },
   "SAJ": {
-    "station_name": "St Johns (London) Rail Station",
+    "station_name": "St Johns (London)",
     "latitude": 51.4693892196,
     "longitude": -0.0226931111
   },
   "SAL": {
-    "station_name": "Salisbury Rail Station",
+    "station_name": "Salisbury",
     "latitude": 51.0705407298,
     "longitude": -1.8063773738
   },
   "SAM": {
-    "station_name": "Saltmarshe Rail Station",
+    "station_name": "Saltmarshe",
     "latitude": 53.721943052,
     "longitude": -0.8094903376
   },
   "SAN": {
-    "station_name": "Sandown Rail Station",
+    "station_name": "Sandown",
     "latitude": 50.6568577497,
     "longitude": -1.1623772447
   },
   "SAR": {
-    "station_name": "St Andrews Road Rail Station",
+    "station_name": "St Andrews Road",
     "latitude": 51.5127676823,
     "longitude": -2.6963176571
   },
   "SAS": {
-    "station_name": "St Annes-on-the-Sea Rail Station",
+    "station_name": "St Annes-on-the-Sea",
     "latitude": 53.7530450492,
     "longitude": -3.0290965047
   },
   "SAT": {
-    "station_name": "South Acton Rail Station",
+    "station_name": "South Acton",
     "latitude": 51.4996944038,
     "longitude": -0.2701346279
   },
   "SAU": {
-    "station_name": "St Austell Rail Station",
+    "station_name": "St Austell",
     "latitude": 50.3395021406,
     "longitude": -4.7894011447
   },
   "SAV": {
-    "station_name": "Stratford-upon-Avon Rail Station",
+    "station_name": "Stratford-upon-Avon",
     "latitude": 52.1942606452,
     "longitude": -1.7162794479
   },
   "SAW": {
-    "station_name": "Sawbridgeworth Rail Station",
+    "station_name": "Sawbridgeworth",
     "latitude": 51.8143528887,
     "longitude": 0.1604379052
   },
   "SAX": {
-    "station_name": "Saxmundham Rail Station",
+    "station_name": "Saxmundham",
     "latitude": 52.2149132591,
     "longitude": 1.4901964806
   },
   "SAY": {
-    "station_name": "Swanley Rail Station",
+    "station_name": "Swanley",
     "latitude": 51.3933848234,
     "longitude": 0.1692513064
   },
   "SBE": {
-    "station_name": "Starbeck Rail Station",
+    "station_name": "Starbeck",
     "latitude": 53.9990126023,
     "longitude": -1.5011353743
   },
   "SBF": {
-    "station_name": "St Budeaux Ferry Road Rail Station",
+    "station_name": "St Budeaux Ferry Road",
     "latitude": 50.4013767558,
     "longitude": -4.1868416838
   },
   "SBJ": {
-    "station_name": "Stourbridge Junction Rail Station",
+    "station_name": "Stourbridge Junction",
     "latitude": 52.4475544797,
     "longitude": -2.1338704963
   },
   "SBK": {
-    "station_name": "South Bank Rail Station",
+    "station_name": "South Bank",
     "latitude": 54.5838411607,
     "longitude": -1.1766809553
   },
   "SBM": {
-    "station_name": "South Bermondsey Rail Station",
+    "station_name": "South Bermondsey",
     "latitude": 51.4881347391,
     "longitude": -0.0546518416
   },
   "SBP": {
-    "station_name": "Stonebridge Park Rail Station",
+    "station_name": "Stonebridge Park",
     "latitude": 51.5441109985,
     "longitude": -0.2758051183
   },
   "SBR": {
-    "station_name": "Spean Bridge Rail Station",
+    "station_name": "Spean Bridge",
     "latitude": 56.889995674,
     "longitude": -4.921595255
   },
   "SBS": {
-    "station_name": "St Bees Rail Station",
+    "station_name": "St Bees",
     "latitude": 54.4925405036,
     "longitude": -3.5911492633
   },
   "SBT": {
-    "station_name": "Stourbridge Town Rail Station",
+    "station_name": "Stourbridge Town",
     "latitude": 52.455591256,
     "longitude": -2.1418120086
   },
   "SBU": {
-    "station_name": "Southbury Rail Station",
+    "station_name": "Southbury",
     "latitude": 51.6487058202,
     "longitude": -0.0524104286
   },
   "SBV": {
-    "station_name": "St Budeaux Victoria Road Rail Station",
+    "station_name": "St Budeaux Victoria Road",
     "latitude": 50.4019952477,
     "longitude": -4.1874330909
   },
   "SBY": {
-    "station_name": "Selby Rail Station",
+    "station_name": "Selby",
     "latitude": 53.7828026439,
     "longitude": -1.063791006
   },
   "SCA": {
-    "station_name": "Scarborough Rail Station",
+    "station_name": "Scarborough",
     "latitude": 54.2798078946,
     "longitude": -0.4057198208
   },
   "SCF": {
-    "station_name": "Stechford Rail Station",
+    "station_name": "Stechford",
     "latitude": 52.4848336609,
     "longitude": -1.81101967
   },
   "SCG": {
-    "station_name": "Stone Crossing Rail Station",
+    "station_name": "Stone Crossing",
     "latitude": 51.4513283183,
     "longitude": 0.2637992585
   },
   "SCH": {
-    "station_name": "Scotstounhill Rail Station",
+    "station_name": "Scotstounhill",
     "latitude": 55.88513372,
     "longitude": -4.3528726659
   },
   "SCR": {
-    "station_name": "St Columb Road Rail Station",
+    "station_name": "St Columb Road",
     "latitude": 50.3986945398,
     "longitude": -4.9407987491
   },
   "SCS": {
-    "station_name": "Starcross Rail Station",
+    "station_name": "Starcross",
     "latitude": 50.6277843819,
     "longitude": -3.4477177832
   },
   "SCT": {
-    "station_name": "Scotscalder Rail Station",
+    "station_name": "Scotscalder",
     "latitude": 58.4829756671,
     "longitude": -3.5520574676
   },
   "SCU": {
-    "station_name": "Scunthorpe Rail Station",
+    "station_name": "Scunthorpe",
     "latitude": 53.5861949288,
     "longitude": -0.6509843133
   },
   "SCY": {
-    "station_name": "South Croydon Rail Station",
+    "station_name": "South Croydon",
     "latitude": 51.3629626314,
     "longitude": -0.0934308139
   },
   "SDA": {
-    "station_name": "Snodland Rail Station",
+    "station_name": "Snodland",
     "latitude": 51.3302285584,
     "longitude": 0.4482700817
   },
   "SDB": {
-    "station_name": "Sandbach Rail Station",
+    "station_name": "Sandbach",
     "latitude": 53.1501833523,
     "longitude": -2.3935053074
   },
   "SDC": {
-    "station_name": "Shoreditch High Street Rail Station",
+    "station_name": "Shoreditch High Street",
     "latitude": 51.5233750963,
     "longitude": -0.0752198072
   },
   "SDE": {
-    "station_name": "Shadwell Rail Station",
+    "station_name": "Shadwell",
     "latitude": 51.5112835169,
     "longitude": -0.0569079056
   },
   "SDF": {
-    "station_name": "Saundersfoot Rail Station",
+    "station_name": "Saundersfoot",
     "latitude": 51.7220987761,
     "longitude": -4.7166131873
   },
   "SDG": {
-    "station_name": "Sandling Rail Station",
+    "station_name": "Sandling",
     "latitude": 51.09037099,
     "longitude": 1.0660749872
   },
   "SDH": {
-    "station_name": "Sudbury Hill Harrow Rail Station",
+    "station_name": "Sudbury Hill Harrow",
     "latitude": 51.558465264,
     "longitude": -0.3357809724
   },
   "SDL": {
-    "station_name": "Sandhills Rail Station",
+    "station_name": "Sandhills",
     "latitude": 53.4299516422,
     "longitude": -2.9914899197
   },
   "SDM": {
-    "station_name": "Shieldmuir Rail Station",
+    "station_name": "Shieldmuir",
     "latitude": 55.7774860976,
     "longitude": -3.9569803961
   },
   "SDN": {
-    "station_name": "St Denys Rail Station",
+    "station_name": "St Denys",
     "latitude": 50.9221787802,
     "longitude": -1.3877499436
   },
   "SDP": {
-    "station_name": "Sandplace Rail Station",
+    "station_name": "Sandplace",
     "latitude": 50.3867379699,
     "longitude": -4.4645157634
   },
   "SDR": {
-    "station_name": "Saunderton Rail Station",
+    "station_name": "Saunderton",
     "latitude": 51.6759048289,
     "longitude": -0.8254472358
   },
   "SDW": {
-    "station_name": "Sandwich Rail Station",
+    "station_name": "Sandwich",
     "latitude": 51.2699092555,
     "longitude": 1.3425965892
   },
   "SDY": {
-    "station_name": "Sandy Rail Station",
+    "station_name": "Sandy",
     "latitude": 52.1247435871,
     "longitude": -0.281167619
   },
   "SEA": {
-    "station_name": "Seaham Rail Station",
+    "station_name": "Seaham",
     "latitude": 54.839061911,
     "longitude": -1.3463511926
   },
   "SEB": {
-    "station_name": "Seaburn Rail Station",
+    "station_name": "Seaburn",
     "latitude": 54.929542046,
     "longitude": -1.3867070759
   },
   "SEC": {
-    "station_name": "Seaton Carew Rail Station",
+    "station_name": "Seaton Carew",
     "latitude": 54.6583208071,
     "longitude": -1.2004437475
   },
   "SED": {
-    "station_name": "Shelford (Cambs) Rail Station",
+    "station_name": "Shelford (Cambs)",
     "latitude": 52.1488379665,
     "longitude": 0.1400093409
   },
   "SEE": {
-    "station_name": "Southease Rail Station",
+    "station_name": "Southease",
     "latitude": 50.8312579508,
     "longitude": 0.0306695579
   },
   "SEF": {
-    "station_name": "Seaford Rail Station",
+    "station_name": "Seaford",
     "latitude": 50.7728366774,
     "longitude": 0.100161285
   },
   "SEG": {
-    "station_name": "Selling Rail Station",
+    "station_name": "Selling",
     "latitude": 51.2773559024,
     "longitude": 0.9409001439
   },
   "SEH": {
-    "station_name": "Shoreham (Kent) Rail Station",
+    "station_name": "Shoreham (Kent)",
     "latitude": 51.3322156624,
     "longitude": 0.1889169828
   },
   "SEL": {
-    "station_name": "Sellafield Rail Station",
+    "station_name": "Sellafield",
     "latitude": 54.4165930704,
     "longitude": -3.5104560059
   },
   "SEM": {
-    "station_name": "Seamer Rail Station",
+    "station_name": "Seamer",
     "latitude": 54.2407682264,
     "longitude": -0.4170454656
   },
   "SEN": {
-    "station_name": "Shenstone Rail Station",
+    "station_name": "Shenstone",
     "latitude": 52.6393741914,
     "longitude": -1.8441949254
   },
   "SER": {
-    "station_name": "St Erth Rail Station",
+    "station_name": "St Erth",
     "latitude": 50.1704799545,
     "longitude": -5.4443040887
   },
   "SES": {
-    "station_name": "South Elmsall Rail Station",
+    "station_name": "South Elmsall",
     "latitude": 53.594624192,
     "longitude": -1.2848611415
   },
   "SET": {
-    "station_name": "Settle Rail Station",
+    "station_name": "Settle",
     "latitude": 54.0669251994,
     "longitude": -2.2807172129
   },
   "SEV": {
-    "station_name": "Sevenoaks Rail Station",
+    "station_name": "Sevenoaks",
     "latitude": 51.2768624115,
     "longitude": 0.1816963041
   },
   "SFA": {
-    "station_name": "Stratford International Rail Station",
+    "station_name": "Stratford International",
     "latitude": 51.5448283609,
     "longitude": -0.0087499388
   },
   "SFD": {
-    "station_name": "Salford Central Rail Station",
+    "station_name": "Salford Central",
     "latitude": 53.4830977645,
     "longitude": -2.2548383451
   },
   "SFI": {
-    "station_name": "Shawfair Rail Station",
+    "station_name": "Shawfair",
     "latitude": 55.9199329881,
     "longitude": -3.0787162657
   },
   "SFL": {
-    "station_name": "Seaforth & Litherland Rail Station",
+    "station_name": "Seaforth & Litherland",
     "latitude": 53.4662829283,
     "longitude": -3.0056221352
   },
   "SFN": {
-    "station_name": "Shifnal Rail Station",
+    "station_name": "Shifnal",
     "latitude": 52.6660843703,
     "longitude": -2.3718373899
   },
   "SFO": {
-    "station_name": "Stanford-le-Hope Rail Station",
+    "station_name": "Stanford-le-Hope",
     "latitude": 51.5143632423,
     "longitude": 0.4230666756
   },
   "SFR": {
-    "station_name": "Shalford (Surrey) Rail Station",
+    "station_name": "Shalford (Surrey)",
     "latitude": 51.2143177182,
     "longitude": -0.5667825878
   },
   "SGB": {
-    "station_name": "Smethwick Galton Bridge Rail Station",
+    "station_name": "Smethwick Galton Bridge",
     "latitude": 52.5017945032,
     "longitude": -1.9805048854
   },
   "SGL": {
-    "station_name": "South Gyle Rail Station",
+    "station_name": "South Gyle",
     "latitude": 55.9363467134,
     "longitude": -3.2994753799
   },
   "SGM": {
-    "station_name": "St Germans Rail Station",
+    "station_name": "St Germans",
     "latitude": 50.3942591741,
     "longitude": -4.3084363092
   },
   "SGN": {
-    "station_name": "South Greenford Rail Station",
+    "station_name": "South Greenford",
     "latitude": 51.5337487794,
     "longitude": -0.3366818438
   },
   "SGR": {
-    "station_name": "Slade Green Rail Station",
+    "station_name": "Slade Green",
     "latitude": 51.4677848035,
     "longitude": 0.19051795
   },
   "SHB": {
-    "station_name": "Shirebrook Rail Station",
+    "station_name": "Shirebrook",
     "latitude": 53.20425967,
     "longitude": -1.2024390578
   },
   "SHC": {
-    "station_name": "Streethouse Rail Station",
+    "station_name": "Streethouse",
     "latitude": 53.6761699951,
     "longitude": -1.4001215054
   },
   "SHD": {
-    "station_name": "Shildon Rail Station",
+    "station_name": "Shildon",
     "latitude": 54.6261726082,
     "longitude": -1.6366159332
   },
   "SHE": {
-    "station_name": "Sherborne Rail Station",
+    "station_name": "Sherborne",
     "latitude": 50.9440137558,
     "longitude": -2.5130735512
   },
   "SHF": {
-    "station_name": "Sheffield Rail Station",
+    "station_name": "Sheffield",
     "latitude": 53.3782362148,
     "longitude": -1.4621101656
   },
   "SHH": {
-    "station_name": "Shirehampton Rail Station",
+    "station_name": "Shirehampton",
     "latitude": 51.4843469177,
     "longitude": -2.6792781047
   },
   "SHI": {
-    "station_name": "Shiplake Rail Station",
+    "station_name": "Shiplake",
     "latitude": 51.5114625615,
     "longitude": -0.8825832762
   },
   "SHJ": {
-    "station_name": "St Helens Junction Rail Station",
+    "station_name": "St Helens Junction",
     "latitude": 53.4337400237,
     "longitude": -2.7002586912
   },
   "SHL": {
-    "station_name": "Shawlands Rail Station",
+    "station_name": "Shawlands",
     "latitude": 55.8292064055,
     "longitude": -4.2923288907
   },
   "SHM": {
-    "station_name": "Sheringham Rail Station",
+    "station_name": "Sheringham",
     "latitude": 52.9414541496,
     "longitude": 1.2103377731
   },
   "SHN": {
-    "station_name": "Shanklin Rail Station",
+    "station_name": "Shanklin",
     "latitude": 50.633896807,
     "longitude": -1.1798245747
   },
   "SHO": {
-    "station_name": "Sholing Rail Station",
+    "station_name": "Sholing",
     "latitude": 50.896742165,
     "longitude": -1.3649055402
   },
   "SHP": {
-    "station_name": "Shepperton Rail Station",
+    "station_name": "Shepperton",
     "latitude": 51.3968021836,
     "longitude": -0.4467657574
   },
   "SHR": {
-    "station_name": "Shrewsbury Rail Station",
+    "station_name": "Shrewsbury",
     "latitude": 52.7119413175,
     "longitude": -2.749759506
   },
   "SHS": {
-    "station_name": "Shotts Rail Station",
+    "station_name": "Shotts",
     "latitude": 55.81864295,
     "longitude": -3.7983094064
   },
   "SHT": {
-    "station_name": "Shotton Rail Station",
+    "station_name": "Shotton",
     "latitude": 53.2125551564,
     "longitude": -3.0384238251
   },
   "SHU": {
-    "station_name": "Stonehouse Rail Station",
+    "station_name": "Stonehouse",
     "latitude": 51.7458905703,
     "longitude": -2.2794958307
   },
@@ -10355,92 +10425,92 @@
     "longitude": -1.0999768593
   },
   "SHW": {
-    "station_name": "Shawford Rail Station",
+    "station_name": "Shawford",
     "latitude": 51.0221166807,
     "longitude": -1.3277625973
   },
   "SHY": {
-    "station_name": "Shipley Rail Station",
+    "station_name": "Shipley",
     "latitude": 53.8330646823,
     "longitude": -1.7734929691
   },
   "SIA": {
-    "station_name": "Southend Airport Rail Station",
+    "station_name": "Southend Airport",
     "latitude": 51.5686727167,
     "longitude": 0.7050788997
   },
   "SIC": {
-    "station_name": "Silecroft Rail Station",
+    "station_name": "Silecroft",
     "latitude": 54.2259646268,
     "longitude": -3.3344411623
   },
   "SID": {
-    "station_name": "Sidcup Rail Station",
+    "station_name": "Sidcup",
     "latitude": 51.4338684504,
     "longitude": 0.103820707
   },
   "SIE": {
-    "station_name": "Sherburn-in-Elmet Rail Station",
+    "station_name": "Sherburn-in-Elmet",
     "latitude": 53.797168439,
     "longitude": -1.2326887081
   },
   "SIH": {
-    "station_name": "St Helier (London) Rail Station",
+    "station_name": "St Helier (London)",
     "latitude": 51.3898980858,
     "longitude": -0.1987461399
   },
   "SIL": {
-    "station_name": "Sileby Rail Station",
+    "station_name": "Sileby",
     "latitude": 52.7316119497,
     "longitude": -1.1099817344
   },
   "SIN": {
-    "station_name": "Singer Rail Station",
+    "station_name": "Singer",
     "latitude": 55.9076643414,
     "longitude": -4.4054709223
   },
   "SIP": {
-    "station_name": "Shipton Rail Station",
+    "station_name": "Shipton",
     "latitude": 51.8656602235,
     "longitude": -1.5926793251
   },
   "SIT": {
-    "station_name": "Sittingbourne Rail Station",
+    "station_name": "Sittingbourne",
     "latitude": 51.3419765756,
     "longitude": 0.734715016
   },
   "SIV": {
-    "station_name": "St Ives (Cornwall) Rail Station",
+    "station_name": "St Ives (Cornwall)",
     "latitude": 50.2090340797,
     "longitude": -5.4779638071
   },
   "SJP": {
-    "station_name": "St James Park (Devon) Rail Station",
+    "station_name": "St James Park (Devon)",
     "latitude": 50.7311433327,
     "longitude": -3.522008373
   },
   "SJS": {
-    "station_name": "St James Street (London) Rail Station",
+    "station_name": "St James Street (London)",
     "latitude": 51.5809810952,
     "longitude": -0.0328918555
   },
   "SKE": {
-    "station_name": "Skewen Rail Station",
+    "station_name": "Skewen",
     "latitude": 51.6613929554,
     "longitude": -3.8465246377
   },
   "SKG": {
-    "station_name": "Skegness Rail Station",
+    "station_name": "Skegness",
     "latitude": 53.1432054155,
     "longitude": 0.3343478313
   },
   "SKI": {
-    "station_name": "Skipton Rail Station",
+    "station_name": "Skipton",
     "latitude": 53.9586993556,
     "longitude": -2.0258762003
   },
   "SKM": {
-    "station_name": "Stoke Mandeville Rail Station",
+    "station_name": "Stoke Mandeville",
     "latitude": 51.7878005079,
     "longitude": -0.7840627602
   },
@@ -10450,587 +10520,592 @@
     "longitude": -4.4635552009
   },
   "SKS": {
-    "station_name": "Stocksfield Rail Station",
+    "station_name": "Stocksfield",
     "latitude": 54.9470541409,
     "longitude": -1.9167691115
   },
   "SKW": {
-    "station_name": "Stoke Newington Rail Station",
+    "station_name": "Stoke Newington",
     "latitude": 51.5652328179,
     "longitude": -0.0728615603
   },
   "SLA": {
-    "station_name": "Slateford Rail Station",
+    "station_name": "Slateford",
     "latitude": 55.9266820904,
     "longitude": -3.2434555997
   },
   "SLB": {
-    "station_name": "Saltburn Rail Station",
+    "station_name": "Saltburn",
     "latitude": 54.5834629003,
     "longitude": -0.9741485323
   },
   "SLD": {
-    "station_name": "Salford Crescent Rail Station",
+    "station_name": "Salford Crescent",
     "latitude": 53.4866023466,
     "longitude": -2.2757478149
   },
   "SLH": {
-    "station_name": "Sleights Rail Station",
+    "station_name": "Sleights",
     "latitude": 54.4610657105,
     "longitude": -0.6624968789
   },
   "SLK": {
-    "station_name": "Silkstone Common Rail Station",
+    "station_name": "Silkstone Common",
     "latitude": 53.5349327521,
     "longitude": -1.5634802419
   },
   "SLL": {
-    "station_name": "Stallingborough Rail Station",
+    "station_name": "Stallingborough",
     "latitude": 53.5871163761,
     "longitude": -0.1836712695
   },
   "SLO": {
-    "station_name": "Slough Rail Station",
+    "station_name": "Slough",
     "latitude": 51.5118802466,
     "longitude": -0.5914931274
   },
   "SLQ": {
-    "station_name": "St Leonards Warrior Square Rail Station",
+    "station_name": "St Leonards Warrior Square",
     "latitude": 50.8556892437,
     "longitude": 0.5603085614
   },
   "SLR": {
-    "station_name": "Sleaford Rail Station",
+    "station_name": "Sleaford",
     "latitude": 52.9954938802,
     "longitude": -0.4103411047
   },
   "SLS": {
-    "station_name": "Shettleston Rail Station",
+    "station_name": "Shettleston",
     "latitude": 55.8535309533,
     "longitude": -4.1600304592
   },
   "SLT": {
-    "station_name": "Saltcoats Rail Station",
+    "station_name": "Saltcoats",
     "latitude": 55.6338785668,
     "longitude": -4.7842684101
   },
   "SLV": {
-    "station_name": "Silver Street Rail Station",
+    "station_name": "Silver Street",
     "latitude": 51.614688688,
     "longitude": -0.0672151307
   },
   "SLW": {
-    "station_name": "Salwick Rail Station",
+    "station_name": "Salwick",
     "latitude": 53.781554319,
     "longitude": -2.8170354918
   },
   "SLY": {
-    "station_name": "Selly Oak Rail Station",
+    "station_name": "Selly Oak",
     "latitude": 52.4419948393,
     "longitude": -1.9358085367
   },
   "SMA": {
-    "station_name": "Small Heath Rail Station",
+    "station_name": "Small Heath",
     "latitude": 52.4637743964,
     "longitude": -1.8593875424
   },
   "SMB": {
-    "station_name": "Smithy Bridge Rail Station",
+    "station_name": "Smithy Bridge",
     "latitude": 53.6332679916,
     "longitude": -2.1135014139
   },
   "SMC": {
-    "station_name": "Sampford Courtenay Rail Station",
+    "station_name": "Sampford Courtenay",
     "latitude": 50.7700908969,
     "longitude": -3.9489125512
   },
   "SMD": {
-    "station_name": "Stamford Rail Station",
+    "station_name": "Stamford",
     "latitude": 52.6478489455,
     "longitude": -0.4801041079
   },
   "SMG": {
-    "station_name": "St Margarets (London) Rail Station",
+    "station_name": "St Margarets (London)",
     "latitude": 51.4552338666,
     "longitude": -0.3201782408
   },
   "SMH": {
-    "station_name": "Stamford Hill Rail Station",
+    "station_name": "Stamford Hill",
     "latitude": 51.5744676612,
     "longitude": -0.0766565162
   },
   "SMK": {
-    "station_name": "Stowmarket Rail Station",
+    "station_name": "Stowmarket",
     "latitude": 52.189727647,
     "longitude": 1.0000367465
   },
   "SML": {
-    "station_name": "Sea Mills Rail Station",
+    "station_name": "Sea Mills",
     "latitude": 51.4799904425,
     "longitude": -2.6499531782
   },
   "SMN": {
-    "station_name": "Southminster Rail Station",
+    "station_name": "Southminster",
     "latitude": 51.6606288734,
     "longitude": 0.8352211602
   },
   "SMO": {
-    "station_name": "South Merton Rail Station",
+    "station_name": "South Merton",
     "latitude": 51.4029904753,
     "longitude": -0.2051331043
   },
   "SMR": {
-    "station_name": "Smethwick Rolfe Street Rail Station",
+    "station_name": "Smethwick Rolfe Street",
     "latitude": 52.4963984863,
     "longitude": -1.9706383988
   },
   "SMT": {
-    "station_name": "St Margarets (Herts) Rail Station",
+    "station_name": "St Margarets (Herts)",
     "latitude": 51.7878447991,
     "longitude": 0.0012964611
   },
   "SMY": {
-    "station_name": "St Mary Cray Rail Station",
+    "station_name": "St Mary Cray",
     "latitude": 51.3947475934,
     "longitude": 0.1064098734
   },
   "SNA": {
-    "station_name": "Sandal & Agbrigg Rail Station",
+    "station_name": "Sandal & Agbrigg",
     "latitude": 53.663093616,
     "longitude": -1.4814212432
   },
   "SND": {
-    "station_name": "Sandhurst Rail Station",
+    "station_name": "Sandhurst",
     "latitude": 51.3469294691,
     "longitude": -0.8045742694
   },
   "SNE": {
-    "station_name": "Stone Rail Station",
+    "station_name": "Stone",
     "latitude": 52.9083405003,
     "longitude": -2.1550394406
   },
   "SNF": {
-    "station_name": "Shenfield Rail Station",
+    "station_name": "Shenfield",
     "latitude": 51.6308782728,
     "longitude": 0.3298784447
   },
   "SNG": {
-    "station_name": "Sunningdale Rail Station",
+    "station_name": "Sunningdale",
     "latitude": 51.3919389035,
     "longitude": -0.6330228307
   },
   "SNH": {
-    "station_name": "St Helens Central Rail Station",
+    "station_name": "St Helens Central",
     "latitude": 53.4531374207,
     "longitude": -2.7303039117
   },
   "SNI": {
-    "station_name": "Snaith Rail Station",
+    "station_name": "Snaith",
     "latitude": 53.6931319312,
     "longitude": -1.0284631537
   },
   "SNK": {
-    "station_name": "Sankey for Penketh Rail Station",
+    "station_name": "Sankey for Penketh",
     "latitude": 53.392475627,
     "longitude": -2.6504695097
   },
   "SNL": {
-    "station_name": "Stoneleigh Rail Station",
+    "station_name": "Stoneleigh",
     "latitude": 51.3633975389,
     "longitude": -0.248640927
   },
   "SNN": {
-    "station_name": "Swinton (Manchester) Rail Station",
+    "station_name": "Swinton (Manchester)",
     "latitude": 53.5148477623,
     "longitude": -2.3374594966
   },
   "SNO": {
-    "station_name": "St Neots Rail Station",
+    "station_name": "St Neots",
     "latitude": 52.2315789405,
     "longitude": -0.2473922859
   },
   "SNP": {
-    "station_name": "Stanhope Rail Station",
+    "station_name": "Stanhope",
     "latitude": 54.7433166118,
     "longitude": -2.003270368
   },
   "SNR": {
-    "station_name": "Sanderstead Rail Station",
+    "station_name": "Sanderstead",
     "latitude": 51.3482809474,
     "longitude": -0.0936522427
   },
   "SNS": {
-    "station_name": "Staines Rail Station",
+    "station_name": "Staines",
     "latitude": 51.4324535002,
     "longitude": -0.5031448916
   },
   "SNT": {
-    "station_name": "Stanlow & Thornton Rail Station",
+    "station_name": "Stanlow & Thornton",
     "latitude": 53.2783765388,
     "longitude": -2.8420514589
   },
   "SNW": {
-    "station_name": "Swanwick Rail Station",
+    "station_name": "Swanwick",
     "latitude": 50.8756583726,
     "longitude": -1.2658406523
   },
   "SNY": {
-    "station_name": "Sunnymeads Rail Station",
+    "station_name": "Sunnymeads",
     "latitude": 51.4702876016,
     "longitude": -0.5593563895
   },
   "SOA": {
-    "station_name": "Southampton Airport Parkway Rail Station",
+    "station_name": "Southampton Airport Parkway",
     "latitude": 50.9508051335,
     "longitude": -1.3630864575
   },
   "SOB": {
-    "station_name": "Southbourne Rail Station",
+    "station_name": "Southbourne",
     "latitude": 50.8482655747,
     "longitude": -0.9080912718
   },
   "SOC": {
-    "station_name": "Southend Central Rail Station",
+    "station_name": "Southend Central",
     "latitude": 51.537066598,
     "longitude": 0.7117558649
   },
   "SOE": {
-    "station_name": "Southend East Rail Station",
+    "station_name": "Southend East",
     "latitude": 51.5389747276,
     "longitude": 0.7318442913
   },
   "SOF": {
-    "station_name": "South Woodham Ferrers Rail Station",
+    "station_name": "South Woodham Ferrers",
     "latitude": 51.6494615164,
     "longitude": 0.6065323444
   },
   "SOG": {
-    "station_name": "Stonegate Rail Station",
+    "station_name": "Stonegate",
     "latitude": 51.0199626384,
     "longitude": 0.3638955581
   },
   "SOH": {
-    "station_name": "South Hampstead Rail Station",
+    "station_name": "South Hampstead",
     "latitude": 51.5414325626,
     "longitude": -0.1788526652
   },
   "SOI": {
-    "station_name": "Stow Rail Station",
+    "station_name": "Stow",
     "latitude": 55.6924175451,
     "longitude": -2.8659523944
   },
+  "SOJ": {
+    "station_name": "Soham",
+    "latitude": 52.331,
+    "longitude": -0.337
+    },
   "SOK": {
-    "station_name": "South Kenton Rail Station",
+    "station_name": "South Kenton",
     "latitude": 51.5702144388,
     "longitude": -0.3084401599
   },
   "SOL": {
-    "station_name": "Solihull Rail Station",
+    "station_name": "Solihull",
     "latitude": 52.4144038973,
     "longitude": -1.7883836849
   },
   "SOM": {
-    "station_name": "South Milford Rail Station",
+    "station_name": "South Milford",
     "latitude": 53.782342555,
     "longitude": -1.2505333925
   },
   "SON": {
-    "station_name": "Steeton & Silsden Rail Station",
+    "station_name": "Steeton & Silsden",
     "latitude": 53.9000444561,
     "longitude": -1.9447229013
   },
   "SOO": {
-    "station_name": "Strood Rail Station",
+    "station_name": "Strood",
     "latitude": 51.3965463718,
     "longitude": 0.5002161998
   },
   "SOP": {
-    "station_name": "Southport Rail Station",
+    "station_name": "Southport",
     "latitude": 53.6465333176,
     "longitude": -3.0024325138
   },
   "SOR": {
-    "station_name": "Sole Street Rail Station",
+    "station_name": "Sole Street",
     "latitude": 51.3831433215,
     "longitude": 0.3781256752
   },
   "SOT": {
-    "station_name": "Stoke-on-Trent Rail Station",
+    "station_name": "Stoke-on-Trent",
     "latitude": 53.0079958214,
     "longitude": -2.1809866656
   },
   "SOU": {
-    "station_name": "Southampton Central Rail Station",
+    "station_name": "Southampton Central",
     "latitude": 50.9074381105,
     "longitude": -1.4135875626
   },
   "SOV": {
-    "station_name": "Southend Victoria Rail Station",
+    "station_name": "Southend Victoria",
     "latitude": 51.5415147415,
     "longitude": 0.7115300293
   },
   "SOW": {
-    "station_name": "Sowerby Bridge Rail Station",
+    "station_name": "Sowerby Bridge",
     "latitude": 53.7078597734,
     "longitude": -1.9070230861
   },
   "SPA": {
-    "station_name": "Spalding Rail Station",
+    "station_name": "Spalding",
     "latitude": 52.7888256516,
     "longitude": -0.1568731307
   },
   "SPB": {
-    "station_name": "Shepherds Bush Rail Station",
+    "station_name": "Shepherds Bush",
     "latitude": 51.505284273,
     "longitude": -0.2176304274
   },
   "SPF": {
-    "station_name": "Springfield Rail Station",
+    "station_name": "Springfield",
     "latitude": 56.2949608449,
     "longitude": -3.0524499272
   },
   "SPH": {
-    "station_name": "Shepherds Well Rail Station",
+    "station_name": "Shepherds Well",
     "latitude": 51.1884029231,
     "longitude": 1.229940616
   },
   "SPI": {
-    "station_name": "Spital Rail Station",
+    "station_name": "Spital",
     "latitude": 53.3399518307,
     "longitude": -2.9939065057
   },
   "SPK": {
-    "station_name": "Sutton Parkway Rail Station",
+    "station_name": "Sutton Parkway",
     "latitude": 53.1141094224,
     "longitude": -1.2455659505
   },
   "SPL": {
-    "station_name": "London St Pancras International LL Rail Station",
+    "station_name": "London St Pancras International LL",
     "latitude": 51.5321682332,
     "longitude": -0.1273170838
   },
   "SPN": {
-    "station_name": "Spooner Row Rail Station",
+    "station_name": "Spooner Row",
     "latitude": 52.535018036,
     "longitude": 1.0864987701
   },
   "SPO": {
-    "station_name": "Spondon Rail Station",
+    "station_name": "Spondon",
     "latitude": 52.9122360781,
     "longitude": -1.4110901354
   },
   "SPP": {
-    "station_name": "Shippea Hill Rail Station",
+    "station_name": "Shippea Hill",
     "latitude": 52.4302290785,
     "longitude": 0.4133683213
   },
   "SPR": {
-    "station_name": "Springburn Rail Station",
+    "station_name": "Springburn",
     "latitude": 55.8819306661,
     "longitude": -4.2305204867
   },
   "SPS": {
-    "station_name": "Stepps Rail Station",
+    "station_name": "Stepps",
     "latitude": 55.8901303522,
     "longitude": -4.1407948936
   },
   "SPT": {
-    "station_name": "Stockport Rail Station",
+    "station_name": "Stockport",
     "latitude": 53.4055533886,
     "longitude": -2.1630118236
   },
   "SPU": {
-    "station_name": "Staplehurst Rail Station",
+    "station_name": "Staplehurst",
     "latitude": 51.1714644595,
     "longitude": 0.5504684545
   },
   "SPY": {
-    "station_name": "Shepley Rail Station",
+    "station_name": "Shepley",
     "latitude": 53.5887544999,
     "longitude": -1.7049300824
   },
   "SQE": {
-    "station_name": "Surrey Quays Rail Station",
+    "station_name": "Surrey Quays",
     "latitude": 51.493195576,
     "longitude": -0.0474925165
   },
   "SQH": {
-    "station_name": "Sanquhar Rail Station",
+    "station_name": "Sanquhar",
     "latitude": 55.3701688129,
     "longitude": -3.9245103507
   },
   "SQU": {
-    "station_name": "Squires Gate Rail Station",
+    "station_name": "Squires Gate",
     "latitude": 53.7773453923,
     "longitude": -3.0502988204
   },
   "SRA": {
-    "station_name": "Stratford (London) Rail Station",
+    "station_name": "Stratford (London)",
     "latitude": 51.541895146,
     "longitude": -0.0033691271
   },
   "SRC": {
-    "station_name": "Streatham Common Rail Station",
+    "station_name": "Streatham Common",
     "latitude": 51.4187280874,
     "longitude": -0.1359839628
   },
   "SRD": {
-    "station_name": "Stapleton Road Rail Station",
+    "station_name": "Stapleton Road",
     "latitude": 51.4675039991,
     "longitude": -2.5662177437
   },
   "SRG": {
-    "station_name": "Seer Green Rail Station",
+    "station_name": "Seer Green",
     "latitude": 51.6098457593,
     "longitude": -0.6077986309
   },
   "SRH": {
-    "station_name": "Streatham Hill Rail Station",
+    "station_name": "Streatham Hill",
     "latitude": 51.4381912428,
     "longitude": -0.1271343887
   },
   "SRI": {
-    "station_name": "Spring Road Rail Station",
+    "station_name": "Spring Road",
     "latitude": 52.4434290378,
     "longitude": -1.8373837238
   },
   "SRL": {
-    "station_name": "Shirley Rail Station",
+    "station_name": "Shirley",
     "latitude": 52.4034335801,
     "longitude": -1.8451727358
   },
   "SRN": {
-    "station_name": "Strines Rail Station",
+    "station_name": "Strines",
     "latitude": 53.375053434,
     "longitude": -2.03391498
   },
   "SRO": {
-    "station_name": "Shireoaks Rail Station",
+    "station_name": "Shireoaks",
     "latitude": 53.324793696,
     "longitude": -1.1679906243
   },
   "SRR": {
-    "station_name": "Sarn Rail Station",
+    "station_name": "Sarn",
     "latitude": 51.538716062,
     "longitude": -3.5899278153
   },
   "SRS": {
-    "station_name": "Selhurst Rail Station",
+    "station_name": "Selhurst",
     "latitude": 51.3919256691,
     "longitude": -0.0882746656
   },
   "SRT": {
-    "station_name": "Shortlands Rail Station",
+    "station_name": "Shortlands",
     "latitude": 51.4057983982,
     "longitude": 0.0018099278
   },
   "SRU": {
-    "station_name": "South Ruislip Rail Station",
+    "station_name": "South Ruislip",
     "latitude": 51.5569197794,
     "longitude": -0.3992385186
   },
   "SRY": {
-    "station_name": "Shoeburyness Rail Station",
+    "station_name": "Shoeburyness",
     "latitude": 51.5309751312,
     "longitude": 0.7953748853
   },
   "SSC": {
-    "station_name": "Seascale Rail Station",
+    "station_name": "Seascale",
     "latitude": 54.3958826629,
     "longitude": -3.4845106158
   },
   "SSD": {
-    "station_name": "Stansted Airport Rail Station",
+    "station_name": "Stansted Airport",
     "latitude": 51.8885969065,
     "longitude": 0.2608429847
   },
   "SSE": {
-    "station_name": "Shoreham-by-Sea (Sussex) Rail Station",
+    "station_name": "Shoreham-by-Sea (Sussex)",
     "latitude": 50.8344187806,
     "longitude": -0.2716932437
   },
   "SSM": {
-    "station_name": "Stocksmoor Rail Station",
+    "station_name": "Stocksmoor",
     "latitude": 53.5941012185,
     "longitude": -1.723249622
   },
   "SSS": {
-    "station_name": "Sheerness-on-Sea Rail Station",
+    "station_name": "Sheerness-on-Sea",
     "latitude": 51.4410626729,
     "longitude": 0.7585627159
   },
   "SST": {
-    "station_name": "Stansted Mountfitchet Rail Station",
+    "station_name": "Stansted Mountfitchet",
     "latitude": 51.9014446092,
     "longitude": 0.1998076437
   },
   "STA": {
-    "station_name": "Stafford Rail Station",
+    "station_name": "Stafford",
     "latitude": 52.8039040388,
     "longitude": -2.122032317
   },
   "STC": {
-    "station_name": "Strathcarron Rail Station",
+    "station_name": "Strathcarron",
     "latitude": 57.4227106139,
     "longitude": -5.4286056714
   },
   "STD": {
-    "station_name": "Stroud (Glos) Rail Station",
+    "station_name": "Stroud (Glos)",
     "latitude": 51.7446251691,
     "longitude": -2.2193787757
   },
   "STE": {
-    "station_name": "Streatham Rail Station",
+    "station_name": "Streatham",
     "latitude": 51.425806399,
     "longitude": -0.1315244629
   },
   "STF": {
-    "station_name": "Stromeferry Rail Station",
+    "station_name": "Stromeferry",
     "latitude": 57.3522743311,
     "longitude": -5.5511508974
   },
   "STG": {
-    "station_name": "Stirling Rail Station",
+    "station_name": "Stirling",
     "latitude": 56.1198084255,
     "longitude": -3.9356129186
   },
   "STH": {
-    "station_name": "Shepreth Rail Station",
+    "station_name": "Shepreth",
     "latitude": 52.1141714275,
     "longitude": 0.0313474706
   },
   "STJ": {
-    "station_name": "Severn Tunnel Junction Rail Station",
+    "station_name": "Severn Tunnel Junction",
     "latitude": 51.5846753669,
     "longitude": -2.777896695
   },
   "STK": {
-    "station_name": "Stockton Rail Station",
+    "station_name": "Stockton",
     "latitude": 54.5696329596,
     "longitude": -1.3185563444
   },
   "STL": {
-    "station_name": "Southall Rail Station",
+    "station_name": "Southall",
     "latitude": 51.5059555535,
     "longitude": -0.3785893432
   },
   "STM": {
-    "station_name": "St Michaels Rail Station",
+    "station_name": "St Michaels",
     "latitude": 53.3756143466,
     "longitude": -2.9527983882
   },
   "STN": {
-    "station_name": "Stonehaven Rail Station",
+    "station_name": "Stonehaven",
     "latitude": 56.9668074474,
     "longitude": -2.2253042533
   },
   "STO": {
-    "station_name": "South Tottenham Rail Station",
+    "station_name": "South Tottenham",
     "latitude": 51.580372482,
     "longitude": -0.0720773948
   },
   "STP": {
-    "station_name": "London St Pancras International Rail Station",
+    "station_name": "London St Pancras International",
     "latitude": 51.5323906044,
     "longitude": -0.1271637715
   },
@@ -11040,687 +11115,687 @@
     "longitude": -1.4058217125
   },
   "STR": {
-    "station_name": "Stranraer Rail Station",
+    "station_name": "Stranraer",
     "latitude": 54.9096119416,
     "longitude": -5.0247136457
   },
   "STS": {
-    "station_name": "Saltash Rail Station",
+    "station_name": "Saltash",
     "latitude": 50.407341292,
     "longitude": -4.2091429608
   },
   "STT": {
-    "station_name": "Stewarton Rail Station",
+    "station_name": "Stewarton",
     "latitude": 55.6821494442,
     "longitude": -4.5180405975
   },
   "STU": {
-    "station_name": "Sturry Rail Station",
+    "station_name": "Sturry",
     "latitude": 51.301071637,
     "longitude": 1.1222846311
   },
   "STV": {
-    "station_name": "Stevenston Rail Station",
+    "station_name": "Stevenston",
     "latitude": 55.6342752646,
     "longitude": -4.7507681765
   },
   "STW": {
-    "station_name": "Strawberry Hill Rail Station",
+    "station_name": "Strawberry Hill",
     "latitude": 51.4389610182,
     "longitude": -0.3393370866
   },
   "STY": {
-    "station_name": "Stratford-upon-Avon Parkway Rail Station",
+    "station_name": "Stratford-upon-Avon Parkway",
     "latitude": 52.20679123,
     "longitude": -1.7308347436
   },
   "STZ": {
-    "station_name": "St Peters Rail Station",
+    "station_name": "St Peters",
     "latitude": 54.9114465319,
     "longitude": -1.3838157241
   },
   "SUC": {
-    "station_name": "Sutton Common Rail Station",
+    "station_name": "Sutton Common",
     "latitude": 51.374887892,
     "longitude": -0.1963176971
   },
   "SUD": {
-    "station_name": "Sudbury & Harrow Road Rail Station",
+    "station_name": "Sudbury & Harrow Road",
     "latitude": 51.5543983927,
     "longitude": -0.3154454426
   },
   "SUG": {
-    "station_name": "Sugar Loaf Rail Station",
+    "station_name": "Sugar Loaf",
     "latitude": 52.082277733,
     "longitude": -3.6869603427
   },
   "SUM": {
-    "station_name": "Summerston Rail Station",
+    "station_name": "Summerston",
     "latitude": 55.8988291055,
     "longitude": -4.2915239477
   },
   "SUN": {
-    "station_name": "Sunderland Rail Station",
+    "station_name": "Sunderland",
     "latitude": 54.9053460619,
     "longitude": -1.382318101
   },
   "SUO": {
-    "station_name": "Sutton (London) Rail Station",
+    "station_name": "Sutton (London)",
     "latitude": 51.359530184,
     "longitude": -0.1911898264
   },
   "SUP": {
-    "station_name": "Sundridge Park Rail Station",
+    "station_name": "Sundridge Park",
     "latitude": 51.4137794712,
     "longitude": 0.0214722343
   },
   "SUR": {
-    "station_name": "Surbiton Rail Station",
+    "station_name": "Surbiton",
     "latitude": 51.392457041,
     "longitude": -0.3039362021
   },
   "SUT": {
-    "station_name": "Sutton Coldfield Rail Station",
+    "station_name": "Sutton Coldfield",
     "latitude": 52.5649558162,
     "longitude": -1.824837271
   },
   "SUU": {
-    "station_name": "Sunbury Rail Station",
+    "station_name": "Sunbury",
     "latitude": 51.4183118212,
     "longitude": -0.4177615601
   },
   "SUY": {
-    "station_name": "Sudbury (Suffolk) Rail Station",
+    "station_name": "Sudbury (Suffolk)",
     "latitude": 52.0362894221,
     "longitude": 0.7354756664
   },
   "SVB": {
-    "station_name": "Severn Beach Rail Station",
+    "station_name": "Severn Beach",
     "latitude": 51.560023655,
     "longitude": -2.6644812454
   },
   "SVG": {
-    "station_name": "Stevenage Rail Station",
+    "station_name": "Stevenage",
     "latitude": 51.9016927995,
     "longitude": -0.2070860807
   },
   "SVK": {
-    "station_name": "Seven Kings Rail Station",
+    "station_name": "Seven Kings",
     "latitude": 51.5640254913,
     "longitude": 0.0971266259
   },
   "SVL": {
-    "station_name": "Staveley Rail Station",
+    "station_name": "Staveley",
     "latitude": 54.3755397414,
     "longitude": -2.8188650127
   },
   "SVR": {
-    "station_name": "Silverdale Rail Station",
+    "station_name": "Silverdale",
     "latitude": 54.1699177481,
     "longitude": -2.8038415221
   },
   "SVS": {
-    "station_name": "Seven Sisters Rail Station",
+    "station_name": "Seven Sisters",
     "latitude": 51.5822680092,
     "longitude": -0.0752448572
   },
   "SWA": {
-    "station_name": "Swansea Rail Station",
+    "station_name": "Swansea",
     "latitude": 51.6251487596,
     "longitude": -3.9415644468
   },
   "SWD": {
-    "station_name": "Swinderby Rail Station",
+    "station_name": "Swinderby",
     "latitude": 53.1695752058,
     "longitude": -0.7026776123
   },
   "SWE": {
-    "station_name": "Swineshead Rail Station",
+    "station_name": "Swineshead",
     "latitude": 52.9698246032,
     "longitude": -0.1871603301
   },
   "SWG": {
-    "station_name": "Swaythling Rail Station",
+    "station_name": "Swaythling",
     "latitude": 50.9411378896,
     "longitude": -1.3763987158
   },
   "SWI": {
-    "station_name": "Swindon Rail Station",
+    "station_name": "Swindon",
     "latitude": 51.5654717291,
     "longitude": -1.7854997597
   },
   "SWK": {
-    "station_name": "Southwick Rail Station",
+    "station_name": "Southwick",
     "latitude": 50.8325078755,
     "longitude": -0.2359343912
   },
   "SWL": {
-    "station_name": "Swale Rail Station",
+    "station_name": "Swale",
     "latitude": 51.3892367714,
     "longitude": 0.7471634594
   },
   "SWM": {
-    "station_name": "Swanscombe Rail Station",
+    "station_name": "Swanscombe",
     "latitude": 51.4490684493,
     "longitude": 0.3095719354
   },
   "SWN": {
-    "station_name": "Swinton (South Yorks) Rail Station",
+    "station_name": "Swinton (South Yorks)",
     "latitude": 53.4862573953,
     "longitude": -1.3058228385
   },
   "SWO": {
-    "station_name": "Snowdown Rail Station",
+    "station_name": "Snowdown",
     "latitude": 51.2153033313,
     "longitude": 1.2137349076
   },
   "SWR": {
-    "station_name": "Stewartby Rail Station",
+    "station_name": "Stewartby",
     "latitude": 52.0690889946,
     "longitude": -0.5206700583
   },
   "SWS": {
-    "station_name": "South Wigston Rail Station",
+    "station_name": "South Wigston",
     "latitude": 52.5822411091,
     "longitude": -1.1340686433
   },
   "SWT": {
-    "station_name": "Slaithwaite Rail Station",
+    "station_name": "Slaithwaite",
     "latitude": 53.6238425513,
     "longitude": -1.8815786683
   },
   "SWY": {
-    "station_name": "Sway Rail Station",
+    "station_name": "Sway",
     "latitude": 50.7846919652,
     "longitude": -1.6099880732
   },
   "SXY": {
-    "station_name": "Saxilby Rail Station",
+    "station_name": "Saxilby",
     "latitude": 53.2672239409,
     "longitude": -0.664039544
   },
   "SYA": {
-    "station_name": "Styal Rail Station",
+    "station_name": "Styal",
     "latitude": 53.3483444707,
     "longitude": -2.2404551552
   },
   "SYB": {
-    "station_name": "Stalybridge Rail Station",
+    "station_name": "Stalybridge",
     "latitude": 53.4845940592,
     "longitude": -2.0627406537
   },
   "SYD": {
-    "station_name": "Sydenham Rail Station",
+    "station_name": "Sydenham",
     "latitude": 51.4272456275,
     "longitude": -0.0542181492
   },
   "SYH": {
-    "station_name": "Sydenham Hill Rail Station",
+    "station_name": "Sydenham Hill",
     "latitude": 51.4327121996,
     "longitude": -0.0803137756
   },
   "SYL": {
-    "station_name": "Syon Lane Rail Station",
+    "station_name": "Syon Lane",
     "latitude": 51.4817833206,
     "longitude": -0.3248202577
   },
   "SYS": {
-    "station_name": "Syston Rail Station",
+    "station_name": "Syston",
     "latitude": 52.6942282549,
     "longitude": -1.0823921267
   },
   "SYT": {
-    "station_name": "Somerleyton Rail Station",
+    "station_name": "Somerleyton",
     "latitude": 52.510254523,
     "longitude": 1.65228441
   },
   "TAB": {
-    "station_name": "Tame Bridge Parkway Rail Station",
+    "station_name": "Tame Bridge Parkway",
     "latitude": 52.5529462534,
     "longitude": -1.9762062325
   },
   "TAC": {
-    "station_name": "Tackley Rail Station",
+    "station_name": "Tackley",
     "latitude": 51.8812440038,
     "longitude": -1.2975180267
   },
   "TAD": {
-    "station_name": "Tadworth Rail Station",
+    "station_name": "Tadworth",
     "latitude": 51.2916337745,
     "longitude": -0.2359396303
   },
   "TAF": {
-    "station_name": "Taffs Well Rail Station",
+    "station_name": "Taffs Well",
     "latitude": 51.5408038104,
     "longitude": -3.2629475716
   },
   "TAH": {
-    "station_name": "Tamworth High Level Rail Station",
+    "station_name": "Tamworth High Level",
     "latitude": 52.6374896703,
     "longitude": -1.6864429533
   },
   "TAI": {
-    "station_name": "Tain Rail Station",
+    "station_name": "Tain",
     "latitude": 57.814403344,
     "longitude": -4.052050677
   },
   "TAL": {
-    "station_name": "Talsarnau Rail Station",
+    "station_name": "Talsarnau",
     "latitude": 52.9043217775,
     "longitude": -4.0681617526
   },
   "TAM": {
-    "station_name": "Tamworth Rail Station",
+    "station_name": "Tamworth",
     "latitude": 52.6374897095,
     "longitude": -1.6864577321
   },
   "TAP": {
-    "station_name": "Taplow Rail Station",
+    "station_name": "Taplow",
     "latitude": 51.5235630262,
     "longitude": -0.6813523989
   },
   "TAT": {
-    "station_name": "Tattenham Corner Rail Station",
+    "station_name": "Tattenham Corner",
     "latitude": 51.3091795736,
     "longitude": -0.242584206
   },
   "TAU": {
-    "station_name": "Taunton Rail Station",
+    "station_name": "Taunton",
     "latitude": 51.0232957201,
     "longitude": -3.1027501001
   },
   "TAY": {
-    "station_name": "Taynuilt Rail Station",
+    "station_name": "Taynuilt",
     "latitude": 56.4307929324,
     "longitude": -5.2395897581
   },
   "TBD": {
-    "station_name": "Three Bridges Rail Station",
+    "station_name": "Three Bridges",
     "latitude": 51.1169179407,
     "longitude": -0.1611569978
   },
   "TBW": {
-    "station_name": "Tunbridge Wells Rail Station",
+    "station_name": "Tunbridge Wells",
     "latitude": 51.1302300678,
     "longitude": 0.2628373001
   },
   "TBY": {
-    "station_name": "Thornaby Rail Station",
+    "station_name": "Thornaby",
     "latitude": 54.5592813582,
     "longitude": -1.3014251552
   },
   "TDU": {
-    "station_name": "Tondu Rail Station",
+    "station_name": "Tondu",
     "latitude": 51.547362229,
     "longitude": -3.5955651626
   },
   "TEA": {
-    "station_name": "Tees-side Airport Rail Station",
+    "station_name": "Tees-side Airport",
     "latitude": 54.5181424575,
     "longitude": -1.4253223693
   },
   "TED": {
-    "station_name": "Teddington Rail Station",
+    "station_name": "Teddington",
     "latitude": 51.4244788122,
     "longitude": -0.3326846191
   },
   "TEN": {
-    "station_name": "Tenby Rail Station",
+    "station_name": "Tenby",
     "latitude": 51.672951966,
     "longitude": -4.7067273929
   },
   "TEO": {
-    "station_name": "Theobalds Grove Rail Station",
+    "station_name": "Theobalds Grove",
     "latitude": 51.692457758,
     "longitude": -0.0348052112
   },
   "TEY": {
-    "station_name": "Teynham Rail Station",
+    "station_name": "Teynham",
     "latitude": 51.3333932934,
     "longitude": 0.8074562729
   },
   "TFC": {
-    "station_name": "Telford Central Rail Station",
+    "station_name": "Telford Central",
     "latitude": 52.6811206446,
     "longitude": -2.4409698489
   },
   "TGM": {
-    "station_name": "Teignmouth Rail Station",
+    "station_name": "Teignmouth",
     "latitude": 50.5480477205,
     "longitude": -3.4946764735
   },
   "TGS": {
-    "station_name": "Ty Glas Rail Station",
+    "station_name": "Ty Glas",
     "latitude": 51.5215383785,
     "longitude": -3.1965433402
   },
   "THA": {
-    "station_name": "Thatcham Rail Station",
+    "station_name": "Thatcham",
     "latitude": 51.3938422697,
     "longitude": -1.2431703674
   },
   "THB": {
-    "station_name": "Thornliebank Rail Station",
+    "station_name": "Thornliebank",
     "latitude": 55.8110931929,
     "longitude": -4.3116934017
   },
   "THC": {
-    "station_name": "Thurnscoe Rail Station",
+    "station_name": "Thurnscoe",
     "latitude": 53.5450596404,
     "longitude": -1.3087865327
   },
   "THD": {
-    "station_name": "Thames Ditton Rail Station",
+    "station_name": "Thames Ditton",
     "latitude": 51.389094233,
     "longitude": -0.3391301451
   },
   "THE": {
-    "station_name": "Theale Rail Station",
+    "station_name": "Theale",
     "latitude": 51.4334510541,
     "longitude": -1.074953188
   },
   "THH": {
-    "station_name": "Thatto Heath Rail Station",
+    "station_name": "Thatto Heath",
     "latitude": 53.4365966678,
     "longitude": -2.7593735619
   },
   "THI": {
-    "station_name": "Thirsk Rail Station",
+    "station_name": "Thirsk",
     "latitude": 54.2282229773,
     "longitude": -1.3725964904
   },
   "THL": {
-    "station_name": "Tile Hill Rail Station",
+    "station_name": "Tile Hill",
     "latitude": 52.3951180004,
     "longitude": -1.5968388563
   },
   "THO": {
-    "station_name": "Thornford Rail Station",
+    "station_name": "Thornford",
     "latitude": 50.9105671531,
     "longitude": -2.5789881669
   },
   "THS": {
-    "station_name": "Thurso Rail Station",
+    "station_name": "Thurso",
     "latitude": 58.5901618735,
     "longitude": -3.5275560192
   },
   "THT": {
-    "station_name": "Thorntonhall Rail Station",
+    "station_name": "Thorntonhall",
     "latitude": 55.7686725545,
     "longitude": -4.251148703
   },
   "THU": {
-    "station_name": "Thurgarton Rail Station",
+    "station_name": "Thurgarton",
     "latitude": 53.0289614147,
     "longitude": -0.9622529876
   },
   "THW": {
-    "station_name": "The Hawthorns Rail Station",
+    "station_name": "The Hawthorns",
     "latitude": 52.5053866205,
     "longitude": -1.9640028874
   },
   "TIL": {
-    "station_name": "Tilbury Town Rail Station",
+    "station_name": "Tilbury Town",
     "latitude": 51.4623579727,
     "longitude": 0.3540684253
   },
   "TIP": {
-    "station_name": "Tipton Rail Station",
+    "station_name": "Tipton",
     "latitude": 52.5304554489,
     "longitude": -2.0656957349
   },
   "TIR": {
-    "station_name": "Tir-phil Rail Station",
+    "station_name": "Tir-phil",
     "latitude": 51.720908438,
     "longitude": -3.2463907704
   },
   "TIS": {
-    "station_name": "Tisbury Rail Station",
+    "station_name": "Tisbury",
     "latitude": 51.0608447298,
     "longitude": -2.078996052
   },
   "TLB": {
-    "station_name": "Talybont Rail Station",
+    "station_name": "Talybont",
     "latitude": 52.7726445507,
     "longitude": -4.0966036401
   },
   "TLC": {
-    "station_name": "Tal-y-Cafn Rail Station",
+    "station_name": "Tal-y-Cafn",
     "latitude": 53.2283776011,
     "longitude": -3.8182676092
   },
   "TLH": {
-    "station_name": "Tilehurst Rail Station",
+    "station_name": "Tilehurst",
     "latitude": 51.4715086374,
     "longitude": -1.0297956661
   },
   "TLK": {
-    "station_name": "The Lakes Rail Station",
+    "station_name": "The Lakes",
     "latitude": 52.3591567803,
     "longitude": -1.8446654141
   },
   "TLS": {
-    "station_name": "Thorpe-le-Soken Rail Station",
+    "station_name": "Thorpe-le-Soken",
     "latitude": 51.847646828,
     "longitude": 1.1614320188
   },
   "TMC": {
-    "station_name": "Templecombe Rail Station",
+    "station_name": "Templecombe",
     "latitude": 51.0014953975,
     "longitude": -2.4177222648
   },
   "TNA": {
-    "station_name": "Thornton Abbey Rail Station",
+    "station_name": "Thornton Abbey",
     "latitude": 53.6543223993,
     "longitude": -0.3230275398
   },
   "TNF": {
-    "station_name": "Tonfanau Rail Station",
+    "station_name": "Tonfanau",
     "latitude": 52.6135565545,
     "longitude": -4.1237062703
   },
   "TNN": {
-    "station_name": "Thorne North Rail Station",
+    "station_name": "Thorne North",
     "latitude": 53.6160814226,
     "longitude": -0.9723356959
   },
   "TNP": {
-    "station_name": "Tonypandy Rail Station",
+    "station_name": "Tonypandy",
     "latitude": 51.6197644665,
     "longitude": -3.4488804142
   },
   "TNS": {
-    "station_name": "Thorne South Rail Station",
+    "station_name": "Thorne South",
     "latitude": 53.6033482935,
     "longitude": -0.9551144553
   },
   "TOD": {
-    "station_name": "Todmorden Rail Station",
+    "station_name": "Todmorden",
     "latitude": 53.7138309013,
     "longitude": -2.0996605197
   },
   "TOK": {
-    "station_name": "Three Oaks Rail Station",
+    "station_name": "Three Oaks",
     "latitude": 50.9011098188,
     "longitude": 0.6130803485
   },
   "TOL": {
-    "station_name": "Tolworth Rail Station",
+    "station_name": "Tolworth",
     "latitude": 51.376857174,
     "longitude": -0.279438167
   },
   "TOM": {
-    "station_name": "Tottenham Hale Rail Station",
+    "station_name": "Tottenham Hale",
     "latitude": 51.5883098971,
     "longitude": -0.0599041132
   },
   "TON": {
-    "station_name": "Tonbridge Rail Station",
+    "station_name": "Tonbridge",
     "latitude": 51.1914072217,
     "longitude": 0.27100092
   },
   "TOO": {
-    "station_name": "Tooting Rail Station",
+    "station_name": "Tooting",
     "latitude": 51.4198462078,
     "longitude": -0.1612523385
   },
   "TOP": {
-    "station_name": "Topsham Rail Station",
+    "station_name": "Topsham",
     "latitude": 50.6862032067,
     "longitude": -3.4644362802
   },
   "TOT": {
-    "station_name": "Totnes Rail Station",
+    "station_name": "Totnes",
     "latitude": 50.4358486966,
     "longitude": -3.6887120337
   },
   "TPB": {
-    "station_name": "Thorpe Bay Rail Station",
+    "station_name": "Thorpe Bay",
     "latitude": 51.5375725855,
     "longitude": 0.761757978
   },
   "TPC": {
-    "station_name": "Thorpe Culvert Rail Station",
+    "station_name": "Thorpe Culvert",
     "latitude": 53.1231171411,
     "longitude": 0.199418712
   },
   "TPN": {
-    "station_name": "Ton Pentre Rail Station",
+    "station_name": "Ton Pentre",
     "latitude": 51.6478022913,
     "longitude": -3.4861984834
   },
   "TQY": {
-    "station_name": "Torquay Rail Station",
+    "station_name": "Torquay",
     "latitude": 50.4611182406,
     "longitude": -3.5432904492
   },
   "TRA": {
-    "station_name": "Trafford Park Rail Station",
+    "station_name": "Trafford Park",
     "latitude": 53.4548323413,
     "longitude": -2.310631341
   },
   "TRB": {
-    "station_name": "Treherbert Rail Station",
+    "station_name": "Treherbert",
     "latitude": 51.6722450222,
     "longitude": -3.5363140662
   },
   "TRD": {
-    "station_name": "Troed-y-Rhiw Rail Station",
+    "station_name": "Troed-y-Rhiw",
     "latitude": 51.7124284343,
     "longitude": -3.3467559182
   },
   "TRE": {
-    "station_name": "Trefforest Estate Rail Station",
+    "station_name": "Trefforest Estate",
     "latitude": 51.5682913986,
     "longitude": -3.2902588749
   },
   "TRF": {
-    "station_name": "Trefforest Rail Station",
+    "station_name": "Trefforest",
     "latitude": 51.5914619743,
     "longitude": -3.3251300368
   },
   "TRH": {
-    "station_name": "Trehafod Rail Station",
+    "station_name": "Trehafod",
     "latitude": 51.6101512603,
     "longitude": -3.3809848496
   },
   "TRI": {
-    "station_name": "Tring Rail Station",
+    "station_name": "Tring",
     "latitude": 51.8007474169,
     "longitude": -0.6224150693
   },
   "TRM": {
-    "station_name": "Trimley Rail Station",
+    "station_name": "Trimley",
     "latitude": 51.9765411505,
     "longitude": 1.3195660189
   },
   "TRN": {
-    "station_name": "Troon Rail Station",
+    "station_name": "Troon",
     "latitude": 55.5428092479,
     "longitude": -4.6552789194
   },
   "TRO": {
-    "station_name": "Trowbridge Rail Station",
+    "station_name": "Trowbridge",
     "latitude": 51.3198258981,
     "longitude": -2.2143311551
   },
   "TRR": {
-    "station_name": "Torre Rail Station",
+    "station_name": "Torre",
     "latitude": 50.4731733437,
     "longitude": -3.546431156
   },
   "TRS": {
-    "station_name": "Thurston Rail Station",
+    "station_name": "Thurston",
     "latitude": 52.250018318,
     "longitude": 0.80868287
   },
   "TRU": {
-    "station_name": "Truro Rail Station",
+    "station_name": "Truro",
     "latitude": 50.2638281307,
     "longitude": -5.0648592797
   },
   "TRY": {
-    "station_name": "Treorchy Rail Station",
+    "station_name": "Treorchy",
     "latitude": 51.6575345216,
     "longitude": -3.5057452076
   },
   "TTF": {
-    "station_name": "Thetford Rail Station",
+    "station_name": "Thetford",
     "latitude": 52.4191425696,
     "longitude": 0.7450983124
   },
   "TTH": {
-    "station_name": "Thornton Heath Rail Station",
+    "station_name": "Thornton Heath",
     "latitude": 51.3987754716,
     "longitude": -0.100280296
   },
   "TTN": {
-    "station_name": "Totton Rail Station",
+    "station_name": "Totton",
     "latitude": 50.917871726,
     "longitude": -1.4824091536
   },
   "TUH": {
-    "station_name": "Tulse Hill Rail Station",
+    "station_name": "Tulse Hill",
     "latitude": 51.439859554,
     "longitude": -0.1050510178
   },
   "TUL": {
-    "station_name": "Tulloch Rail Station",
+    "station_name": "Tulloch",
     "latitude": 56.8842613618,
     "longitude": -4.7013115681
   },
   "TUR": {
-    "station_name": "Turkey Street Rail Station",
+    "station_name": "Turkey Street",
     "latitude": 51.6726289265,
     "longitude": -0.047190258
   },
   "TUT": {
-    "station_name": "Tutbury & Hatton Rail Station",
+    "station_name": "Tutbury & Hatton",
     "latitude": 52.8641515138,
     "longitude": -1.6822308376
   },
   "TVP": {
-    "station_name": "Tiverton Parkway Rail Station",
+    "station_name": "Tiverton Parkway",
     "latitude": 50.917168904,
     "longitude": -3.3596569642
   },
   "TWB": {
-    "station_name": "Tweedbank Rail Station",
+    "station_name": "Tweedbank",
     "latitude": 55.6057393628,
     "longitude": -2.7595353637
   },
   "TWI": {
-    "station_name": "Twickenham Rail Station",
+    "station_name": "Twickenham",
     "latitude": 51.4500290431,
     "longitude": -0.3303719704
   },
   "TWN": {
-    "station_name": "Town Green Rail Station",
+    "station_name": "Town Green",
     "latitude": 53.5428211891,
     "longitude": -2.9044849794
   },
   "TWY": {
-    "station_name": "Twyford Rail Station",
+    "station_name": "Twyford",
     "latitude": 51.4755339055,
     "longitude": -0.8632740226
   },
@@ -11730,1222 +11805,1235 @@
     "longitude": -4.0115223964
   },
   "TYC": {
-    "station_name": "Ty Croes Rail Station",
+    "station_name": "Ty Croes",
     "latitude": 53.2225738882,
     "longitude": -4.4747394282
   },
   "TYG": {
-    "station_name": "Tygwyn Rail Station",
+    "station_name": "Tygwyn",
     "latitude": 52.8937988543,
     "longitude": -4.0786617087
   },
   "TYL": {
-    "station_name": "Tyndrum Lower Rail Station",
+    "station_name": "Tyndrum Lower",
     "latitude": 56.4333287654,
     "longitude": -4.7148053177
   },
   "TYS": {
-    "station_name": "Tyseley Rail Station",
+    "station_name": "Tyseley",
     "latitude": 52.4541295073,
     "longitude": -1.839110539
   },
   "TYW": {
-    "station_name": "Tywyn Rail Station",
+    "station_name": "Tywyn",
     "latitude": 52.5855906404,
     "longitude": -4.0935677848
   },
   "UCK": {
-    "station_name": "Uckfield Rail Station",
+    "station_name": "Uckfield",
     "latitude": 50.9687336094,
     "longitude": 0.0964070853
   },
   "UDD": {
-    "station_name": "Uddingston Rail Station",
+    "station_name": "Uddingston",
     "latitude": 55.8235220757,
     "longitude": -4.0866850065
   },
   "UHA": {
-    "station_name": "Uphall Rail Station",
+    "station_name": "Uphall",
     "latitude": 55.9190364207,
     "longitude": -3.5021160921
   },
   "UHL": {
-    "station_name": "Upper Holloway Rail Station",
+    "station_name": "Upper Holloway",
     "latitude": 51.5636322354,
     "longitude": -0.1294870843
   },
   "ULC": {
-    "station_name": "Ulceby Rail Station",
+    "station_name": "Ulceby",
     "latitude": 53.619221029,
     "longitude": -0.3008319145
   },
   "ULL": {
-    "station_name": "Ulleskelf Rail Station",
+    "station_name": "Ulleskelf",
     "latitude": 53.8536281296,
     "longitude": -1.2139769916
   },
   "ULV": {
-    "station_name": "Ulverston Rail Station",
+    "station_name": "Ulverston",
     "latitude": 54.1915918364,
     "longitude": -3.0979152379
   },
   "UMB": {
-    "station_name": "Umberleigh Rail Station",
+    "station_name": "Umberleigh",
     "latitude": 50.996741205,
     "longitude": -3.9829094548
   },
   "UNI": {
-    "station_name": "University Rail Station",
+    "station_name": "University",
     "latitude": 52.4512550606,
     "longitude": -1.9366781951
   },
   "UPH": {
-    "station_name": "Upper Halliford Rail Station",
+    "station_name": "Upper Halliford",
     "latitude": 51.4130654507,
     "longitude": -0.4308849859
   },
   "UPL": {
-    "station_name": "Upholland Rail Station",
+    "station_name": "Upholland",
     "latitude": 53.5283938559,
     "longitude": -2.7414050505
   },
   "UPM": {
-    "station_name": "Upminster Rail Station",
+    "station_name": "Upminster",
     "latitude": 51.5591080891,
     "longitude": 0.2509114423
   },
   "UPT": {
-    "station_name": "Upton Rail Station",
+    "station_name": "Upton",
     "latitude": 53.3865027098,
     "longitude": -3.0841516558
   },
   "UPW": {
-    "station_name": "Upwey Rail Station",
+    "station_name": "Upwey",
     "latitude": 50.6482597109,
     "longitude": -2.4661355254
   },
   "URM": {
-    "station_name": "Urmston Rail Station",
+    "station_name": "Urmston",
     "latitude": 53.4482848621,
     "longitude": -2.353796027
   },
   "UTT": {
-    "station_name": "Uttoxeter Rail Station",
+    "station_name": "Uttoxeter",
     "latitude": 52.896806652,
     "longitude": -1.8572519121
   },
   "UTY": {
-    "station_name": "Upper Tyndrum Rail Station",
+    "station_name": "Upper Tyndrum",
     "latitude": 56.4346498324,
     "longitude": -4.7037058912
   },
   "UWL": {
-    "station_name": "Upper Warlingham Rail Station",
+    "station_name": "Upper Warlingham",
     "latitude": 51.3085086648,
     "longitude": -0.0779244127
   },
   "VAL": {
-    "station_name": "Valley Rail Station",
+    "station_name": "Valley",
     "latitude": 53.2813003565,
     "longitude": -4.5633754695
   },
   "VIC": {
-    "station_name": "London Victoria Rail Station",
+    "station_name": "London Victoria",
     "latitude": 51.4952569307,
     "longitude": -0.144534171
   },
   "VIR": {
-    "station_name": "Virginia Water Rail Station",
+    "station_name": "Virginia Water",
     "latitude": 51.4018001404,
     "longitude": -0.5621549173
   },
   "VXH": {
-    "station_name": "Vauxhall Rail Station",
+    "station_name": "Vauxhall",
     "latitude": 51.4861891618,
     "longitude": -0.1228646018
   },
   "WAC": {
-    "station_name": "Warrington Central Rail Station",
+    "station_name": "Warrington Central",
     "latitude": 53.3918305175,
     "longitude": -2.5931678177
   },
   "WAD": {
-    "station_name": "Wadhurst Rail Station",
+    "station_name": "Wadhurst",
     "latitude": 51.0734564722,
     "longitude": 0.3132008907
   },
   "WAE": {
-    "station_name": "London Waterloo East Rail Station",
+    "station_name": "London Waterloo East",
     "latitude": 51.504075761,
     "longitude": -0.108872757
   },
   "WAF": {
-    "station_name": "Wallyford Rail Station",
+    "station_name": "Wallyford",
     "latitude": 55.9402786267,
     "longitude": -3.0149549323
   },
   "WAL": {
-    "station_name": "Walton-on-Thames Rail Station",
+    "station_name": "Walton-on-Thames",
     "latitude": 51.3729282422,
     "longitude": -0.4146141512
   },
   "WAM": {
-    "station_name": "Walmer Rail Station",
+    "station_name": "Walmer",
     "latitude": 51.2033289364,
     "longitude": 1.3829045251
   },
   "WAN": {
-    "station_name": "Wanborough Rail Station",
+    "station_name": "Wanborough",
     "latitude": 51.2445185634,
     "longitude": -0.6675689513
   },
   "WAO": {
-    "station_name": "Walton (Merseyside) Rail Station",
+    "station_name": "Walton (Merseyside)",
     "latitude": 53.4562297489,
     "longitude": -2.9657463744
   },
   "WAR": {
-    "station_name": "Ware Rail Station",
+    "station_name": "Ware",
     "latitude": 51.8079649403,
     "longitude": -0.0287536426
   },
   "WAS": {
-    "station_name": "Watton-at-Stone Rail Station",
+    "station_name": "Watton-at-Stone",
     "latitude": 51.8564430342,
     "longitude": -0.1194009287
   },
   "WAT": {
-    "station_name": "London Waterloo Rail Station",
+    "station_name": "London Waterloo",
     "latitude": 51.5032982602,
     "longitude": -0.1130836248
   },
+  "WAW":{
+    "station_name":"Warrington West",
+    "latitude": 53.393744,
+    "longitude": 2.636929
+  },
   "WAV": {
-    "station_name": "Wavertree Technology Park Rail Station",
+    "station_name": "Wavertree Technology Park",
     "latitude": 53.405206521,
     "longitude": -2.9229088929
   },
   "WBC": {
-    "station_name": "Waterbeach Rail Station",
+    "station_name": "Waterbeach",
     "latitude": 52.2623177182,
     "longitude": 0.1968191721
   },
   "WBD": {
-    "station_name": "Whitley Bridge Rail Station",
+    "station_name": "Whitley Bridge",
     "latitude": 53.6991474904,
     "longitude": -1.1582841752
   },
   "WBL": {
-    "station_name": "Warblington Rail Station",
+    "station_name": "Warblington",
     "latitude": 50.8534343877,
     "longitude": -0.9671408737
   },
   "WBO": {
-    "station_name": "Wimbledon Chase Rail Station",
+    "station_name": "Wimbledon Chase",
     "latitude": 51.4095558211,
     "longitude": -0.214007061
   },
   "WBP": {
-    "station_name": "West Brompton Rail Station",
+    "station_name": "West Brompton",
     "latitude": 51.4870605518,
     "longitude": -0.1955689841
   },
   "WBQ": {
-    "station_name": "Warrington Bank Quay Rail Station",
+    "station_name": "Warrington Bank Quay",
     "latitude": 53.3860225082,
     "longitude": -2.6023634292
   },
   "WBR": {
-    "station_name": "Whaley Bridge Rail Station",
+    "station_name": "Whaley Bridge",
     "latitude": 53.3302489394,
     "longitude": -1.9846443668
   },
   "WBY": {
-    "station_name": "West Byfleet Rail Station",
+    "station_name": "West Byfleet",
     "latitude": 51.3392223062,
     "longitude": -0.5054647648
   },
   "WCB": {
-    "station_name": "Westcombe Park Rail Station",
+    "station_name": "Westcombe Park",
     "latitude": 51.484201535,
     "longitude": 0.0184203333
   },
   "WCF": {
-    "station_name": "Westcliff-on-Sea Rail Station",
+    "station_name": "Westcliff-on-Sea",
     "latitude": 51.5373355032,
     "longitude": 0.6914948438
   },
   "WCH": {
-    "station_name": "Whitchurch (Hants) Rail Station",
+    "station_name": "Whitchurch (Hants)",
     "latitude": 51.2375390314,
     "longitude": -1.3377316326
   },
   "WCK": {
-    "station_name": "Wick Rail Station",
+    "station_name": "Wick",
     "latitude": 58.441552763,
     "longitude": -3.0968646871
   },
   "WCL": {
-    "station_name": "West Calder Rail Station",
+    "station_name": "West Calder",
     "latitude": 55.8537981997,
     "longitude": -3.5670119586
   },
   "WCM": {
-    "station_name": "Wickham Market Rail Station",
+    "station_name": "Wickham Market",
     "latitude": 52.151115559,
     "longitude": 1.3987106267
   },
   "WCP": {
-    "station_name": "Worcester Park Rail Station",
+    "station_name": "Worcester Park",
     "latitude": 51.3812496853,
     "longitude": -0.2451435039
   },
   "WCR": {
-    "station_name": "Whitecraigs Rail Station",
+    "station_name": "Whitecraigs",
     "latitude": 55.7903161404,
     "longitude": -4.310143285
   },
   "WCX": {
-    "station_name": "Wembley Stadium Rail Station",
+    "station_name": "Wembley Stadium",
     "latitude": 51.5544157634,
     "longitude": -0.2855850739
   },
   "WCY": {
-    "station_name": "West Croydon Rail Station",
+    "station_name": "West Croydon",
     "latitude": 51.3784258204,
     "longitude": -0.1025603616
   },
   "WDB": {
-    "station_name": "Woodbridge Rail Station",
+    "station_name": "Woodbridge",
     "latitude": 52.0904601291,
     "longitude": 1.317801029
   },
   "WDD": {
-    "station_name": "Widdrington Rail Station",
+    "station_name": "Widdrington",
     "latitude": 55.2413084934,
     "longitude": -1.6164875215
   },
   "WDE": {
-    "station_name": "Wood End Rail Station",
+    "station_name": "Wood End",
     "latitude": 52.3436934001,
     "longitude": -1.8442057013
   },
   "WDH": {
-    "station_name": "Woodhouse Rail Station",
+    "station_name": "Woodhouse",
     "latitude": 53.363760625,
     "longitude": -1.357553357
   },
   "WDL": {
-    "station_name": "Woodhall Rail Station",
+    "station_name": "Woodhall",
     "latitude": 55.9311983025,
     "longitude": -4.6553823064
   },
   "WDM": {
-    "station_name": "Windermere Rail Station",
+    "station_name": "Windermere",
     "latitude": 54.3796096377,
     "longitude": -2.9033943659
   },
   "WDN": {
-    "station_name": "Walsden Rail Station",
+    "station_name": "Walsden",
     "latitude": 53.6962732634,
     "longitude": -2.104464907
   },
   "WDO": {
-    "station_name": "Waddon Rail Station",
+    "station_name": "Waddon",
     "latitude": 51.3673957219,
     "longitude": -0.1173106836
   },
   "WDS": {
-    "station_name": "Woodlesford Rail Station",
+    "station_name": "Woodlesford",
     "latitude": 53.7568021778,
     "longitude": -1.4428831514
   },
   "WDT": {
-    "station_name": "West Drayton Rail Station",
+    "station_name": "West Drayton",
     "latitude": 51.5100546283,
     "longitude": -0.4722138153
   },
   "WDU": {
-    "station_name": "West Dulwich Rail Station",
+    "station_name": "West Dulwich",
     "latitude": 51.4407162507,
     "longitude": -0.0913457383
   },
   "WEA": {
-    "station_name": "West Ealing Rail Station",
+    "station_name": "West Ealing",
     "latitude": 51.5135045768,
     "longitude": -0.3201109918
   },
   "WED": {
-    "station_name": "Wedgwood Rail Station",
+    "station_name": "Wedgwood",
     "latitude": 52.951063264,
     "longitude": -2.1708212356
   },
   "WEE": {
-    "station_name": "Weeley Rail Station",
+    "station_name": "Weeley",
     "latitude": 51.8531089886,
     "longitude": 1.115513113
   },
   "WEH": {
-    "station_name": "West Ham Rail Station",
+    "station_name": "West Ham",
     "latitude": 51.5284892546,
     "longitude": 0.0054585883
   },
   "WEL": {
-    "station_name": "Wellingborough Rail Station",
+    "station_name": "Wellingborough",
     "latitude": 52.3037949376,
     "longitude": -0.6766340582
   },
   "WEM": {
-    "station_name": "Wem Rail Station",
+    "station_name": "Wem",
     "latitude": 52.8564224306,
     "longitude": -2.7180138594
   },
   "WES": {
-    "station_name": "Westerton Rail Station",
+    "station_name": "Westerton",
     "latitude": 55.9047998365,
     "longitude": -4.3348647949
   },
   "WET": {
-    "station_name": "Weeton Rail Station",
+    "station_name": "Weeton",
     "latitude": 53.9231914641,
     "longitude": -1.5812210981
   },
   "WEY": {
-    "station_name": "Weymouth Rail Station",
+    "station_name": "Weymouth",
     "latitude": 50.6153023761,
     "longitude": -2.4542188409
   },
   "WFF": {
-    "station_name": "Whifflet Rail Station",
+    "station_name": "Whifflet",
     "latitude": 55.8536860909,
     "longitude": -4.0186440499
   },
   "WFH": {
-    "station_name": "Watford High Street Rail Station",
+    "station_name": "Watford High Street",
     "latitude": 51.6526581832,
     "longitude": -0.3916880939
   },
   "WFI": {
-    "station_name": "Westerfield Rail Station",
+    "station_name": "Westerfield",
     "latitude": 52.0809953585,
     "longitude": 1.1659358409
   },
   "WFJ": {
-    "station_name": "Watford Junction Rail Station",
+    "station_name": "Watford Junction",
     "latitude": 51.6635326348,
     "longitude": -0.3964938369
   },
   "WFL": {
-    "station_name": "Wainfleet Rail Station",
+    "station_name": "Wainfleet",
     "latitude": 53.1051521478,
     "longitude": 0.2347308866
   },
   "WFN": {
-    "station_name": "Watford North Rail Station",
+    "station_name": "Watford North",
     "latitude": 51.6757075829,
     "longitude": -0.3899023411
   },
   "WGA": {
-    "station_name": "Westgate-on-Sea Rail Station",
+    "station_name": "Westgate-on-Sea",
     "latitude": 51.3814500239,
     "longitude": 1.3383886434
   },
   "WGC": {
-    "station_name": "Welwyn Garden City Rail Station",
+    "station_name": "Welwyn Garden City",
     "latitude": 51.8010528857,
     "longitude": -0.2040464223
   },
   "WGN": {
-    "station_name": "Wigan North Western Rail Station",
+    "station_name": "Wigan North Western",
     "latitude": 53.5436746706,
     "longitude": -2.6332734056
   },
   "WGR": {
-    "station_name": "Woodgrange Park Rail Station",
+    "station_name": "Woodgrange Park",
     "latitude": 51.5492631072,
     "longitude": 0.0444499653
   },
   "WGT": {
-    "station_name": "Wigton Rail Station",
+    "station_name": "Wigton",
     "latitude": 54.8291221455,
     "longitude": -3.1643456818
   },
   "WGV": {
-    "station_name": "Wargrave Rail Station",
+    "station_name": "Wargrave",
     "latitude": 51.4981592025,
     "longitude": -0.8764978044
   },
   "WGW": {
-    "station_name": "Wigan Wallgate Rail Station",
+    "station_name": "Wigan Wallgate",
     "latitude": 53.5448346342,
     "longitude": -2.633185063
   },
   "WHA": {
-    "station_name": "Westenhanger Rail Station",
+    "station_name": "Westenhanger",
     "latitude": 51.0949607041,
     "longitude": 1.0380815591
   },
   "WHC": {
-    "station_name": "Walthamstow Central Rail Station",
+    "station_name": "Walthamstow Central",
     "latitude": 51.5829189505,
     "longitude": -0.0197878799
   },
   "WHD": {
-    "station_name": "West Hampstead Rail Station",
+    "station_name": "West Hampstead",
     "latitude": 51.5474681384,
     "longitude": -0.1911595369
   },
   "WHE": {
-    "station_name": "Whalley Rail Station",
+    "station_name": "Whalley",
     "latitude": 53.8240295678,
     "longitude": -2.412253049
   },
   "WHG": {
-    "station_name": "Westhoughton Rail Station",
+    "station_name": "Westhoughton",
     "latitude": 53.5556848068,
     "longitude": -2.5237269574
   },
   "WHI": {
-    "station_name": "Whitstable Rail Station",
+    "station_name": "Whitstable",
     "latitude": 51.3575849431,
     "longitude": 1.0333248141
   },
   "WHL": {
-    "station_name": "White Hart Lane Rail Station",
+    "station_name": "White Hart Lane",
     "latitude": 51.6050372456,
     "longitude": -0.0708886785
   },
   "WHM": {
-    "station_name": "Whimple Rail Station",
+    "station_name": "Whimple",
     "latitude": 50.7680161469,
     "longitude": -3.3543350506
   },
   "WHN": {
-    "station_name": "Whiston Rail Station",
+    "station_name": "Whiston",
     "latitude": 53.4138830477,
     "longitude": -2.7964313384
   },
   "WHP": {
-    "station_name": "West Hampstead Thameslink Rail Station",
+    "station_name": "West Hampstead Thameslink",
     "latitude": 51.5484763715,
     "longitude": -0.1918118442
   },
   "WHR": {
-    "station_name": "West Horndon Rail Station",
+    "station_name": "West Horndon",
     "latitude": 51.5679455135,
     "longitude": 0.3406719119
   },
   "WHS": {
-    "station_name": "Whyteleafe South Rail Station",
+    "station_name": "Whyteleafe South",
     "latitude": 51.3033836423,
     "longitude": -0.076890083
   },
   "WHT": {
-    "station_name": "Whitchurch (Cardiff) Rail Station",
+    "station_name": "Whitchurch (Cardiff)",
     "latitude": 51.5207503854,
     "longitude": -3.2232604275
   },
   "WHY": {
-    "station_name": "Whyteleafe Rail Station",
+    "station_name": "Whyteleafe",
     "latitude": 51.3099550362,
     "longitude": -0.0811212248
   },
   "WIC": {
-    "station_name": "Wickford Rail Station",
+    "station_name": "Wickford",
     "latitude": 51.6150252316,
     "longitude": 0.5192126597
   },
   "WID": {
-    "station_name": "Widnes Rail Station",
+    "station_name": "Widnes",
     "latitude": 53.3785111245,
     "longitude": -2.7335372039
   },
   "WIH": {
-    "station_name": "Winchmore Hill Rail Station",
+    "station_name": "Winchmore Hill",
     "latitude": 51.6339428901,
     "longitude": -0.1008743449
   },
   "WIJ": {
-    "station_name": "Willesden Junction Rail Station",
+    "station_name": "Willesden Junction",
     "latitude": 51.5324966867,
     "longitude": -0.2445240688
   },
   "WIL": {
-    "station_name": "Willington Rail Station",
+    "station_name": "Willington",
     "latitude": 52.8536609081,
     "longitude": -1.5633566039
   },
   "WIM": {
-    "station_name": "Wimbledon Rail Station",
+    "station_name": "Wimbledon",
     "latitude": 51.4212733693,
     "longitude": -0.2063586485
   },
   "WIN": {
-    "station_name": "Winchester Rail Station",
+    "station_name": "Winchester",
     "latitude": 51.0672031347,
     "longitude": -1.3196880282
   },
   "WIV": {
-    "station_name": "Wivenhoe Rail Station",
+    "station_name": "Wivenhoe",
     "latitude": 51.8565396555,
     "longitude": 0.9561671919
   },
   "WKB": {
-    "station_name": "West Kilbride Rail Station",
+    "station_name": "West Kilbride",
     "latitude": 55.6961504044,
     "longitude": -4.8517231169
   },
   "WKD": {
-    "station_name": "Walkden Rail Station",
+    "station_name": "Walkden",
     "latitude": 53.5197896484,
     "longitude": -2.3963191924
   },
   "WKF": {
-    "station_name": "Wakefield Westgate Rail Station",
+    "station_name": "Wakefield Westgate",
     "latitude": 53.6830884864,
     "longitude": -1.5061128915
   },
   "WKG": {
-    "station_name": "Workington Rail Station",
+    "station_name": "Workington",
     "latitude": 54.6451016394,
     "longitude": -3.5585006973
   },
   "WKI": {
-    "station_name": "West Kirby Rail Station",
+    "station_name": "West Kirby",
     "latitude": 53.3731876944,
     "longitude": -3.1837707177
   },
   "WKK": {
-    "station_name": "Wakefield Kirkgate Rail Station",
+    "station_name": "Wakefield Kirkgate",
     "latitude": 53.6786734429,
     "longitude": -1.4885726643
   },
   "WKM": {
-    "station_name": "Wokingham Rail Station",
+    "station_name": "Wokingham",
     "latitude": 51.4112171669,
     "longitude": -0.8425250632
   },
   "WLC": {
-    "station_name": "Waltham Cross Rail Station",
+    "station_name": "Waltham Cross",
     "latitude": 51.6850619631,
     "longitude": -0.0265322372
   },
   "WLD": {
-    "station_name": "West St Leonards Rail Station",
+    "station_name": "West St Leonards",
     "latitude": 50.8531478652,
     "longitude": 0.539964669
   },
   "WLE": {
-    "station_name": "Whittlesea Rail Station",
+    "station_name": "Whittlesea",
     "latitude": 52.5495457817,
     "longitude": -0.1189720533
   },
   "WLF": {
-    "station_name": "Whittlesford Parkway Rail Station",
+    "station_name": "Whittlesford Parkway",
     "latitude": 52.1035981209,
     "longitude": 0.1656457011
   },
   "WLG": {
-    "station_name": "Wallasey Grove Road Rail Station",
+    "station_name": "Wallasey Grove Road",
     "latitude": 53.4280187313,
     "longitude": -3.069705311
   },
   "WLH": {
-    "station_name": "Wolsingham Rail Station",
+    "station_name": "Wolsingham",
     "latitude": 54.7263219512,
     "longitude": -1.8835277375
   },
   "WLI": {
-    "station_name": "Welling Rail Station",
+    "station_name": "Welling",
     "latitude": 51.4647970094,
     "longitude": 0.1017165383
   },
   "WLM": {
-    "station_name": "Williamwood Rail Station",
+    "station_name": "Williamwood",
     "latitude": 55.7936801397,
     "longitude": -4.2903211229
   },
   "WLN": {
-    "station_name": "Wellington (Shropshire) Rail Station",
+    "station_name": "Wellington (Shropshire)",
     "latitude": 52.7013189006,
     "longitude": -2.5171628549
   },
   "WLO": {
-    "station_name": "Waterloo (Merseyside) Rail Station",
+    "station_name": "Waterloo (Merseyside)",
     "latitude": 53.4749677015,
     "longitude": -3.0255345128
   },
   "WLP": {
-    "station_name": "Welshpool Rail Station",
+    "station_name": "Welshpool",
     "latitude": 52.6575072859,
     "longitude": -3.1398692323
   },
   "WLS": {
-    "station_name": "Woolston Rail Station",
+    "station_name": "Woolston",
     "latitude": 50.898912011,
     "longitude": -1.3770486087
   },
   "WLT": {
-    "station_name": "Wallington Rail Station",
+    "station_name": "Wallington",
     "latitude": 51.3603838072,
     "longitude": -0.1508078249
   },
   "WLV": {
-    "station_name": "Wallasey Village Rail Station",
+    "station_name": "Wallasey Village",
     "latitude": 53.4229003142,
     "longitude": -3.0691254064
   },
   "WLW": {
-    "station_name": "Welwyn North Rail Station",
+    "station_name": "Welwyn North",
     "latitude": 51.8235025409,
     "longitude": -0.1920673777
   },
   "WLY": {
-    "station_name": "Woodley Rail Station",
+    "station_name": "Woodley",
     "latitude": 53.4292679007,
     "longitude": -2.0932702851
   },
   "WMA": {
-    "station_name": "West Malling Rail Station",
+    "station_name": "West Malling",
     "latitude": 51.2920176581,
     "longitude": 0.4186819525
   },
   "WMB": {
-    "station_name": "Wembley Central Rail Station",
+    "station_name": "Wembley Central",
     "latitude": 51.552325148,
     "longitude": -0.2964096325
   },
   "WMC": {
-    "station_name": "Wilmcote Rail Station",
+    "station_name": "Wilmcote",
     "latitude": 52.2230107026,
     "longitude": -1.7560030891
   },
   "WMD": {
-    "station_name": "Wymondham Rail Station",
+    "station_name": "Wymondham",
     "latitude": 52.5654338739,
     "longitude": 1.1180480575
   },
   "WME": {
-    "station_name": "Woodmansterne Rail Station",
+    "station_name": "Woodmansterne",
     "latitude": 51.3190162934,
     "longitude": -0.1542365305
   },
   "WMG": {
-    "station_name": "Welham Green Rail Station",
+    "station_name": "Welham Green",
     "latitude": 51.736355041,
     "longitude": -0.210669375
   },
   "WMI": {
-    "station_name": "Wildmill Rail Station",
+    "station_name": "Wildmill",
     "latitude": 51.5208701744,
     "longitude": -3.5796491532
   },
   "WML": {
-    "station_name": "Wilmslow Rail Station",
+    "station_name": "Wilmslow",
     "latitude": 53.3268623597,
     "longitude": -2.226326187
   },
   "WMN": {
-    "station_name": "Warminster Rail Station",
+    "station_name": "Warminster",
     "latitude": 51.2067697704,
     "longitude": -2.1767285454
   },
   "WMR": {
-    "station_name": "Widney Manor Rail Station",
+    "station_name": "Widney Manor",
     "latitude": 52.3959484322,
     "longitude": -1.7743630129
   },
   "WMS": {
-    "station_name": "Wemyss Bay Rail Station",
+    "station_name": "Wemyss Bay",
     "latitude": 55.8761375469,
     "longitude": -4.8890595221
   },
   "WMW": {
-    "station_name": "Walthamstow Queens Road Rail Station",
+    "station_name": "Walthamstow Queens Road",
     "latitude": 51.5815031634,
     "longitude": -0.0238187685
   },
   "WNC": {
-    "station_name": "Windsor & Eton Central Rail Station",
+    "station_name": "Windsor & Eton Central",
     "latitude": 51.4832677885,
     "longitude": -0.6103634231
   },
   "WND": {
-    "station_name": "Wendover Rail Station",
+    "station_name": "Wendover",
     "latitude": 51.7617617158,
     "longitude": -0.7473477525
   },
   "WNE": {
-    "station_name": "Wilnecote (Staffs) Rail Station",
+    "station_name": "Wilnecote (Staffs)",
     "latitude": 52.6107271717,
     "longitude": -1.6797075751
   },
   "WNF": {
-    "station_name": "Winchfield Rail Station",
+    "station_name": "Winchfield",
     "latitude": 51.2849477502,
     "longitude": -0.9069607416
   },
   "WNG": {
-    "station_name": "Waun-gron Park Rail Station",
+    "station_name": "Waun-gron Park",
     "latitude": 51.4881949213,
     "longitude": -3.2296615036
   },
   "WNH": {
-    "station_name": "Warnham Rail Station",
+    "station_name": "Warnham",
     "latitude": 51.0928963956,
     "longitude": -0.3294372471
   },
   "WNL": {
-    "station_name": "Whinhill Rail Station",
+    "station_name": "Whinhill",
     "latitude": 55.9383637813,
     "longitude": -4.7466746978
   },
   "WNM": {
-    "station_name": "Weston Milton Rail Station",
+    "station_name": "Weston Milton",
     "latitude": 51.348465771,
     "longitude": -2.9423917485
   },
   "WNN": {
-    "station_name": "Wennington Rail Station",
+    "station_name": "Wennington",
     "latitude": 54.1237145615,
     "longitude": -2.5875119193
   },
   "WNP": {
-    "station_name": "Wanstead Park Rail Station",
+    "station_name": "Wanstead Park",
     "latitude": 51.5516926945,
     "longitude": 0.0262400164
   },
   "WNR": {
-    "station_name": "Windsor & Eton Riverside Rail Station",
+    "station_name": "Windsor & Eton Riverside",
     "latitude": 51.4856499617,
     "longitude": -0.6065175067
   },
   "WNS": {
-    "station_name": "Winnersh Rail Station",
+    "station_name": "Winnersh",
     "latitude": 51.4302818498,
     "longitude": -0.87683995
   },
   "WNT": {
-    "station_name": "Wandsworth Town Rail Station",
+    "station_name": "Wandsworth Town",
     "latitude": 51.4610465985,
     "longitude": -0.1881010831
   },
   "WNW": {
-    "station_name": "West Norwood Rail Station",
+    "station_name": "West Norwood",
     "latitude": 51.4317458109,
     "longitude": -0.1038042183
   },
   "WNY": {
-    "station_name": "White Notley Rail Station",
+    "station_name": "White Notley",
     "latitude": 51.8389190888,
     "longitude": 0.5958911326
   },
   "WOB": {
-    "station_name": "Woburn Sands Rail Station",
+    "station_name": "Woburn Sands",
     "latitude": 52.0181602116,
     "longitude": -0.6540621907
   },
   "WOF": {
-    "station_name": "Worcester Foregate Street Rail Station",
+    "station_name": "Worcester Foregate Street",
     "latitude": 52.1951552361,
     "longitude": -2.2215923384
   },
   "WOH": {
-    "station_name": "Woldingham Rail Station",
+    "station_name": "Woldingham",
     "latitude": 51.2901548311,
     "longitude": -0.0518430517
   },
   "WOK": {
-    "station_name": "Woking Rail Station",
+    "station_name": "Woking",
     "latitude": 51.3184663679,
     "longitude": -0.5569403769
   },
   "WOL": {
-    "station_name": "Wolverton Rail Station",
+    "station_name": "Wolverton",
     "latitude": 52.0658873901,
     "longitude": -0.8042463611
   },
   "WOM": {
-    "station_name": "Wombwell Rail Station",
+    "station_name": "Wombwell",
     "latitude": 53.517362766,
     "longitude": -1.4161637925
   },
   "WON": {
-    "station_name": "Walton-on-the-Naze Rail Station",
+    "station_name": "Walton-on-the-Naze",
     "latitude": 51.8461792474,
     "longitude": 1.2676990657
   },
   "WOO": {
-    "station_name": "Wool Rail Station",
+    "station_name": "Wool",
     "latitude": 50.681626061,
     "longitude": -2.2214563212
   },
+  "WOP":{
+    "station_name":"Worcestershire Parkway","latitude":52.1556,"longitude": -2.1609
+  },
   "WOR": {
-    "station_name": "Worle Rail Station",
+    "station_name": "Worle",
     "latitude": 51.3580317777,
     "longitude": -2.9096264535
   },
   "WOS": {
-    "station_name": "Worcester Shrub Hill Rail Station",
+    "station_name": "Worcester Shrub Hill",
     "latitude": 52.194736867,
     "longitude": -2.2094036358
   },
   "WPE": {
-    "station_name": "Wapping Rail Station",
+    "station_name": "Wapping",
     "latitude": 51.5043874917,
     "longitude": -0.0559045836
   },
   "WPL": {
-    "station_name": "Worplesdon Rail Station",
+    "station_name": "Worplesdon",
     "latitude": 51.289013057,
     "longitude": -0.5825586496
   },
   "WRB": {
-    "station_name": "Wrabness Rail Station",
+    "station_name": "Wrabness",
     "latitude": 51.9395205813,
     "longitude": 1.1715280173
   },
   "WRE": {
-    "station_name": "Wrenbury Rail Station",
+    "station_name": "Wrenbury",
     "latitude": 53.0194020901,
     "longitude": -2.5959470421
   },
   "WRH": {
-    "station_name": "Worthing Rail Station",
+    "station_name": "Worthing",
     "latitude": 50.8184892196,
     "longitude": -0.3761461656
   },
   "WRK": {
-    "station_name": "Worksop Rail Station",
+    "station_name": "Worksop",
     "latitude": 53.3115252628,
     "longitude": -1.1227713307
   },
   "WRL": {
-    "station_name": "Wetheral Rail Station",
+    "station_name": "Wetheral",
     "latitude": 54.8838456329,
     "longitude": -2.8317175358
   },
   "WRM": {
-    "station_name": "Wareham Rail Station",
+    "station_name": "Wareham",
     "latitude": 50.6928762389,
     "longitude": -2.1152411345
   },
   "WRN": {
-    "station_name": "West Runton Rail Station",
+    "station_name": "West Runton",
     "latitude": 52.9355527634,
     "longitude": 1.2454754855
   },
   "WRP": {
-    "station_name": "Warwick Parkway Rail Station",
+    "station_name": "Warwick Parkway",
     "latitude": 52.2861162934,
     "longitude": -1.6120460343
   },
   "WRS": {
-    "station_name": "Wressle Rail Station",
+    "station_name": "Wressle",
     "latitude": 53.7729422572,
     "longitude": -0.9243539655
   },
   "WRT": {
-    "station_name": "Worstead Rail Station",
+    "station_name": "Worstead",
     "latitude": 52.7774520547,
     "longitude": 1.4041024484
   },
   "WRU": {
-    "station_name": "West Ruislip Rail Station",
+    "station_name": "West Ruislip",
     "latitude": 51.5697585389,
     "longitude": -0.4377469365
   },
   "WRW": {
-    "station_name": "Warwick Rail Station",
+    "station_name": "Warwick",
     "latitude": 52.2865527555,
     "longitude": -1.5818426042
   },
   "WRX": {
-    "station_name": "Wrexham General Rail Station",
+    "station_name": "Wrexham General",
     "latitude": 53.0502463948,
     "longitude": -3.0024435025
   },
   "WRY": {
-    "station_name": "Wraysbury Rail Station",
+    "station_name": "Wraysbury",
     "latitude": 51.4577071718,
     "longitude": -0.5419033065
   },
   "WSA": {
-    "station_name": "West Allerton Rail Station",
+    "station_name": "West Allerton",
     "latitude": 53.3691394493,
     "longitude": -2.9069642345
   },
   "WSB": {
-    "station_name": "Westbury (Wilts) Rail Station",
+    "station_name": "Westbury (Wilts)",
     "latitude": 51.2669801221,
     "longitude": -2.1991779411
   },
   "WSE": {
-    "station_name": "Winchelsea Rail Station",
+    "station_name": "Winchelsea",
     "latitude": 50.933760407,
     "longitude": 0.7022917517
   },
   "WSF": {
-    "station_name": "Winsford Rail Station",
+    "station_name": "Winsford",
     "latitude": 53.190525188,
     "longitude": -2.4945975727
   },
   "WSH": {
-    "station_name": "Wishaw Rail Station",
+    "station_name": "Wishaw",
     "latitude": 55.7720379365,
     "longitude": -3.9264142917
   },
   "WSL": {
-    "station_name": "Walsall Rail Station",
+    "station_name": "Walsall",
     "latitude": 52.5844123362,
     "longitude": -1.9847496237
   },
   "WSM": {
-    "station_name": "Weston-super-Mare Rail Station",
+    "station_name": "Weston-super-Mare",
     "latitude": 51.3443145157,
     "longitude": -2.9716684624
   },
   "WSR": {
-    "station_name": "Woodsmoor Rail Station",
+    "station_name": "Woodsmoor",
     "latitude": 53.3864885313,
     "longitude": -2.1420856045
   },
   "WST": {
-    "station_name": "Wood Street Rail Station",
+    "station_name": "Wood Street",
     "latitude": 51.5865803321,
     "longitude": -0.0023784573
   },
   "WSU": {
-    "station_name": "West Sutton Rail Station",
+    "station_name": "West Sutton",
     "latitude": 51.3658510426,
     "longitude": -0.2051484336
   },
   "WSW": {
-    "station_name": "Wandsworth Common Rail Station",
+    "station_name": "Wandsworth Common",
     "latitude": 51.4461834495,
     "longitude": -0.1633607829
   },
   "WTA": {
-    "station_name": "Wester Hailes Rail Station",
+    "station_name": "Wester Hailes",
     "latitude": 55.9143114673,
     "longitude": -3.2843381703
   },
   "WTB": {
-    "station_name": "Whitby Rail Station",
+    "station_name": "Whitby",
     "latitude": 54.4846228934,
     "longitude": -0.6154196587
   },
   "WTC": {
-    "station_name": "Whitchurch (Shrops) Rail Station",
+    "station_name": "Whitchurch (Shrops)",
     "latitude": 52.9680723073,
     "longitude": -2.6716975313
   },
   "WTE": {
-    "station_name": "Whitlocks End Rail Station",
+    "station_name": "Whitlocks End",
     "latitude": 52.3918444057,
     "longitude": -1.8515316565
   },
   "WTG": {
-    "station_name": "Watlington Rail Station",
+    "station_name": "Watlington",
     "latitude": 52.6731905958,
     "longitude": 0.383333413
   },
   "WTH": {
-    "station_name": "Whitehaven Rail Station",
+    "station_name": "Whitehaven",
     "latitude": 54.5530370984,
     "longitude": -3.5869341489
   },
   "WTI": {
-    "station_name": "Winnersh Triangle Rail Station",
+    "station_name": "Winnersh Triangle",
     "latitude": 51.436740952,
     "longitude": -0.891312814
   },
   "WTL": {
-    "station_name": "Whitland Rail Station",
+    "station_name": "Whitland",
     "latitude": 51.8180389016,
     "longitude": -4.6144179575
   },
   "WTM": {
-    "station_name": "Witham (Essex) Rail Station",
+    "station_name": "Witham (Essex)",
     "latitude": 51.8059754077,
     "longitude": 0.6391569064
   },
   "WTN": {
-    "station_name": "Whitton Rail Station",
+    "station_name": "Whitton",
     "latitude": 51.4496053939,
     "longitude": -0.3576601374
   },
   "WTO": {
-    "station_name": "Water Orton Rail Station",
+    "station_name": "Water Orton",
     "latitude": 52.5185987323,
     "longitude": -1.743083154
   },
   "WTR": {
-    "station_name": "Wateringbury Rail Station",
+    "station_name": "Wateringbury",
     "latitude": 51.2497316844,
     "longitude": 0.4224946816
   },
   "WTS": {
-    "station_name": "Whatstandwell Rail Station",
+    "station_name": "Whatstandwell",
     "latitude": 53.0833304944,
     "longitude": -1.5040836241
   },
   "WTT": {
-    "station_name": "Witton (West Midlands) Rail Station",
+    "station_name": "Witton (West Midlands)",
     "latitude": 52.512392581,
     "longitude": -1.88442989
   },
   "WTY": {
-    "station_name": "Witley Rail Station",
+    "station_name": "Witley",
     "latitude": 51.1331560769,
     "longitude": -0.6457625387
   },
   "WVF": {
-    "station_name": "Wivelsfield Rail Station",
+    "station_name": "Wivelsfield",
     "latitude": 50.9642899705,
     "longitude": -0.1207633726
   },
   "WVH": {
-    "station_name": "Wolverhampton Rail Station",
+    "station_name": "Wolverhampton",
     "latitude": 52.5878584294,
     "longitude": -2.1195080884
   },
   "WWA": {
-    "station_name": "Woolwich Arsenal Rail Station",
+    "station_name": "Woolwich Arsenal",
     "latitude": 51.4899075996,
     "longitude": 0.0692207097
   },
+  "WWC": {
+    "station_name": "Woolwich",
+    "latitude": 51.491578,
+    "longitude": 0.071819
+  },
   "WWD": {
-    "station_name": "Woolwich Dockyard Rail Station",
+    "station_name": "Woolwich Dockyard",
     "latitude": 51.4911257712,
     "longitude": 0.0546684641
   },
   "WWI": {
-    "station_name": "West Wickham Rail Station",
+    "station_name": "West Wickham",
     "latitude": 51.381299435,
     "longitude": -0.01440507
   },
   "WWL": {
-    "station_name": "Whitwell (Derbys) Rail Station",
+    "station_name": "Whitwell (Derbys)",
     "latitude": 53.2799805667,
     "longitude": -1.2002056127
   },
   "WWO": {
-    "station_name": "West Worthing Rail Station",
+    "station_name": "West Worthing",
     "latitude": 50.8183442209,
     "longitude": -0.3929601185
   },
   "WWR": {
-    "station_name": "Wandsworth Road Rail Station",
+    "station_name": "Wandsworth Road",
     "latitude": 51.4702155479,
     "longitude": -0.1384945236
   },
   "WWW": {
-    "station_name": "Wootton Wawen Rail Station",
+    "station_name": "Wootton Wawen",
     "latitude": 52.2669127478,
     "longitude": -1.7846878163
   },
   "WXC": {
-    "station_name": "Wrexham Central Rail Station",
+    "station_name": "Wrexham Central",
     "latitude": 53.0462026991,
     "longitude": -2.9990529112
   },
   "WYB": {
-    "station_name": "Weybridge Rail Station",
+    "station_name": "Weybridge",
     "latitude": 51.3617683693,
     "longitude": -0.4577187292
   },
   "WYE": {
-    "station_name": "Wye Rail Station",
+    "station_name": "Wye",
     "latitude": 51.1850110281,
     "longitude": 0.9293337289
   },
   "WYL": {
-    "station_name": "Wylde Green Rail Station",
+    "station_name": "Wylde Green",
     "latitude": 52.545726518,
     "longitude": -1.8314010655
   },
   "WYM": {
-    "station_name": "Wylam Rail Station",
+    "station_name": "Wylam",
     "latitude": 54.9749775863,
     "longitude": -1.8140737353
   },
   "WYT": {
-    "station_name": "Wythall Rail Station",
+    "station_name": "Wythall",
     "latitude": 52.3799491076,
     "longitude": -1.8655274464
   },
   "YAE": {
-    "station_name": "Yate Rail Station",
+    "station_name": "Yate",
     "latitude": 51.5405996642,
     "longitude": -2.4325201347
   },
   "YAL": {
-    "station_name": "Yalding Rail Station",
+    "station_name": "Yalding",
     "latitude": 51.2264801343,
     "longitude": 0.4121922549
   },
   "YAT": {
-    "station_name": "Yatton Rail Station",
+    "station_name": "Yatton",
     "latitude": 51.3910100893,
     "longitude": -2.8277833431
   },
   "YEO": {
-    "station_name": "Yeoford Rail Station",
+    "station_name": "Yeoford",
     "latitude": 50.7769135717,
     "longitude": -3.7271368279
   },
   "YET": {
-    "station_name": "Yetminster Rail Station",
+    "station_name": "Yetminster",
     "latitude": 50.8957550733,
     "longitude": -2.5737566578
   },
   "YNW": {
-    "station_name": "Ynyswen Rail Station",
+    "station_name": "Ynyswen",
     "latitude": 51.6649733413,
     "longitude": -3.5216084057
   },
   "YOK": {
-    "station_name": "Yoker Rail Station",
+    "station_name": "Yoker",
     "latitude": 55.8925792728,
     "longitude": -4.3862714831
   },
   "YRD": {
-    "station_name": "Yardley Wood Rail Station",
+    "station_name": "Yardley Wood",
     "latitude": 52.4215152176,
     "longitude": -1.8543739528
   },
   "YRK": {
-    "station_name": "York Rail Station",
+    "station_name": "York",
     "latitude": 53.9579821958,
     "longitude": -1.0931909318
   },
   "YRM": {
-    "station_name": "Yarm Rail Station",
+    "station_name": "Yarm",
     "latitude": 54.493908683,
     "longitude": -1.3515575298
   },
   "YRT": {
-    "station_name": "Yorton Rail Station",
+    "station_name": "Yorton",
     "latitude": 52.8089705446,
     "longitude": -2.736458295
   },
   "YSM": {
-    "station_name": "Ystrad Mynach Rail Station",
+    "station_name": "Ystrad Mynach",
     "latitude": 51.6409356979,
     "longitude": -3.2413052794
   },
   "YSR": {
-    "station_name": "Ystrad Rhondda Rail Station",
+    "station_name": "Ystrad Rhondda",
     "latitude": 51.6436413608,
     "longitude": -3.4666955023
   },
   "YVJ": {
-    "station_name": "Yeovil Junction Rail Station",
+    "station_name": "Yeovil Junction",
     "latitude": 50.9247392604,
     "longitude": -2.6124572985
   },
   "YVP": {
-    "station_name": "Yeovil Pen Mill Rail Station",
+    "station_name": "Yeovil Pen Mill",
     "latitude": 50.9445178485,
     "longitude": -2.6134285854
   },
@@ -12955,22 +13043,22 @@
     "longitude": 0.0178462867
   },
   "ZCW": {
-    "station_name": "Canada Water Rail Station",
+    "station_name": "Canada Water",
     "latitude": 51.4979894212,
     "longitude": -0.0496935895
   },
   "ZFD": {
-    "station_name": "Farringdon (London) Rail Station",
+    "station_name": "Farringdon (London)",
     "latitude": 51.5201671742,
     "longitude": -0.1051789136
   },
   "ZWL": {
-    "station_name": "Whitechapel Rail Station",
+    "station_name": "Whitechapel",
     "latitude": 51.5194686455,
     "longitude": -0.0597305213
   },
   "ZZT": {
-    "station_name": "Lintley Rail Station",
+    "station_name": "Lintley",
     "latitude": 54.853558347,
     "longitude": -2.4883171256
   }

--- a/uk-train-stations-dictonary.json
+++ b/uk-train-stations-dictonary.json
@@ -459,6 +459,11 @@
     "latitude": 51.9989119042,
     "longitude": -2.1087526816
   },
+  "ASD": {
+    "station_name": "Ashley Down",
+    "latitude": 51.4788,
+    "longitude": -2.5767
+    },
   "ASF": {
     "station_name": "Ashfield",
     "latitude": 55.8889152278,
@@ -478,6 +483,11 @@
     "station_name": "Askam",
     "latitude": 54.1889365481,
     "longitude": -3.2045108901
+  },
+  "ASL": {
+    "station_name": "Ashington",
+    "latitude": 55.1820,
+    "longitude": -1.5731
   },
   "ASN": {
     "station_name": "Addlestone",
@@ -2228,6 +2238,11 @@
     "station_name": "Canterbury West",
     "latitude": 51.284271981,
     "longitude": 1.0753330452
+  },
+  "CBX": {
+    "station_name": "Cameron Bridge",
+    "latitude": 56.189693,
+    "longitude": -3.046855
   },
   "CBY": {
     "station_name": "Charlbury",
@@ -6944,6 +6959,11 @@
     "latitude": 53.6988690686,
     "longitude": -2.6871416367
   },
+  "LEV": {
+    "station_name": "Leven",
+    "latitude": 56.1923,
+    "longitude": -3.002
+  },
   "LFD": {
     "station_name": "Lingfield",
     "latitude": 51.1764479512,
@@ -9184,6 +9204,11 @@
     "latitude": 53.7568736745,
     "longitude": -2.7081248286
   },
+  "PRI": {
+    "station_name": "Portway Park and Ride",
+    "latitude": 51.488611,
+    "longitude": -2.688056
+  },
   "PRH": {
     "station_name": "Penrhyndeudraeth",
     "latitude": 52.9288395107,
@@ -9628,6 +9653,11 @@
     "station_name": "Rugeley Trent Valley",
     "latitude": 52.7696708266,
     "longitude": -1.9298468285
+  },
+  "RGP": {
+    "station_name": "Reading Green Park",
+    "latitude": 51.426667,
+    "longitude": -1.001389
   },
   "RGT": {
     "station_name": "Rugeley Town",
@@ -11513,6 +11543,11 @@
     "station_name": "Thornford",
     "latitude": 50.9105671531,
     "longitude": -2.5789881669
+  },
+  "THP": {
+    "station_name": "Thanet Parkway",
+    "latitude": 51.330843,
+    "longitude": 1.361777
   },
   "THS": {
     "station_name": "Thurso",

--- a/uk-train-stations.csv
+++ b/uk-train-stations.csv
@@ -1,2596 +1,2621 @@
 "3alpha","station_name","latitude","longitude"
-"AAP","Alexandra Palace Rail Station",51.5979250073,-0.1202099313
-"AAT","Achanalt Rail Station",57.6095763828,-4.913846165
-"ABA","Aberdare Rail Station",51.7150603368,-3.4430947912
-"ABC","Altnabreac Rail Station",58.3881329239,-3.7062873902
-"ABD","Aberdeen Rail Station",57.1436867734,-2.0986925585
-"ABE","Aber Rail Station",51.5749656756,-3.2298391052
-"ABH","Abererch Rail Station",52.8985982311,-4.3741839689
-"ABW","Abbey Wood (London) Rail Station",51.4910611665,0.1214217457
-"ABY","Ashburys Rail Station",53.4716521884,-2.194434998
-"ACB","Acton Bridge Rail Station",53.2665207003,-2.6031255204
-"ACC","Acton Central Rail Station",51.5087156784,-0.2629477949
-"ACG","Acocks Green Rail Station",52.4493357815,-1.8189696484
-"ACH","Achnashellach Rail Station",57.4820517208,-5.3330497284
-"ACK","Acklington Rail Station",55.3070995797,-1.6518483985
-"ACL","Acle Rail Station",52.6347061444,1.5439384675
-"ACN","Achnasheen Rail Station",57.5792680938,-5.0723280881
-"ACR","Accrington Rail Station",53.7529844843,-2.3695474455
-"ACT","Ascot Rail Station",51.4062421592,-0.6758156963
-"ACY","Abercynon Rail Station",51.6447111646,-3.3270008927
-"ADC","Adlington (Cheshire) Rail Station",53.3195695329,-2.1335617879
-"ADD","Adderley Park Rail Station",52.4830987434,-1.8559397876
-"ADK","Ardwick Rail Station",53.471358298,-2.213882234
-"ADL","Adlington (Lancs) Rail Station",53.6132582182,-2.603069152
-"ADM","Adisham Rail Station",51.2412043148,1.1991182098
-"ADN","Ardrossan Town Rail Station",55.6397026924,-4.8126528377
-"ADR","Airdrie Rail Station",55.8639734432,-3.9829014475
-"ADS","Ardrossan Harbour Rail Station",55.6398684301,-4.8210878622
-"ADV","Andover Rail Station",51.2115409141,-1.4922208179
-"ADW","Addiewell Rail Station",55.8434039199,-3.6065211407
-"AFK","Ashford International Rail Station",51.143703647,0.8762282027
-"AFS","Ashford (Surrey) Rail Station",51.4365050918,-0.4680505426
-"AFV","Ansdell & Fairhaven Rail Station",53.7414755302,-2.9930315929
-"AGL","Abergele & Pensarn Rail Station",53.2945885877,-3.5826252049
-"AGR","Angel Road Rail Station",51.612404791,-0.0487664558
-"AGS","Argyle Street Rail Station",55.8572976321,-4.2506797284
-"AGT","Aldrington Rail Station",50.8363759964,-0.1837938786
-"AGV","Abergavenny Rail Station",51.8166929204,-3.0096529786
-"AHD","Ashtead Rail Station",51.3178707762,-0.3075480044
-"AHN","Ashton-under-Lyne Rail Station",53.4912877289,-2.0943117675
-"AHS","Ashurst (Kent) Rail Station",51.1286581521,0.1526783965
-"AHT","Aldershot Rail Station",51.2464146675,-0.7598418662
-"AHV","Ash Vale Rail Station",51.2722439454,-0.721630982
-"AIG","Aigburth Rail Station",53.364579864,-2.9271549702
-"AIN","Aintree Rail Station",53.4739239739,-2.9562794487
-"AIR","Airbles Rail Station",55.7828281606,-3.9941848819
-"ALB","Albrighton Rail Station",52.637955578,-2.2688961662
-"ALD","Alderley Edge Rail Station",53.3037949434,-2.2367975748
-"ALF","Alfreton Rail Station",53.1004491479,-1.3696938892
-"ALK","Aslockton Rail Station",52.9515688778,-0.8980931448
-"ALM","Alnmouth Rail Station",55.3927781339,-1.6366531856
-"ALN","Althorne Rail Station",51.647874589,0.7525126479
-"ALO","Alloa Rail Station",56.1177816937,-3.7900478514
-"ALP","Althorpe Rail Station",53.5855202235,-0.7331858491
-"ALR","Alresford (Essex) Rail Station",51.8540099196,0.9974663385
-"ALT","Altrincham Rail Station",53.3877312834,-2.3468882352
-"ALV","Alvechurch Rail Station",52.3460841489,-1.96765319
-"ALW","Allens West Rail Station",54.5246329186,-1.361128823
-"ALX","Alexandria Rail Station",55.9850750252,-4.5774669847
-"AMB","Ambergate Rail Station",53.0605332632,-1.4806950473
-"AMF","Ammanford Rail Station",51.7959802661,-3.9967546569
-"AML","Acton Main Line Rail Station",51.5171796932,-0.2667334712
-"AMR","Amersham Rail Station",51.6742082152,-0.6075738184
-"AMT","Aldermaston Rail Station",51.4019601992,-1.1374044609
-"AMY","Amberley Rail Station",50.8966706624,-0.5419699859
-"ANC","Ancaster Rail Station",52.9877078434,-0.5356177511
-"AND","Anderston Rail Station",55.8598905332,-4.2709646678
-"ANF","Ashurst New Forest Rail Station",50.8898407705,-1.5266232035
-"ANG","Angmering Rail Station",50.8165649857,-0.4893702151
-"ANL","Anniesland Rail Station",55.8893432336,-4.3219418416
-"ANN","Annan Rail Station",54.9838392542,-3.2625828964
-"ANS","Ainsdale Rail Station",53.6020465522,-3.0426494721
-"ANZ","Anerley Rail Station",51.4121504955,-0.0658599305
-"AON","Alton Rail Station",51.151964195,-0.9668980606
-"APB","Appley Bridge Rail Station",53.5786855814,-2.7192513076
-"APD","Appledore (Kent) Rail Station",51.0332339326,0.8163754751
-"APF","Appleford Rail Station",51.6396427695,-1.2421230581
-"APG","Aspley Guise Rail Station",52.0212455205,-0.6323124906
+"AAP","Alexandra Palace",51.5979250073,-0.1202099313
+"AAT","Achanalt",57.6095763828,-4.913846165
+"ABA","Aberdare",51.7150603368,-3.4430947912
+"ABC","Altnabreac",58.3881329239,-3.7062873902
+"ABD","Aberdeen",57.1436867734,-2.0986925585
+"ABE","Aber",51.5749656756,-3.2298391052
+"ABH","Abererch",52.8985982311,-4.3741839689
+"ABW","Abbey Wood (London)",51.4910611665,0.1214217457
+"ABY","Ashburys",53.4716521884,-2.194434998
+"ACB","Acton Bridge",53.2665207003,-2.6031255204
+"ACC","Acton Central",51.5087156784,-0.2629477949
+"ACG","Acocks Green",52.4493357815,-1.8189696484
+"ACH","Achnashellach",57.4820517208,-5.3330497284
+"ACK","Acklington",55.3070995797,-1.6518483985
+"ACL","Acle",52.6347061444,1.5439384675
+"ACN","Achnasheen",57.5792680938,-5.0723280881
+"ACR","Accrington",53.7529844843,-2.3695474455
+"ACT","Ascot",51.4062421592,-0.6758156963
+"ACY","Abercynon",51.6447111646,-3.3270008927
+"ADC","Adlington (Cheshire)",53.3195695329,-2.1335617879
+"ADD","Adderley Park",52.4830987434,-1.8559397876
+"ADK","Ardwick",53.471358298,-2.213882234
+"ADL","Adlington (Lancs)",53.6132582182,-2.603069152
+"ADM","Adisham",51.2412043148,1.1991182098
+"ADN","Ardrossan Town",55.6397026924,-4.8126528377
+"ADR","Airdrie",55.8639734432,-3.9829014475
+"ADS","Ardrossan Harbour",55.6398684301,-4.8210878622
+"ADV","Andover",51.2115409141,-1.4922208179
+"ADW","Addiewell",55.8434039199,-3.6065211407
+"AFK","Ashford International",51.143703647,0.8762282027
+"AFS","Ashford (Surrey)",51.4365050918,-0.4680505426
+"AFV","Ansdell & Fairhaven",53.7414755302,-2.9930315929
+"AGL","Abergele & Pensarn",53.2945885877,-3.5826252049
+"AGR","Angel Road",51.612404791,-0.0487664558
+"AGS","Argyle Street",55.8572976321,-4.2506797284
+"AGT","Aldrington",50.8363759964,-0.1837938786
+"AGV","Abergavenny",51.8166929204,-3.0096529786
+"AHD","Ashtead",51.3178707762,-0.3075480044
+"AHN","Ashton-under-Lyne",53.4912877289,-2.0943117675
+"AHS","Ashurst (Kent)",51.1286581521,0.1526783965
+"AHT","Aldershot",51.2464146675,-0.7598418662
+"AHV","Ash Vale",51.2722439454,-0.721630982
+"AIG","Aigburth",53.364579864,-2.9271549702
+"AIN","Aintree",53.4739239739,-2.9562794487
+"AIR","Airbles",55.7828281606,-3.9941848819
+"ALB","Albrighton",52.637955578,-2.2688961662
+"ALD","Alderley Edge",53.3037949434,-2.2367975748
+"ALF","Alfreton",53.1004491479,-1.3696938892
+"ALK","Aslockton",52.9515688778,-0.8980931448
+"ALM","Alnmouth",55.3927781339,-1.6366531856
+"ALN","Althorne",51.647874589,0.7525126479
+"ALO","Alloa",56.1177816937,-3.7900478514
+"ALP","Althorpe",53.5855202235,-0.7331858491
+"ALR","Alresford (Essex)",51.8540099196,0.9974663385
+"ALT","Altrincham",53.3877312834,-2.3468882352
+"ALV","Alvechurch",52.3460841489,-1.96765319
+"ALW","Allens West",54.5246329186,-1.361128823
+"ALX","Alexandria",55.9850750252,-4.5774669847
+"AMB","Ambergate",53.0605332632,-1.4806950473
+"AMF","Ammanford",51.7959802661,-3.9967546569
+"AML","Acton Main Line",51.5171796932,-0.2667334712
+"AMR","Amersham",51.6742082152,-0.6075738184
+"AMT","Aldermaston",51.4019601992,-1.1374044609
+"AMY","Amberley",50.8966706624,-0.5419699859
+"ANC","Ancaster",52.9877078434,-0.5356177511
+"AND","Anderston",55.8598905332,-4.2709646678
+"ANF","Ashurst New Forest",50.8898407705,-1.5266232035
+"ANG","Angmering",50.8165649857,-0.4893702151
+"ANL","Anniesland",55.8893432336,-4.3219418416
+"ANN","Annan",54.9838392542,-3.2625828964
+"ANS","Ainsdale",53.6020465522,-3.0426494721
+"ANZ","Anerley",51.4121504955,-0.0658599305
+"AON","Alton",51.151964195,-0.9668980606
+"APB","Appley Bridge",53.5786855814,-2.7192513076
+"APD","Appledore (Kent)",51.0332339326,0.8163754751
+"APF","Appleford",51.6396427695,-1.2421230581
+"APG","Aspley Guise",52.0212455205,-0.6323124906
 "APN","Newcastle Airport Metro",55.0359539314,-1.7110611354
-"APP","Appleby Rail Station",54.5803531214,-2.4866970812
-"APS","Apsley Rail Station",51.7325265818,-0.462913617
-"APY","Apperley Bridge Rail Station",53.8417623189,-1.7058332
-"ARB","Arbroath Rail Station",56.5595623759,-2.58893669
-"ARD","Ardgay Rail Station",57.8814343743,-4.3620902545
-"ARG","Arisaig Rail Station",56.9125239651,-5.8390581876
-"ARL","Arlesey Rail Station",52.0260393622,-0.2662942214
-"ARM","Armadale (W Lothian) Rail Station",55.8857041796,-3.6954045698
-"ARN","Arnside Rail Station",54.2027369524,-2.8282411629
-"ARR","Arram Rail Station",53.8843617225,-0.4265787094
-"ART","Arrochar & Tarbet Rail Station",56.2039604882,-4.7227536136
-"ARU","Arundel Rail Station",50.848204225,-0.5461513877
-"ASB","Ardrossan South Beach Rail Station",55.6414123987,-4.8011892639
-"ASC","Ashchurch for Tewkesbury Rail Station",51.9989119042,-2.1087526816
-"ASF","Ashfield Rail Station",55.8889152278,-4.2492001758
-"ASG","Alsager Rail Station",53.0930183471,-2.2990577384
-"ASH","Ash Rail Station",51.2495930968,-0.7127872134
-"ASK","Askam Rail Station",54.1889365481,-3.2045108901
-"ASN","Addlestone Rail Station",51.3730427936,-0.4844377608
-"ASP","Aspatria Rail Station",54.7589613565,-3.3318751754
-"ASS","Alness Rail Station",57.6943767246,-4.2497156226
-"AST","Aston Rail Station",52.5042436334,-1.8719289166
-"ASY","Ashley Rail Station",53.3557384507,-2.3414591344
-"ATB","Attenborough Rail Station",52.9062307659,-1.2314110309
-"ATH","Atherstone Rail Station",52.5789873633,-1.5528024825
-"ATL","Attleborough Rail Station",52.5145682909,1.0223710881
-"ATN","Atherton Rail Station",53.5291592416,-2.4789715129
-"ATT","Attadale Rail Station",57.395013788,-5.4555693529
-"AUD","Audley End Rail Station",52.0044503988,0.2071861287
-"AUG","Aughton Park Rail Station",53.5542616334,-2.8952192106
-"AUI","Ardlui Rail Station",56.3019554792,-4.7216411129
-"AUK","Auchinleck Rail Station",55.4702735607,-4.2953352235
-"AUR","Aberdour Rail Station",56.0545845646,-3.3005596025
-"AUW","Ascott-under-Wychwood Rail Station",51.8673469281,-1.5640381523
-"AVF","Avoncliff Rail Station",51.3396455319,-2.2813231272
-"AVM","Aviemore Rail Station",57.1884955899,-3.8288664748
-"AVN","Avonmouth Rail Station",51.5003586482,-2.6994701634
-"AVP","Aylesbury Vale Parkway Rail Station",51.8311641936,-0.860160203
-"AVY","Aberdovey Rail Station",52.5439709134,-4.0570763906
-"AWK","Adwick Rail Station",53.5723385016,-1.1803591649
-"AWM","Ashwell & Morden Rail Station",52.0307801801,-0.1097609643
-"AWT","Armathwaite Rail Station",54.8094705871,-2.7720762415
-"AXM","Axminster Rail Station",50.7792590196,-3.0047301649
-"AXP","Alexandra Parade Rail Station",55.8631647206,-4.2106343183
-"AYH","Aylesham Rail Station",51.2272573443,1.2094822749
-"AYL","Aylesford Rail Station",51.3013150665,0.4661994822
-"AYP","Albany Park Rail Station",51.4354510748,0.1257631402
-"AYR","Ayr Rail Station",55.4581420821,-4.6258547017
-"AYS","Aylesbury Rail Station",51.8138958856,-0.8150732917
-"AYW","Aberystwyth Rail Station",52.4140589056,-4.081904916
-"BAA","Barnham Rail Station",50.8308955044,-0.6396586529
-"BAB","Balcombe Rail Station",51.0555161298,-0.1369064512
-"BAC","Bache Rail Station",53.2087996005,-2.8916714556
-"BAD","Banstead Rail Station",51.3293456873,-0.2131338747
-"BAG","Bagshot Rail Station",51.3643658384,-0.688644212
-"BAH","Bank Hall Rail Station",53.4375081504,-2.9875109807
-"BAI","Blairhill Rail Station",55.866445195,-4.0432793703
-"BAJ","Baglan Rail Station",51.6155428964,-3.8111528304
-"BAK","Battersea Park Rail Station",51.4769589055,-0.1475087424
-"BAL","Balham Rail Station",51.4432235254,-0.1523989843
-"BAM","Bamford Rail Station",53.3390149874,-1.6890804845
-"BAN","Banbury Rail Station",52.0603171415,-1.3281174658
-"BAR","Bare Lane Rail Station",54.0745502872,-2.8353285199
-"BAS","Bere Alston Rail Station",50.4855801051,-4.2003841017
-"BAT","Battle Rail Station",50.9129099302,0.494731748
-"BAU","Barton-on-Humber Rail Station",53.6889361427,-0.443441463
-"BAV","Barrow Haven Rail Station",53.6974399715,-0.3929610176
-"BAW","Blackwater Rail Station",51.3315799276,-0.7767238015
-"BAY","Bayford Rail Station",51.7577191097,-0.0955835363
-"BBG","Bishopbriggs Rail Station",55.9038715243,-4.2249012111
-"BBK","Bilbrook Rail Station",52.6237315662,-2.1860832074
-"BBL","Bat & Ball Rail Station",51.28975765,0.1942546658
-"BBN","Blackburn Rail Station",53.7465295919,-2.4791202443
-"BBS","Bordesley Rail Station",52.4718857429,-1.877763734
-"BBW","Berry Brow Rail Station",53.6210542572,-1.793433127
-"BCB","Burscough Bridge Rail Station",53.6052706223,-2.8408791461
-"BCC","Beccles Rail Station",52.4585445204,1.5695203477
-"BCE","Bracknell Rail Station",51.4130905636,-0.7516868278
-"BCF","Beaconsfield Rail Station",51.6112923305,-0.6438028303
-"BCG","Birchgrove Rail Station",51.5215559616,-3.2018626211
-"BCH","Birchington-on-Sea Rail Station",51.37749655,1.3014357084
-"BCJ","Burscough Junction Rail Station",53.5975334888,-2.8406044888
-"BCK","Buckley Rail Station",53.1630498684,-3.0559258882
-"BCN","Branchton Rail Station",55.9405880748,-4.8035281728
-"BCS","Bicester North Rail Station",51.9034889722,-1.1503639712
-"BCU","Brockenhurst Rail Station",50.8168300371,-1.5735227393
-"BCV","Bruce Grove Rail Station",51.5939593358,-0.0698420983
-"BCY","Brockley Rail Station",51.4646472415,-0.0375111039
-"BDA","Brundall Rail Station",52.6195070541,1.4393221465
-"BDB","Broadbottom Rail Station",53.4409884275,-2.0165194714
-"BDG","Bridgeton Rail Station",55.8489565185,-4.2260423916
-"BDH","Bedhampton Rail Station",50.8539453593,-0.9958127279
-"BDI","Bradford Interchange Rail Station",53.7910884508,-1.7495992021
-"BDK","Baldock Rail Station",51.9928784919,-0.1875367625
-"BDL","Birkdale Rail Station",53.6340637332,-3.0144470298
-"BDM","Bedford Rail Station",52.1361978063,-0.4794210009
-"BDN","Brading Rail Station",50.6783584598,-1.1387118948
-"BDQ","Bradford Forster Square Rail Station",53.7969375902,-1.7529651428
-"BDT","Bridlington Rail Station",54.0841498279,-0.198733799
-"BDW","Bedwyn Rail Station",51.3796362626,-1.5987734873
-"BDY","Bredbury Rail Station",53.423168059,-2.1104866302
-"BEA","Bridge of Allan Rail Station",56.1566272012,-3.9572209128
-"BEB","Bebington Rail Station",53.3576688627,-3.0036346698
-"BEC","Beckenham Hill Rail Station",51.4245803532,-0.0159250385
-"BEE","Beeston Rail Station",52.920772808,-1.2076539126
-"BEF","Benfleet Rail Station",51.543946833,0.5617405199
-"BEG","Beltring Rail Station",51.2047052539,0.4035240323
-"BEH","Bedworth Rail Station",52.4793121537,-1.4673840381
-"BEL","Beauly Rail Station",57.4782638344,-4.4698634331
-"BEM","Bempton Rail Station",54.1276779105,-0.1804704307
-"BEN","Bentham Rail Station",54.115527405,-2.5106784228
-"BEP","Bermuda Park Rail Station",52.5014490814,-1.4721692914
-"BER","Bearley Rail Station",52.2444229433,-1.7502469172
-"BES","Bescar Lane Rail Station",53.6238666357,-2.914609859
-"BET","Bethnal Green Rail Station",51.5239168448,-0.0595413255
-"BEU","Beaulieu Road Rail Station",50.8550379245,-1.5047402125
-"BEV","Beverley Rail Station",53.8422910042,-0.4229880841
-"BEX","Bexhill Rail Station",50.8410361246,0.4770465179
-"BEY","Ben Rhydding Rail Station",53.9257271035,-1.797433526
-"BFD","Brentford Rail Station",51.4875455966,-0.3096291503
-"BFE","Bere Ferrers Rail Station",50.4512627598,-4.1814634554
-"BFF","Blaenau Ffestiniog Rail Station",52.9945625755,-3.9386014215
-"BFN","Byfleet & New Haw Rail Station",51.3497933814,-0.4813698884
-"BFR","London Blackfriars Rail Station",51.511809604,-0.1033064322
-"BGA","Brundall Gardens Rail Station",52.6234667847,1.4184395543
-"BGD","Bargoed Rail Station",51.6923106201,-3.2296893004
-"BGE","Broad Green Rail Station",53.4065176265,-2.8934838097
-"BGG","Brigg Rail Station",53.5491644813,-0.4861278561
-"BGH","Brighouse Rail Station",53.6982108642,-1.7794410593
-"BGI","Bargeddie Rail Station",55.8512854533,-4.073795488
-"BGL","Bugle Rail Station",50.4003357574,-4.7921412594
-"BGM","Bellingham Rail Station",51.432910924,-0.0193048772
-"BGN","Bridgend Rail Station",51.5069726538,-3.5752917878
-"BGS","Bogston Rail Station",55.9370336273,-4.7113815133
-"BHC","Balloch Rail Station",56.0029254961,-4.5834681974
-"BHD","Brithdir Rail Station",51.7103040613,-3.2287299229
-"BHG","Bathgate Rail Station",55.8971463148,-3.6360891747
-"BHI","Birmingham International Rail Station",52.4508199122,-1.7258497513
-"BHK","Bush Hill Park Rail Station",51.6415193249,-0.0691949356
-"BHM","Birmingham New Street Rail Station",52.4778312827,-1.9002004707
-"BHO","Blackhorse Road Rail Station",51.5866055024,-0.041209942
-"BHR","Builth Road Rail Station",52.1693300616,-3.4270408474
-"BHS","Brockholes Rail Station",53.5969856546,-1.7696922549
-"BIA","Bishop Auckland Rail Station",54.6572030524,-1.6777249795
+"APP","Appleby",54.5803531214,-2.4866970812
+"APS","Apsley",51.7325265818,-0.462913617
+"APY","Apperley Bridge",53.8417623189,-1.7058332
+"ARB","Arbroath",56.5595623759,-2.58893669
+"ARD","Ardgay",57.8814343743,-4.3620902545
+"ARG","Arisaig",56.9125239651,-5.8390581876
+"ARL","Arlesey",52.0260393622,-0.2662942214
+"ARM","Armadale (W Lothian)",55.8857041796,-3.6954045698
+"ARN","Arnside",54.2027369524,-2.8282411629
+"ARR","Arram",53.8843617225,-0.4265787094
+"ART","Arrochar & Tarbet",56.2039604882,-4.7227536136
+"ARU","Arundel",50.848204225,-0.5461513877
+"ASB","Ardrossan South Beach",55.6414123987,-4.8011892639
+"ASC","Ashchurch for Tewkesbury",51.9989119042,-2.1087526816
+"ASD","Ashley Down",51.4788,-2.5767
+"ASF","Ashfield",55.8889152278,-4.2492001758
+"ASG","Alsager",53.0930183471,-2.2990577384
+"ASH","Ash",51.2495930968,-0.7127872134
+"ASK","Askam",54.1889365481,-3.2045108901
+"ASL","Ashington",55.1820,-1.5731
+"ASN","Addlestone",51.3730427936,-0.4844377608
+"ASP","Aspatria",54.7589613565,-3.3318751754
+"ASS","Alness",57.6943767246,-4.2497156226
+"AST","Aston",52.5042436334,-1.8719289166
+"ASY","Ashley",53.3557384507,-2.3414591344
+"ATB","Attenborough",52.9062307659,-1.2314110309
+"ATH","Atherstone",52.5789873633,-1.5528024825
+"ATL","Attleborough",52.5145682909,1.0223710881
+"ATN","Atherton",53.5291592416,-2.4789715129
+"ATT","Attadale",57.395013788,-5.4555693529
+"AUD","Audley End",52.0044503988,0.2071861287
+"AUG","Aughton Park",53.5542616334,-2.8952192106
+"AUI","Ardlui",56.3019554792,-4.7216411129
+"AUK","Auchinleck",55.4702735607,-4.2953352235
+"AUR","Aberdour",56.0545845646,-3.3005596025
+"AUW","Ascott-under-Wychwood",51.8673469281,-1.5640381523
+"AVF","Avoncliff",51.3396455319,-2.2813231272
+"AVM","Aviemore",57.1884955899,-3.8288664748
+"AVN","Avonmouth",51.5003586482,-2.6994701634
+"AVP","Aylesbury Vale Parkway",51.8311641936,-0.860160203
+"AVY","Aberdovey",52.5439709134,-4.0570763906
+"AWK","Adwick",53.5723385016,-1.1803591649
+"AWM","Ashwell & Morden",52.0307801801,-0.1097609643
+"AWT","Armathwaite",54.8094705871,-2.7720762415
+"AXM","Axminster",50.7792590196,-3.0047301649
+"AXP","Alexandra Parade",55.8631647206,-4.2106343183
+"AYH","Aylesham",51.2272573443,1.2094822749
+"AYL","Aylesford",51.3013150665,0.4661994822
+"AYP","Albany Park",51.4354510748,0.1257631402
+"AYR","Ayr",55.4581420821,-4.6258547017
+"AYS","Aylesbury",51.8138958856,-0.8150732917
+"AYW","Aberystwyth",52.4140589056,-4.081904916
+"BAA","Barnham",50.8308955044,-0.6396586529
+"BAB","Balcombe",51.0555161298,-0.1369064512
+"BAC","Bache",53.2087996005,-2.8916714556
+"BAD","Banstead",51.3293456873,-0.2131338747
+"BAG","Bagshot",51.3643658384,-0.688644212
+"BAH","Bank Hall",53.4375081504,-2.9875109807
+"BAI","Blairhill",55.866445195,-4.0432793703
+"BAJ","Baglan",51.6155428964,-3.8111528304
+"BAK","Battersea Park",51.4769589055,-0.1475087424
+"BAL","Balham",51.4432235254,-0.1523989843
+"BAM","Bamford",53.3390149874,-1.6890804845
+"BAN","Banbury",52.0603171415,-1.3281174658
+"BAR","Bare Lane",54.0745502872,-2.8353285199
+"BAS","Bere Alston",50.4855801051,-4.2003841017
+"BAT","Battle",50.9129099302,0.494731748
+"BAU","Barton-on-Humber",53.6889361427,-0.443441463
+"BAV","Barrow Haven",53.6974399715,-0.3929610176
+"BAW","Blackwater",51.3315799276,-0.7767238015
+"BAY","Bayford",51.7577191097,-0.0955835363
+"BBG","Bishopbriggs",55.9038715243,-4.2249012111
+"BBK","Bilbrook",52.6237315662,-2.1860832074
+"BBL","Bat & Ball",51.28975765,0.1942546658
+"BBN","Blackburn",53.7465295919,-2.4791202443
+"BBS","Bordesley",52.4718857429,-1.877763734
+"BBW","Berry Brow",53.6210542572,-1.793433127
+"BCB","Burscough Bridge",53.6052706223,-2.8408791461
+"BCC","Beccles",52.4585445204,1.5695203477
+"BCE","Bracknell",51.4130905636,-0.7516868278
+"BCF","Beaconsfield",51.6112923305,-0.6438028303
+"BCG","Birchgrove",51.5215559616,-3.2018626211
+"BCH","Birchington-on-Sea",51.37749655,1.3014357084
+"BCJ","Burscough Junction",53.5975334888,-2.8406044888
+"BCK","Buckley",53.1630498684,-3.0559258882
+"BCN","Branchton",55.9405880748,-4.8035281728
+"BCS","Bicester North",51.9034889722,-1.1503639712
+"BCU","Brockenhurst",50.8168300371,-1.5735227393
+"BCV","Bruce Grove",51.5939593358,-0.0698420983
+"BCY","Brockley",51.4646472415,-0.0375111039
+"BCZ","Brent Cross West",51.5687,-0.2269
+"BDA","Brundall",52.6195070541,1.4393221465
+"BDB","Broadbottom",53.4409884275,-2.0165194714
+"BDG","Bridgeton",55.8489565185,-4.2260423916
+"BDH","Bedhampton",50.8539453593,-0.9958127279
+"BDI","Bradford Interchange",53.7910884508,-1.7495992021
+"BDK","Baldock",51.9928784919,-0.1875367625
+"BDL","Birkdale",53.6340637332,-3.0144470298
+"BDM","Bedford",52.1361978063,-0.4794210009
+"BDN","Brading",50.6783584598,-1.1387118948
+"BDQ","Bradford Forster Square",53.7969375902,-1.7529651428
+"BDT","Bridlington",54.0841498279,-0.198733799
+"BDW","Bedwyn",51.3796362626,-1.5987734873
+"BDY","Bredbury",53.423168059,-2.1104866302
+"BEA","Bridge of Allan",56.1566272012,-3.9572209128
+"BEB","Bebington",53.3576688627,-3.0036346698
+"BEC","Beckenham Hill",51.4245803532,-0.0159250385
+"BEE","Beeston",52.920772808,-1.2076539126
+"BEF","Benfleet",51.543946833,0.5617405199
+"BEG","Beltring",51.2047052539,0.4035240323
+"BEH","Bedworth",52.4793121537,-1.4673840381
+"BEL","Beauly",57.4782638344,-4.4698634331
+"BEM","Bempton",54.1276779105,-0.1804704307
+"BEN","Bentham",54.115527405,-2.5106784228
+"BEP","Bermuda Park",52.5014490814,-1.4721692914
+"BER","Bearley",52.2444229433,-1.7502469172
+"BES","Bescar Lane",53.6238666357,-2.914609859
+"BET","Bethnal Green",51.5239168448,-0.0595413255
+"BEU","Beaulieu Road",50.8550379245,-1.5047402125
+"BEV","Beverley",53.8422910042,-0.4229880841
+"BEX","Bexhill",50.8410361246,0.4770465179
+"BEY","Ben Rhydding",53.9257271035,-1.797433526
+"BFD","Brentford",51.4875455966,-0.3096291503
+"BFE","Bere Ferrers",50.4512627598,-4.1814634554
+"BFF","Blaenau Ffestiniog",52.9945625755,-3.9386014215
+"BFN","Byfleet & New Haw",51.3497933814,-0.4813698884
+"BFR","London Blackfriars",51.511809604,-0.1033064322
+"BGA","Brundall Gardens",52.6234667847,1.4184395543
+"BGD","Bargoed",51.6923106201,-3.2296893004
+"BGE","Broad Green",53.4065176265,-2.8934838097
+"BGG","Brigg",53.5491644813,-0.4861278561
+"BGH","Brighouse",53.6982108642,-1.7794410593
+"BGI","Bargeddie",55.8512854533,-4.073795488
+"BGL","Bugle",50.4003357574,-4.7921412594
+"BGM","Bellingham",51.432910924,-0.0193048772
+"BGN","Bridgend",51.5069726538,-3.5752917878
+"BGS","Bogston",55.9370336273,-4.7113815133
+"BGV","Barking Riverside",51.519108,0.114764
+"BHC","Balloch",56.0029254961,-4.5834681974
+"BHD","Brithdir",51.7103040613,-3.2287299229
+"BHG","Bathgate",55.8971463148,-3.6360891747
+"BHI","Birmingham International",52.4508199122,-1.7258497513
+"BHK","Bush Hill Park",51.6415193249,-0.0691949356
+"BHM","Birmingham New Street",52.4778312827,-1.9002004707
+"BHO","Blackhorse Road",51.5866055024,-0.041209942
+"BHR","Builth Road",52.1693300616,-3.4270408474
+"BHS","Brockholes",53.5969856546,-1.7696922549
+"BIA","Bishop Auckland",54.6572030524,-1.6777249795
 "BIB","Bishop's Lydeard",51.0545801757,-3.194339982
-"BIC","Billericay Rail Station",51.6288849556,0.4186576571
-"BID","Bidston Rail Station",53.4091524654,-3.0785590277
-"BIF","Barrow-in-Furness Rail Station",54.1190066162,-3.2261172119
-"BIG","Billingshurst Rail Station",51.0151974096,-0.4502767801
-"BIK","Birkbeck Rail Station",51.403888888,-0.0557126082
-"BIL","Billingham Rail Station",54.6056166679,-1.2797344554
-"BIN","Bingham Rail Station",52.9542094023,-0.9515394619
-"BIO","Baillieston Rail Station",55.8444952694,-4.1136857366
-"BIP","Bishopstone Rail Station",50.7801363721,0.0827845347
-"BIS","Bishops Stortford Rail Station",51.8666972924,0.1649202653
-"BIT","Bicester Village Rail Station",51.8930294144,-1.1487446761
-"BIW","Biggleswade Rail Station",52.0846893974,-0.2611631855
-"BIY","Bingley Rail Station",53.8486270204,-1.8373250124
-"BKA","Bookham Rail Station",51.2887348796,-0.3839979684
-"BKC","Birkenhead Central Rail Station",53.388328806,-3.0208206224
-"BKD","Blakedown Rail Station",52.406413288,-2.1768606091
-"BKG","Barking Rail Station",51.5394940483,0.0809293557
-"BKH","Blackheath Rail Station",51.4657947771,0.0088974464
-"BKJ","Beckenham Junction Rail Station",51.4111710618,-0.0259963666
-"BKL","Bickley Rail Station",51.4001025009,0.0452659962
-"BKM","Berkhamsted Rail Station",51.7631393379,-0.5619899853
-"BKN","Birkenhead North Rail Station",53.4044504204,-3.057532076
-"BKO","Brookwood Rail Station",51.3037544754,-0.6357308777
-"BKP","Birkenhead Park Rail Station",53.3974209727,-3.039100208
-"BKQ","Birkenhead Hamilton Square Rail Station",53.3947090805,-3.013679563
-"BKR","Blackridge Rail Station",55.8842459211,-3.7507875146
-"BKS","Bekesbourne Rail Station",51.2613599688,1.136737067
-"BKT","Blake Street Rail Station",52.6048991066,-1.8449076544
-"BKW","Berkswell Rail Station",52.3958946388,-1.6428309089
-"BLA","Blair Atholl Rail Station",56.7655325077,-3.8502251597
-"BLB","Battlesbridge Rail Station",51.6248280358,0.5653129218
-"BLD","Baildon Rail Station",53.8502374199,-1.7536396791
-"BLE","Bramley (West Yorks) Rail Station",53.8053627078,-1.6372110715
-"BLG","Bellgrove Rail Station",55.8566980297,-4.2243600625
-"BLH","Bellshill Rail Station",55.8170582892,-4.0244880674
-"BLK","Blackrod Rail Station",53.5915357166,-2.5695231754
-"BLL","Bardon Mill Rail Station",54.9744979891,-2.346513133
-"BLM","Belmont Rail Station",51.3438116974,-0.1988301486
-"BLN","Blundellsands & Crosby Rail Station",53.4876981044,-3.0398576774
-"BLO","Blaydon Rail Station",54.9657939357,-1.7125935978
-"BLP","Belper Rail Station",53.0237754008,-1.482508538
-"BLT","Blantyre Rail Station",55.7973203505,-4.0869580948
-"BLV","Belle Vue Rail Station",53.4623891164,-2.1805056874
-"BLW","Bulwell Rail Station",52.9997132956,-1.1962272378
-"BLX","Bloxwich Rail Station",52.6182145823,-2.0114721566
-"BLY","Bletchley Rail Station",51.9953423523,-0.7362994344
-"BMB","Bamber Bridge Rail Station",53.7268807835,-2.6607719493
-"BMC","Bromley Cross Rail Station",53.61405521,-2.4108970227
-"BMD","Brimsdown Rail Station",51.6555835568,-0.0307911888
-"BME","Broome Rail Station",52.4227839595,-2.8852059507
-"BMF","Broomfleet Rail Station",53.7402272872,-0.6718345795
-"BMG","Barming Rail Station",51.2848921433,0.4789874974
-"BMH","Bournemouth Rail Station",50.7272603225,-1.8644946471
-"BML","Bramhall Rail Station",53.3606279318,-2.1635920263
-"BMN","Bromley North Rail Station",51.4083255508,0.0170184004
-"BMO","Birmingham Moor Street Rail Station",52.4790920668,-1.8924677323
-"BMP","Brampton (Cumbria) Rail Station",54.9323952275,-2.7029523076
-"BMR","Bromborough Rake Rail Station",53.3299208626,-2.9894688327
-"BMS","Bromley South Rail Station",51.3999742022,0.0173696569
-"BMT","Bedminster Rail Station",51.4400845068,-2.5941516846
-"BMV","Bromsgrove Rail Station",52.3222981835,-2.0473389281
-"BMY","Bramley (Hants) Rail Station",51.330292014,-1.0609834929
-"BNA","Burnage Rail Station",53.4211811715,-2.2156768396
-"BNC","Burnley Central Rail Station",53.7935247085,-2.2449718815
-"BND","Brandon Rail Station",52.4540242165,0.6247556786
-"BNE","Bourne End Rail Station",51.5771193996,-0.7104544193
-"BNF","Briton Ferry Rail Station",51.6378987804,-3.8192683057
-"BNG","Bangor (Gwynedd) Rail Station",53.2222979654,-4.1358869294
-"BNH","Barnehurst Rail Station",51.4649576152,0.1596730747
-"BNI","Barnes Bridge Rail Station",51.4720070868,-0.2526072102
-"BNL","Barnhill Rail Station",55.8774834443,-4.2229911506
-"BNM","Burnham (Berks) Rail Station",51.5235064374,-0.6463561439
-"BNP","Barnstaple Rail Station",51.0739644921,-4.0631402025
-"BNR","Brockley Whins Rail Station",54.9595502728,-1.4613667215
-"BNS","Barnes Rail Station",51.4670846365,-0.2421410454
-"BNT","Brinnington Rail Station",53.432131208,-2.1351183485
-"BNV","Banavie Rail Station",56.8432899877,-5.0954121623
-"BNW","Bootle New Strand Rail Station",53.4534030856,-2.9947465497
-"BNY","Barnsley Rail Station",53.5543175422,-1.47716617
-"BOA","Bradford-on-Avon Rail Station",51.3449090983,-2.2523240424
-"BOC","Bootle (Cumbria) Rail Station",54.291308954,-3.3938621381
-"BOD","Bodmin Parkway Rail Station",50.4458496871,-4.6629674421
-"BOE","Botley Rail Station",50.9164438022,-1.2592242694
-"BOG","Bognor Regis Rail Station",50.786547177,-0.6761573725
-"BOH","Bosham Rail Station",50.8427366135,-0.8474129936
-"BOM","Bromborough Rail Station",53.321860927,-2.9868952277
-"BON","Bolton Rail Station",53.5741575045,-2.425822783
-"BOP","Bowes Park Rail Station",51.6070128955,-0.1205568702
-"BOR","Bodorgan Rail Station",53.2043181126,-4.4180098996
-"BOT","Bootle Oriel Road Rail Station",53.4466353518,-2.9957327823
-"BPB","Blackpool Pleasure Beach Rail Station",53.7879651191,-3.0538730548
-"BPC","Penychain Rail Station",52.9028982685,-4.3387298378
-"BPK","Brookmans Park Rail Station",51.7210644329,-0.204525873
-"BPN","Blackpool North Rail Station",53.8219272752,-3.0492707494
-"BPS","Blackpool South Rail Station",53.7987134952,-3.0489347667
-"BPT","Bishopton Rail Station",55.9022563659,-4.5004702272
-"BPW","Bristol Parkway Rail Station",51.5137984154,-2.5421644857
-"BRA","Brora Rail Station",58.012933425,-3.8522865622
-"BRC","Breich Rail Station",55.8273074741,-3.6681187271
-"BRE","Brentwood Rail Station",51.6136062194,0.2996132443
-"BRF","Brierfield Rail Station",53.8239929448,-2.2364914709
-"BRG","Borough Green & Wrotham Rail Station",51.293215966,0.3062721999
-"BRH","Borth Rail Station",52.4910411643,-4.0501863389
-"BRI","Bristol Temple Meads Rail Station",51.4491404983,-2.5813170589
-"BRK","Berwick (Sussex) Rail Station",50.8403713146,0.1660450404
-"BRL","Barrhill Rail Station",55.0970097604,-4.7817610115
-"BRM","Barmouth Rail Station",52.7229049113,-4.0566037471
-"BRN","Bearsden Rail Station",55.9171219632,-4.3320048257
-"BRO","Bridge of Orchy Rail Station",56.5158519882,-4.7629778286
-"BRP","Brampton (Suffolk) Rail Station",52.39545585,1.5438396721
-"BRR","Barrhead Rail Station",55.8037470316,-4.3972682443
-"BRS","Berrylands Rail Station",51.3990426839,-0.280691098
-"BRT","Barlaston Rail Station",52.9428868109,-2.1681101939
-"BRU","Bruton Rail Station",51.1116312549,-2.4470735628
-"BRV","Bournville Rail Station",52.4269759491,-1.9264177275
-"BRW","Brunswick Rail Station",53.3832558566,-2.9760770621
-"BRX","Brixton Rail Station",51.4632979174,-0.1141578263
-"BRY","Barry Rail Station",51.3967799856,-3.2849950221
-"BSB","Bleasby Rail Station",53.0413834346,-0.9436832322
-"BSC","Bescot Stadium Rail Station",52.5631069514,-1.9911001339
-"BSD","Bearsted Rail Station",51.2758186317,0.5776101903
-"BSE","Bury St Edmunds Rail Station",52.2537779145,0.7133353034
-"BSH","Bushey Rail Station",51.6457542219,-0.3852982939
-"BSI","Balmossie Rail Station",56.4745544268,-2.8389594192
-"BSJ","Bedford St Johns Rail Station",52.1294885146,-0.4674793726
-"BSK","Basingstoke Rail Station",51.2683550841,-1.0872452751
-"BSL","Beasdale Rail Station",56.8995320852,-5.7637827088
-"BSM","Branksome Rail Station",50.7269511745,-1.9197490477
-"BSN","Boston Rail Station",52.9781123717,-0.0309954737
-"BSO","Basildon Rail Station",51.5681072863,0.4568185797
-"BSP","Brondesbury Park Rail Station",51.5406994758,-0.2101030164
-"BSR","Broadstairs Rail Station",51.3606801474,1.4335860392
-"BSS","Barassie Rail Station",55.5610564283,-4.6511181093
-"BSU","Brunstane Rail Station",55.9425045311,-3.1009897555
-"BSV","Buckshaw Parkway Rail Station",53.6733558277,-2.6608267264
-"BSW","Birmingham Snow Hill Rail Station",52.4833681846,-1.89908361
-"BSY","Brondesbury Rail Station",51.5451661494,-0.2022838772
-"BTB","Barnetby Rail Station",53.5751404569,-0.4096836565
-"BTD","Bolton-Upon-Dearne Rail Station",53.5189640059,-1.3115478698
-"BTE","Bitterne Rail Station",50.9182096759,-1.3769901266
-"BTF","Bottesford Rail Station",52.944634247,-0.7948377662
-"BTG","Barnt Green Rail Station",52.3611012481,-1.9924584823
-"BTH","Bath Spa Rail Station",51.3776813346,-2.3570165586
-"BTL","Batley Rail Station",53.7099546488,-1.6229560553
-"BTN","Brighton Rail Station",50.8289969623,-0.1412525289
-"BTO","Betchworth Rail Station",51.2481856234,-0.2669489143
-"BTP","Braintree Freeport Rail Station",51.86942396,0.5684631055
-"BTR","Braintree Rail Station",51.8753991861,0.5567148512
-"BTS","Burntisland Rail Station",56.0570735491,-3.233198596
-"BTT","Battersby Rail Station",54.4576909817,-1.092985447
-"BTY","Bentley (Hants) Rail Station",51.1812286564,-0.8681101444
-"BUB","Burnley Barracks Rail Station",53.7908906624,-2.2580864157
-"BUC","Buckenham Rail Station",52.5977618232,1.4703489483
-"BUD","Burneside (Cumbria) Rail Station",54.3549872461,-2.7666793226
-"BUE","Bures Rail Station",51.9711715742,0.7691763467
-"BUG","Burgess Hill Rail Station",50.9536493887,-0.1273860328
-"BUH","Brough Rail Station",53.7269790626,-0.5787296823
-"BUI","Burnside (Strathclyde) Rail Station",55.8169207887,-4.2023757518
-"BUJ","Burton Joyce Rail Station",52.9834597732,-1.0408745342
-"BUK","Bucknell Rail Station",52.3573903067,-2.94737686
-"BUL","Butlers Lane Rail Station",52.5924838341,-1.8380133232
-"BUO","Bursledon Rail Station",50.8836771224,-1.3050217804
-"BUS","Busby Rail Station",55.7803335966,-4.2621874207
-"BUT","Burton-on-Trent Rail Station",52.805831535,-1.6424549107
-"BUU","Burnham-on-Crouch Rail Station",51.6336616952,0.8140576821
-"BUW","Burley-in-Wharfedale Rail Station",53.9081639278,-1.7533757307
-"BUX","Buxton Rail Station",53.2607356445,-1.9128621475
-"BUY","Burley Park Rail Station",53.8120445498,-1.5777714582
-"BVD","Belvedere Rail Station",51.4921169254,0.1523141776
-"BWB","Bow Brickhill Rail Station",52.0043090172,-0.6960564274
-"BWD","Birchwood Rail Station",53.4127333746,-2.5253084603
-"BWG","Bowling Rail Station",55.9310714655,-4.4938258606
-"BWK","Berwick-upon-Tweed Rail Station",55.774332462,-2.0109833916
-"BWN","Bloxwich North Rail Station",52.6254506167,-2.0176785833
-"BWO","Bricket Wood Rail Station",51.7054311593,-0.3590920111
-"BWS","Barrow upon Soar Rail Station",52.7493534585,-1.1448359281
-"BWT","Bridgwater Rail Station",51.1278501854,-2.9904134747
-"BXB","Broxbourne Rail Station",51.746913795,-0.0110606305
-"BXD","Buxted Rail Station",50.9900076084,0.1314658692
-"BXH","Bexleyheath Rail Station",51.4634986628,0.1337619475
-"BXW","Box Hill & Westhumble Rail Station",51.2540077838,-0.3284670481
-"BXY","Bexley Rail Station",51.4402179279,0.1479285922
-"BYA","Berney Arms Rail Station",52.5898102913,1.6303988741
-"BYB","Blythe Bridge Rail Station",52.9681588029,-2.0669597492
-"BYC","Betws-y-Coed Rail Station",53.0920807045,-3.8008660334
-"BYD","Barry Docks Rail Station",51.4024388396,-3.2607138987
-"BYE","Bynea Rail Station",51.6720355869,-4.0989020803
-"BYF","Broughty Ferry Rail Station",56.467149407,-2.8731557887
-"BYI","Barry Island Rail Station",51.3924107233,-3.2733735249
-"BYK","Bentley (S Yorks) Rail Station",53.5439546043,-1.1509511595
-"BYL","Barry Links Rail Station",56.4931375583,-2.7454472508
-"BYM","Burnley Manchester Road Rail Station",53.7849780535,-2.2488678001
-"BYN","Bryn Rail Station",53.4998801227,-2.6472139369
-"BYS","Braystones Rail Station",54.4393680606,-3.5418249064
-"CAA","Coventry Arena Rail Station",52.4477480204,-1.4941167693
-"CAC","Caldercruix Rail Station",55.887937313,-3.8877014781
-"CAD","Cadoxton Rail Station",51.4122775163,-3.2489057172
-"CAG","Carrbridge Rail Station",57.2794851095,-3.8282023232
-"CAK","Cark Rail Station",54.177962852,-2.9740635997
-"CAM","Camberley Rail Station",51.3363253942,-0.7442546332
-"CAN","Carnoustie Rail Station",56.5005520159,-2.7066067008
-"CAO","Cannock Rail Station",52.6861755085,-2.0221416067
-"CAR","Carlisle Rail Station",54.8906568723,-2.9331955073
-"CAS","Castleton (Manchester) Rail Station",53.5918610828,-2.1782323207
-"CAT","Caterham Rail Station",51.2821380427,-0.0782806392
-"CAU","Causeland Rail Station",50.4056755023,-4.466483549
-"CAY","Carntyne Rail Station",55.8548667252,-4.178558829
-"CBB","Carbis Bay Rail Station",50.1970388168,-5.4633147211
-"CBC","Coatbridge Central Rail Station",55.8624998584,-4.0318858547
-"CBD","Conon Bridge Rail Station",57.5617327905,-4.4404033769
-"CBE","Canterbury East Rail Station",51.2742704504,1.0759983241
-"CBG","Cambridge Rail Station",52.1940786826,0.1374844883
-"CBH","Cambridge Heath (London) Rail Station",51.5319721727,-0.0572520963
-"CBK","Cranbrook Rail Station",50.7500793373,-3.4204288894
-"CBL","Cambuslang Rail Station",55.8196005407,-4.1729949447
-"CBN","Camborne Rail Station",50.210424474,-5.2974601339
-"CBP","Castle Bar Park Rail Station",51.5229296496,-0.3315265492
-"CBR","Cooksbridge Rail Station",50.9037495693,-0.0091755079
-"CBS","Coatbridge Sunnyside Rail Station",55.8668282944,-4.0282763675
-"CBW","Canterbury West Rail Station",51.284271981,1.0753330452
-"CBY","Charlbury Rail Station",51.8724337794,-1.4896781604
-"CCC","Criccieth Rail Station",52.9184246922,-4.2375196432
-"CCH","Chichester Rail Station",50.8320420668,-0.7817301783
-"CCT","Cathcart Rail Station",55.8176625197,-4.260522045
-"CDB","Cardiff Bay Rail Station",51.4671073886,-3.1664118035
-"CDD","Cardenden Rail Station",56.1412469307,-3.2616419946
-"CDF","Cardiff Central Rail Station",51.4760241554,-3.1793104707
-"CDI","Crediton Rail Station",50.7832916037,-3.6467942575
-"CDN","Coulsdon Town Rail Station",51.3220392402,-0.1344387303
-"CDO","Cardonald Rail Station",55.8525617165,-4.340677662
-"CDQ","Cardiff Queen Street Rail Station",51.4819604384,-3.1701891748
-"CDR","Cardross Rail Station",55.9603705466,-4.6530550015
-"CDS","Coulsdon South Rail Station",51.3158346141,-0.1378616075
-"CDT","Caldicot Rail Station",51.5847886548,-2.7605785503
-"CDU","Cam & Dursley Rail Station",51.7176208933,-2.3590816591
-"CDY","Cartsdyke Rail Station",55.9422051727,-4.7315711125
-"CEA","Cleland Rail Station",55.8046428518,-3.9102338035
-"CED","Cheddington Rail Station",51.8579248983,-0.6621263072
-"CEF","Chapel-en-le-Frith Rail Station",53.3122450065,-1.9187614767
-"CEH","Coleshill Parkway Rail Station",52.5165405856,-1.7081695542
-"CEL","Chelford Rail Station",53.270324898,-2.2805759167
-"CES","Cressing Rail Station",51.8523442178,0.5779891355
-"CET","Colchester Town Rail Station",51.8864651647,0.904792312
-"CEY","Cononley Rail Station",53.917582567,-2.012071028
-"CFB","Catford Bridge Rail Station",51.4447386824,-0.0247654501
-"CFD","Castleford Rail Station",53.7240933891,-1.3546560801
-"CFF","Croftfoot Rail Station",55.818250801,-4.2283107571
-"CFH","Chafford Hundred Rail Station",51.4855557794,0.2874752389
-"CFL","Crossflatts Rail Station",53.8584785,-1.8448891769
-"CFN","Clifton Down Rail Station",51.4645414825,-2.6117434096
-"CFO","Chalfont & Latimer Rail Station",51.6681107756,-0.5605042796
-"CFR","Chandlers Ford Rail Station",50.9836745047,-1.3851600502
-"CFT","Crofton Park Rail Station",51.45518736,-0.036477467
-"CGD","Craigendoran Rail Station",55.9947875724,-4.7112248712
-"CGM","Cottingham Rail Station",53.7816677653,-0.4064399418
-"CGN","Cogan Rail Station",51.4459907902,-3.189098989
-"CGW","Caergwrle Rail Station",53.1078775755,-3.0329132338
-"CHC","Charing Cross (Glasgow) Rail Station",55.8646752269,-4.2698055885
-"CHD","Chesterfield Rail Station",53.2382369384,-1.4201139064
-"CHE","Cheam Rail Station",51.3554760901,-0.2141426137
-"CHF","Church Fenton Rail Station",53.826617281,-1.227593241
-"CHG","Charing (Kent) Rail Station",51.2080968918,0.790361474
-"CHH","Christs Hospital Rail Station",51.0506799602,-0.3635305612
-"CHI","Chingford Rail Station",51.6330861875,0.0099231874
-"CHK","Chiswick Rail Station",51.4811352623,-0.2678126102
-"CHL","Chilworth Rail Station",51.2152082426,-0.5248019553
-"CHM","Chelmsford Rail Station",51.736377313,0.4685976033
-"CHN","Cheshunt Rail Station",51.7028782333,-0.0239334005
-"CHO","Cholsey Rail Station",51.5702030857,-1.1580033162
-"CHP","Chipstead Rail Station",51.3092732695,-0.1694772828
-"CHR","Christchurch Rail Station",50.7382022761,-1.7845391826
-"CHT","Chathill Rail Station",55.5367311282,-1.7063916064
-"CHU","Cheadle Hulme Rail Station",53.3759438577,-2.1883016906
-"CHW","Chalkwell Rail Station",51.5387210852,0.6706212378
-"CHX","London Charing Cross Rail Station",51.5080271291,-0.124776951
-"CHY","Chertsey Rail Station",51.3870662195,-0.5092980361
-"CIL","Chilham Rail Station",51.244611699,0.9759253356
-"CIM","Cilmeri Rail Station",52.1505372986,-3.456549557
-"CIR","Caledonian Road & Barnsbury Rail Station",51.5430414168,-0.1167032568
-"CIT","Chislehurst Rail Station",51.4055548954,0.0574432034
-"CKH","Corkerhill Rail Station",55.8374943521,-4.3342780321
-"CKL","Corkickle Rail Station",54.5416855173,-3.5821649914
-"CKN","Crewkerne Rail Station",50.8735260536,-2.7784973275
-"CKS","Clarkston Rail Station",55.7893425756,-4.2756304312
-"CKT","Crookston Rail Station",55.842306531,-4.3646599927
-"CKY","Crosskeys Rail Station",51.6209031401,-3.1261795275
-"CLA","Clandon Rail Station",51.2640008411,-0.5027439883
-"CLC","Castle Cary Rail Station",51.0998071422,-2.5227962269
-"CLD","Chelsfield Rail Station",51.3562553945,0.109096599
-"CLE","Cleethorpes Rail Station",53.5619299115,-0.0292269788
-"CLG","Claygate Rail Station",51.3612107148,-0.3482245539
-"CLH","Clitheroe Rail Station",53.8734784154,-2.3943371754
-"CLI","Clifton (Manchester) Rail Station",53.5225049162,-2.3147448248
-"CLJ","Clapham Junction Rail Station",51.4641869937,-0.1702686508
-"CLK","Clock House Rail Station",51.4085837591,-0.0406309221
-"CLL","Collington Rail Station",50.8392826491,0.4578912206
-"CLM","Collingham Rail Station",53.1441054305,-0.7503911592
-"CLN","Chapeltown Rail Station",53.46235275,-1.4662753767
-"CLP","Clapham High Street Rail Station",51.4654799498,-0.1324962988
-"CLR","Clarbeston Road Rail Station",51.8516764519,-4.883577935
-"CLS","Chester-le-Street Rail Station",54.8546014236,-1.5780279033
-"CLT","Clacton-on-Sea Rail Station",51.7940121532,1.1541237294
-"CLU","Carluke Rail Station",55.7312612023,-3.8489142324
-"CLV","Claverdon Rail Station",52.2771032987,-1.696549552
-"CLW","Chorleywood Rail Station",51.6542505776,-0.5182984244
-"CLY","Chinley Rail Station",53.3403042037,-1.9439397765
-"CMB","Cambridge North Rail Station",52.2244936969,0.158507305
-"CMD","Camden Road Rail Station",51.5417913143,-0.1386752331
-"CME","Combe (Oxon) Rail Station",51.8325979785,-1.3940563489
-"CMF","Cromford Rail Station",53.1129487944,-1.5491593967
-"CMH","Cwmbach Rail Station",51.7019306049,-3.4137347518
-"CML","Carmyle Rail Station",55.8343311624,-4.1581669693
-"CMN","Carmarthen Rail Station",51.8533597764,-4.3059837569
-"CMO","Camelon Rail Station",56.0060850872,-3.8175985504
-"CMR","Cromer Rail Station",52.9301115682,1.2928430662
-"CMY","Crossmyloof Rail Station",55.8339394759,-4.2843030651
-"CNE","Colne Rail Station",53.854755007,-2.1818613773
-"CNF","Carnforth Rail Station",54.1296866595,-2.7712312791
-"CNG","Congleton Rail Station",53.1578702503,-2.1925793889
-"CNL","Canley Rail Station",52.3992554076,-1.5475652767
-"CNM","Cheltenham Spa Rail Station",51.8974028753,-2.0996135055
-"CNN","Canonbury Rail Station",51.5487325338,-0.09216443
-"CNO","Chetnole Rail Station",50.8663529505,-2.5729267275
-"CNP","Conway Park Rail Station",53.3933739019,-3.0226705989
-"CNR","Crianlarich Rail Station",56.3904637247,-4.6184189492
-"CNS","Conisbrough Rail Station",53.4893269216,-1.2343330775
-"CNW","Conwy Rail Station",53.2801164248,-3.8305284521
-"CNY","Cantley Rail Station",52.5787715007,1.5134359903
-"COA","Coatdyke Rail Station",55.8643346399,-4.0049736959
-"COB","Cooden Beach Rail Station",50.8333660029,0.4268882942
+"BIC","Billericay",51.6288849556,0.4186576571
+"BID","Bidston",53.4091524654,-3.0785590277
+"BIF","Barrow-in-Furness",54.1190066162,-3.2261172119
+"BIG","Billingshurst",51.0151974096,-0.4502767801
+"BIK","Birkbeck",51.403888888,-0.0557126082
+"BIL","Billingham",54.6056166679,-1.2797344554
+"BIN","Bingham",52.9542094023,-0.9515394619
+"BIO","Baillieston",55.8444952694,-4.1136857366
+"BIP","Bishopstone",50.7801363721,0.0827845347
+"BIS","Bishops Stortford",51.8666972924,0.1649202653
+"BIT","Bicester Village",51.8930294144,-1.1487446761
+"BIW","Biggleswade",52.0846893974,-0.2611631855
+"BIY","Bingley",53.8486270204,-1.8373250124
+"BKA","Bookham",51.2887348796,-0.3839979684
+"BKC","Birkenhead Central",53.388328806,-3.0208206224
+"BKD","Blakedown",52.406413288,-2.1768606091
+"BKG","Barking",51.5394940483,0.0809293557
+"BKH","Blackheath",51.4657947771,0.0088974464
+"BKJ","Beckenham Junction",51.4111710618,-0.0259963666
+"BKL","Bickley",51.4001025009,0.0452659962
+"BKM","Berkhamsted",51.7631393379,-0.5619899853
+"BKN","Birkenhead North",53.4044504204,-3.057532076
+"BKO","Brookwood",51.3037544754,-0.6357308777
+"BKP","Birkenhead Park",53.3974209727,-3.039100208
+"BKQ","Birkenhead Hamilton Square",53.3947090805,-3.013679563
+"BKR","Blackridge",55.8842459211,-3.7507875146
+"BKS","Bekesbourne",51.2613599688,1.136737067
+"BKT","Blake Street",52.6048991066,-1.8449076544
+"BKW","Berkswell",52.3958946388,-1.6428309089
+"BLA","Blair Atholl",56.7655325077,-3.8502251597
+"BLB","Battlesbridge",51.6248280358,0.5653129218
+"BLD","Baildon",53.8502374199,-1.7536396791
+"BLE","Bramley (West Yorks)",53.8053627078,-1.6372110715
+"BLG","Bellgrove",55.8566980297,-4.2243600625
+"BLH","Bellshill",55.8170582892,-4.0244880674
+"BLK","Blackrod",53.5915357166,-2.5695231754
+"BLL","Bardon Mill",54.9744979891,-2.346513133
+"BLM","Belmont",51.3438116974,-0.1988301486
+"BLN","Blundellsands & Crosby",53.4876981044,-3.0398576774
+"BLO","Blaydon",54.9657939357,-1.7125935978
+"BLP","Belper",53.0237754008,-1.482508538
+"BLT","Blantyre",55.7973203505,-4.0869580948
+"BLV","Belle Vue",53.4623891164,-2.1805056874
+"BLW","Bulwell",52.9997132956,-1.1962272378
+"BLX","Bloxwich",52.6182145823,-2.0114721566
+"BLY","Bletchley",51.9953423523,-0.7362994344
+"BMB","Bamber Bridge",53.7268807835,-2.6607719493
+"BMC","Bromley Cross",53.61405521,-2.4108970227
+"BMD","Brimsdown",51.6555835568,-0.0307911888
+"BME","Broome",52.4227839595,-2.8852059507
+"BMF","Broomfleet",53.7402272872,-0.6718345795
+"BMG","Barming",51.2848921433,0.4789874974
+"BMH","Bournemouth",50.7272603225,-1.8644946471
+"BML","Bramhall",53.3606279318,-2.1635920263
+"BMN","Bromley North",51.4083255508,0.0170184004
+"BMO","Birmingham Moor Street",52.4790920668,-1.8924677323
+"BMP","Brampton (Cumbria)",54.9323952275,-2.7029523076
+"BMR","Bromborough Rake",53.3299208626,-2.9894688327
+"BMS","Bromley South",51.3999742022,0.0173696569
+"BMT","Bedminster",51.4400845068,-2.5941516846
+"BMV","Bromsgrove",52.3222981835,-2.0473389281
+"BMY","Bramley (Hants)",51.330292014,-1.0609834929
+"BNA","Burnage",53.4211811715,-2.2156768396
+"BNC","Burnley Central",53.7935247085,-2.2449718815
+"BND","Brandon",52.4540242165,0.6247556786
+"BNE","Bourne End",51.5771193996,-0.7104544193
+"BNF","Briton Ferry",51.6378987804,-3.8192683057
+"BNG","Bangor (Gwynedd)",53.2222979654,-4.1358869294
+"BNH","Barnehurst",51.4649576152,0.1596730747
+"BNI","Barnes Bridge",51.4720070868,-0.2526072102
+"BNL","Barnhill",55.8774834443,-4.2229911506
+"BNM","Burnham (Berks)",51.5235064374,-0.6463561439
+"BNP","Barnstaple",51.0739644921,-4.0631402025
+"BNR","Brockley Whins",54.9595502728,-1.4613667215
+"BNS","Barnes",51.4670846365,-0.2421410454
+"BNT","Brinnington",53.432131208,-2.1351183485
+"BNV","Banavie",56.8432899877,-5.0954121623
+"BNW","Bootle New Strand",53.4534030856,-2.9947465497
+"BNY","Barnsley",53.5543175422,-1.47716617
+"BOA","Bradford-on-Avon",51.3449090983,-2.2523240424
+"BOC","Bootle (Cumbria)",54.291308954,-3.3938621381
+"BOD","Bodmin Parkway",50.4458496871,-4.6629674421
+"BOE","Botley",50.9164438022,-1.2592242694
+"BOG","Bognor Regis",50.786547177,-0.6761573725
+"BOH","Bosham",50.8427366135,-0.8474129936
+"BOM","Bromborough",53.321860927,-2.9868952277
+"BON","Bolton",53.5741575045,-2.425822783
+"BOP","Bowes Park",51.6070128955,-0.1205568702
+"BOR","Bodorgan",53.2043181126,-4.4180098996
+"BOT","Bootle Oriel Road",53.4466353518,-2.9957327823
+"BOW","Bow Street",52.4400,-4.0303
+"BPB","Blackpool Pleasure Beach",53.7879651191,-3.0538730548
+"BPC","Penychain",52.9028982685,-4.3387298378
+"BPK","Brookmans Park",51.7210644329,-0.204525873
+"BPN","Blackpool North",53.8219272752,-3.0492707494
+"BPS","Blackpool South",53.7987134952,-3.0489347667
+"BPT","Bishopton",55.9022563659,-4.5004702272
+"BPW","Bristol Parkway",51.5137984154,-2.5421644857
+"BRA","Brora",58.012933425,-3.8522865622
+"BRC","Breich",55.8273074741,-3.6681187271
+"BRE","Brentwood",51.6136062194,0.2996132443
+"BRF","Brierfield",53.8239929448,-2.2364914709
+"BRG","Borough Green & Wrotham",51.293215966,0.3062721999
+"BRH","Borth",52.4910411643,-4.0501863389
+"BRI","Bristol Temple Meads",51.4491404983,-2.5813170589
+"BRK","Berwick (Sussex)",50.8403713146,0.1660450404
+"BRL","Barrhill",55.0970097604,-4.7817610115
+"BRM","Barmouth",52.7229049113,-4.0566037471
+"BRN","Bearsden",55.9171219632,-4.3320048257
+"BRO","Bridge of Orchy",56.5158519882,-4.7629778286
+"BRP","Brampton (Suffolk)",52.39545585,1.5438396721
+"BRR","Barrhead",55.8037470316,-4.3972682443
+"BRS","Berrylands",51.3990426839,-0.280691098
+"BRT","Barlaston",52.9428868109,-2.1681101939
+"BRU","Bruton",51.1116312549,-2.4470735628
+"BRV","Bournville",52.4269759491,-1.9264177275
+"BRW","Brunswick",53.3832558566,-2.9760770621
+"BRX","Brixton",51.4632979174,-0.1141578263
+"BRY","Barry",51.3967799856,-3.2849950221
+"BSB","Bleasby",53.0413834346,-0.9436832322
+"BSC","Bescot Stadium",52.5631069514,-1.9911001339
+"BSD","Bearsted",51.2758186317,0.5776101903
+"BSE","Bury St Edmunds",52.2537779145,0.7133353034
+"BSH","Bushey",51.6457542219,-0.3852982939
+"BSI","Balmossie",56.4745544268,-2.8389594192
+"BSJ","Bedford St Johns",52.1294885146,-0.4674793726
+"BSK","Basingstoke",51.2683550841,-1.0872452751
+"BSL","Beasdale",56.8995320852,-5.7637827088
+"BSM","Branksome",50.7269511745,-1.9197490477
+"BSN","Boston",52.9781123717,-0.0309954737
+"BSO","Basildon",51.5681072863,0.4568185797
+"BSP","Brondesbury Park",51.5406994758,-0.2101030164
+"BSR","Broadstairs",51.3606801474,1.4335860392
+"BSS","Barassie",55.5610564283,-4.6511181093
+"BSU","Brunstane",55.9425045311,-3.1009897555
+"BSV","Buckshaw Parkway",53.6733558277,-2.6608267264
+"BSW","Birmingham Snow Hill",52.4833681846,-1.89908361
+"BSY","Brondesbury",51.5451661494,-0.2022838772
+"BTB","Barnetby",53.5751404569,-0.4096836565
+"BTD","Bolton-Upon-Dearne",53.5189640059,-1.3115478698
+"BTE","Bitterne",50.9182096759,-1.3769901266
+"BTF","Bottesford",52.944634247,-0.7948377662
+"BTG","Barnt Green",52.3611012481,-1.9924584823
+"BTH","Bath Spa",51.3776813346,-2.3570165586
+"BTL","Batley",53.7099546488,-1.6229560553
+"BTN","Brighton",50.8289969623,-0.1412525289
+"BTO","Betchworth",51.2481856234,-0.2669489143
+"BTP","Braintree Freeport",51.86942396,0.5684631055
+"BTR","Braintree",51.8753991861,0.5567148512
+"BTS","Burntisland",56.0570735491,-3.233198596
+"BTT","Battersby",54.4576909817,-1.092985447
+"BTY","Bentley (Hants)",51.1812286564,-0.8681101444
+"BUB","Burnley Barracks",53.7908906624,-2.2580864157
+"BUC","Buckenham",52.5977618232,1.4703489483
+"BUD","Burneside (Cumbria)",54.3549872461,-2.7666793226
+"BUE","Bures",51.9711715742,0.7691763467
+"BUG","Burgess Hill",50.9536493887,-0.1273860328
+"BUH","Brough",53.7269790626,-0.5787296823
+"BUI","Burnside (Strathclyde)",55.8169207887,-4.2023757518
+"BUJ","Burton Joyce",52.9834597732,-1.0408745342
+"BUK","Bucknell",52.3573903067,-2.94737686
+"BUL","Butlers Lane",52.5924838341,-1.8380133232
+"BUO","Bursledon",50.8836771224,-1.3050217804
+"BUS","Busby",55.7803335966,-4.2621874207
+"BUT","Burton-on-Trent",52.805831535,-1.6424549107
+"BUU","Burnham-on-Crouch",51.6336616952,0.8140576821
+"BUW","Burley-in-Wharfedale",53.9081639278,-1.7533757307
+"BUX","Buxton",53.2607356445,-1.9128621475
+"BUY","Burley Park",53.8120445498,-1.5777714582
+"BVD","Belvedere",51.4921169254,0.1523141776
+"BWB","Bow Brickhill",52.0043090172,-0.6960564274
+"BWD","Birchwood",53.4127333746,-2.5253084603
+"BWG","Bowling",55.9310714655,-4.4938258606
+"BWK","Berwick-upon-Tweed",55.774332462,-2.0109833916
+"BWN","Bloxwich North",52.6254506167,-2.0176785833
+"BWO","Bricket Wood",51.7054311593,-0.3590920111
+"BWS","Barrow upon Soar",52.7493534585,-1.1448359281
+"BWT","Bridgwater",51.1278501854,-2.9904134747
+"BXB","Broxbourne",51.746913795,-0.0110606305
+"BXD","Buxted",50.9900076084,0.1314658692
+"BXH","Bexleyheath",51.4634986628,0.1337619475
+"BXW","Box Hill & Westhumble",51.2540077838,-0.3284670481
+"BXY","Bexley",51.4402179279,0.1479285922
+"BYA","Berney Arms",52.5898102913,1.6303988741
+"BYB","Blythe Bridge",52.9681588029,-2.0669597492
+"BYC","Betws-y-Coed",53.0920807045,-3.8008660334
+"BYD","Barry Docks",51.4024388396,-3.2607138987
+"BYE","Bynea",51.6720355869,-4.0989020803
+"BYF","Broughty Ferry",56.467149407,-2.8731557887
+"BYI","Barry Island",51.3924107233,-3.2733735249
+"BYK","Bentley (S Yorks)",53.5439546043,-1.1509511595
+"BYL","Barry Links",56.4931375583,-2.7454472508
+"BYM","Burnley Manchester Road",53.7849780535,-2.2488678001
+"BYN","Bryn",53.4998801227,-2.6472139369
+"BYS","Braystones",54.4393680606,-3.5418249064
+"CAA","Coventry Arena",52.4477480204,-1.4941167693
+"CAC","Caldercruix",55.887937313,-3.8877014781
+"CAD","Cadoxton",51.4122775163,-3.2489057172
+"CAG","Carrbridge",57.2794851095,-3.8282023232
+"CAK","Cark",54.177962852,-2.9740635997
+"CAM","Camberley",51.3363253942,-0.7442546332
+"CAN","Carnoustie",56.5005520159,-2.7066067008
+"CAO","Cannock",52.6861755085,-2.0221416067
+"CAR","Carlisle",54.8906568723,-2.9331955073
+"CAS","Castleton (Manchester)",53.5918610828,-2.1782323207
+"CAT","Caterham",51.2821380427,-0.0782806392
+"CAU","Causeland",50.4056755023,-4.466483549
+"CAY","Carntyne",55.8548667252,-4.178558829
+"CBB","Carbis Bay",50.1970388168,-5.4633147211
+"CBC","Coatbridge Central",55.8624998584,-4.0318858547
+"CBD","Conon Bridge",57.5617327905,-4.4404033769
+"CBE","Canterbury East",51.2742704504,1.0759983241
+"CBG","Cambridge",52.1940786826,0.1374844883
+"CBH","Cambridge Heath (London)",51.5319721727,-0.0572520963
+"CBK","Cranbrook",50.7500793373,-3.4204288894
+"CBL","Cambuslang",55.8196005407,-4.1729949447
+"CBN","Camborne",50.210424474,-5.2974601339
+"CBP","Castle Bar Park",51.5229296496,-0.3315265492
+"CBR","Cooksbridge",50.9037495693,-0.0091755079
+"CBS","Coatbridge Sunnyside",55.8668282944,-4.0282763675
+"CBW","Canterbury West",51.284271981,1.0753330452
+"CBY","Charlbury",51.8724337794,-1.4896781604
+"CBX","Cameron Bridge",56.189693,-3.046855
+"CCC","Criccieth",52.9184246922,-4.2375196432
+"CCH","Chichester",50.8320420668,-0.7817301783
+"CCT","Cathcart",55.8176625197,-4.260522045
+"CDB","Cardiff Bay",51.4671073886,-3.1664118035
+"CDD","Cardenden",56.1412469307,-3.2616419946
+"CDF","Cardiff Central",51.4760241554,-3.1793104707
+"CDI","Crediton",50.7832916037,-3.6467942575
+"CDN","Coulsdon Town",51.3220392402,-0.1344387303
+"CDO","Cardonald",55.8525617165,-4.340677662
+"CDQ","Cardiff Queen Street",51.4819604384,-3.1701891748
+"CDR","Cardross",55.9603705466,-4.6530550015
+"CDS","Coulsdon South",51.3158346141,-0.1378616075
+"CDT","Caldicot",51.5847886548,-2.7605785503
+"CDU","Cam & Dursley",51.7176208933,-2.3590816591
+"CDY","Cartsdyke",55.9422051727,-4.7315711125
+"CEA","Cleland",55.8046428518,-3.9102338035
+"CED","Cheddington",51.8579248983,-0.6621263072
+"CEF","Chapel-en-le-Frith",53.3122450065,-1.9187614767
+"CEH","Coleshill Parkway",52.5165405856,-1.7081695542
+"CEL","Chelford",53.270324898,-2.2805759167
+"CES","Cressing",51.8523442178,0.5779891355
+"CET","Colchester Town",51.8864651647,0.904792312
+"CEY","Cononley",53.917582567,-2.012071028
+"CFB","Catford Bridge",51.4447386824,-0.0247654501
+"CFD","Castleford",53.7240933891,-1.3546560801
+"CFF","Croftfoot",55.818250801,-4.2283107571
+"CFH","Chafford Hundred",51.4855557794,0.2874752389
+"CFL","Crossflatts",53.8584785,-1.8448891769
+"CFN","Clifton Down",51.4645414825,-2.6117434096
+"CFO","Chalfont & Latimer",51.6681107756,-0.5605042796
+"CFR","Chandlers Ford",50.9836745047,-1.3851600502
+"CFT","Crofton Park",51.45518736,-0.036477467
+"CGD","Craigendoran",55.9947875724,-4.7112248712
+"CGM","Cottingham",53.7816677653,-0.4064399418
+"CGN","Cogan",51.4459907902,-3.189098989
+"CGW","Caergwrle",53.1078775755,-3.0329132338
+"CHC","Charing Cross (Glasgow)",55.8646752269,-4.2698055885
+"CHD","Chesterfield",53.2382369384,-1.4201139064
+"CHE","Cheam",51.3554760901,-0.2141426137
+"CHF","Church Fenton",53.826617281,-1.227593241
+"CHG","Charing (Kent)",51.2080968918,0.790361474
+"CHH","Christs Hospital",51.0506799602,-0.3635305612
+"CHI","Chingford",51.6330861875,0.0099231874
+"CHK","Chiswick",51.4811352623,-0.2678126102
+"CHL","Chilworth",51.2152082426,-0.5248019553
+"CHM","Chelmsford",51.736377313,0.4685976033
+"CHN","Cheshunt",51.7028782333,-0.0239334005
+"CHO","Cholsey",51.5702030857,-1.1580033162
+"CHP","Chipstead",51.3092732695,-0.1694772828
+"CHR","Christchurch",50.7382022761,-1.7845391826
+"CHT","Chathill",55.5367311282,-1.7063916064
+"CHU","Cheadle Hulme",53.3759438577,-2.1883016906
+"CHW","Chalkwell",51.5387210852,0.6706212378
+"CHX","London Charing Cross",51.5080271291,-0.124776951
+"CHY","Chertsey",51.3870662195,-0.5092980361
+"CIL","Chilham",51.244611699,0.9759253356
+"CIM","Cilmeri",52.1505372986,-3.456549557
+"CIR","Caledonian Road & Barnsbury",51.5430414168,-0.1167032568
+"CIT","Chislehurst",51.4055548954,0.0574432034
+"CKH","Corkerhill",55.8374943521,-4.3342780321
+"CKL","Corkickle",54.5416855173,-3.5821649914
+"CKN","Crewkerne",50.8735260536,-2.7784973275
+"CKS","Clarkston",55.7893425756,-4.2756304312
+"CKT","Crookston",55.842306531,-4.3646599927
+"CKY","Crosskeys",51.6209031401,-3.1261795275
+"CLA","Clandon",51.2640008411,-0.5027439883
+"CLC","Castle Cary",51.0998071422,-2.5227962269
+"CLD","Chelsfield",51.3562553945,0.109096599
+"CLE","Cleethorpes",53.5619299115,-0.0292269788
+"CLG","Claygate",51.3612107148,-0.3482245539
+"CLH","Clitheroe",53.8734784154,-2.3943371754
+"CLI","Clifton (Manchester)",53.5225049162,-2.3147448248
+"CLJ","Clapham Junction",51.4641869937,-0.1702686508
+"CLK","Clock House",51.4085837591,-0.0406309221
+"CLL","Collington",50.8392826491,0.4578912206
+"CLM","Collingham",53.1441054305,-0.7503911592
+"CLN","Chapeltown",53.46235275,-1.4662753767
+"CLP","Clapham High Street",51.4654799498,-0.1324962988
+"CLR","Clarbeston Road",51.8516764519,-4.883577935
+"CLS","Chester-le-Street",54.8546014236,-1.5780279033
+"CLT","Clacton-on-Sea",51.7940121532,1.1541237294
+"CLU","Carluke",55.7312612023,-3.8489142324
+"CLV","Claverdon",52.2771032987,-1.696549552
+"CLW","Chorleywood",51.6542505776,-0.5182984244
+"CLY","Chinley",53.3403042037,-1.9439397765
+"CMB","Cambridge North",52.2244936969,0.158507305
+"CMD","Camden Road",51.5417913143,-0.1386752331
+"CME","Combe (Oxon)",51.8325979785,-1.3940563489
+"CMF","Cromford",53.1129487944,-1.5491593967
+"CMH","Cwmbach",51.7019306049,-3.4137347518
+"CML","Carmyle",55.8343311624,-4.1581669693
+"CMN","Carmarthen",51.8533597764,-4.3059837569
+"CMO","Camelon",56.0060850872,-3.8175985504
+"CMR","Cromer",52.9301115682,1.2928430662
+"CMY","Crossmyloof",55.8339394759,-4.2843030651
+"CNE","Colne",53.854755007,-2.1818613773
+"CNF","Carnforth",54.1296866595,-2.7712312791
+"CNG","Congleton",53.1578702503,-2.1925793889
+"CNL","Canley",52.3992554076,-1.5475652767
+"CNM","Cheltenham Spa",51.8974028753,-2.0996135055
+"CNN","Canonbury",51.5487325338,-0.09216443
+"CNO","Chetnole",50.8663529505,-2.5729267275
+"CNP","Conway Park",53.3933739019,-3.0226705989
+"CNR","Crianlarich",56.3904637247,-4.6184189492
+"CNS","Conisbrough",53.4893269216,-1.2343330775
+"CNW","Conwy",53.2801164248,-3.8305284521
+"CNY","Cantley",52.5787715007,1.5134359903
+"COA","Coatdyke",55.8643346399,-4.0049736959
+"COB","Cooden Beach",50.8333660029,0.4268882942
 "COE","Coombe Junction Halt (Rail Station)",50.4459059035,-4.4818867991
-"COH","Crowborough Rail Station",51.0463770048,0.1880407337
-"COI","Crosshill Rail Station",55.8332791971,-4.2567970862
-"COL","Colchester Rail Station",51.9007230246,0.8926284517
-"COM","Commondale Rail Station",54.4812856119,-0.9751641461
-"CON","Connel Ferry Rail Station",56.45233723,-5.3854201352
-"COO","Cookham Rail Station",51.5574642725,-0.7220603119
-"COP","Copplestone Rail Station",50.8144563375,-3.751590555
-"COR","Corby Rail Station",52.4888659511,-0.6883213327
-"COS","Cosford Rail Station",52.6448470661,-2.3002712165
-"COT","Cottingley Rail Station",53.7678308023,-1.5877119373
-"COV","Coventry Rail Station",52.4008284145,-1.5134504816
-"COW","Cowdenbeath Rail Station",56.112083991,-3.3431844925
-"COY","Coryton Rail Station",51.5204358321,-3.2318279619
-"CPA","Corpach Rail Station",56.8428086004,-5.121943037
-"CPH","Caerphilly Rail Station",51.5715771276,-3.2184921838
-"CPK","Carpenders Park Rail Station",51.6283534546,-0.3859168008
-"CPM","Chippenham Rail Station",51.4624852566,-2.1153890334
-"CPN","Chapelton (Devon) Rail Station",51.0165289386,-4.0247448242
-"CPT","Clapton Rail Station",51.5616436677,-0.0569984893
-"CPU","Capenhurst Rail Station",53.2601877687,-2.9422844784
-"CPW","Chepstow Rail Station",51.6401793133,-2.6719110922
-"CPY","Clapham (N Yorks) Rail Station",54.1053962118,-2.4103793434
-"CRA","Cradley Heath Rail Station",52.4696668258,-2.0904823836
-"CRB","Corbridge Rail Station",54.9662659971,-2.0184091796
-"CRD","Chester Road Rail Station",52.5356593313,-1.832472162
-"CRE","Crewe Rail Station",53.089639576,-2.4329694874
-"CRF","Carfin Rail Station",55.8073342674,-3.9562432142
-"CRG","Cross Gates Rail Station",53.8049283962,-1.4515849362
-"CRH","Crouch Hill Rail Station",51.5713028362,-0.11712295
-"CRI","Cricklewood Rail Station",51.5584538453,-0.212652067
-"CRK","Chirk Rail Station",52.9330999763,-3.0656421264
-"CRL","Chorley Rail Station",53.6525509696,-2.6268378803
-"CRM","Cramlington Rail Station",55.0877729503,-1.5986098387
-"CRN","Crowthorne Rail Station",51.3667259688,-0.8192566155
-"CRO","Croy Rail Station",55.9556707554,-4.0359670002
-"CRR","Corrour Rail Station",56.7601959475,-4.6905898827
-"CRS","Carstairs Rail Station",55.6910435615,-3.6684653164
-"CRT","Chartham Rail Station",51.2572676132,1.0180692196
-"CRV","Craven Arms Rail Station",52.4425511842,-2.8374211059
-"CRW","Crawley Rail Station",51.1122079127,-0.1866457301
-"CRY","Crayford Rail Station",51.4482784318,0.1789624549
-"CSA","Cosham Rail Station",50.8419131216,-1.0673147963
-"CSB","Carshalton Beeches Rail Station",51.3574078701,-0.1697719787
-"CSD","Cobham & Stoke d'Abernon Rail Station",51.3180974283,-0.389323466
-"CSG","Cressington Rail Station",53.3587637655,-2.9120028641
-"CSH","Carshalton Rail Station",51.368451556,-0.166343454
-"CSK","Calstock Rail Station",50.497783854,-4.2090174117
-"CSL","Codsall Rail Station",52.6273016994,-2.2017584348
-"CSM","Castleton Moor Rail Station",54.4671552873,-0.9466648318
-"CSN","Chessington North Rail Station",51.3640376909,-0.3006757682
-"CSO","Croston Rail Station",53.6675742668,-2.7777477556
-"CSR","Chassen Road Rail Station",53.4461736991,-2.3682321593
-"CSS","Chessington South Rail Station",51.3565467942,-0.3081340168
-"CST","London Cannon Street Rail Station",51.5113821708,-0.0902671514
-"CSW","Chestfield & Swalecliffe Rail Station",51.3602434955,1.0669610537
-"CSY","Coseley Rail Station",52.545096174,-2.0857720388
-"CTE","Chatelherault Rail Station",55.7652139884,-4.004665396
-"CTF","Catford Rail Station",51.4444046468,-0.0262908765
-"CTH","Chadwell Heath Rail Station",51.5680380571,0.1289849608
-"CTK","City Thameslink Rail Station",51.5139360643,-0.1035639706
-"CTL","Cattal Rail Station",53.997454781,-1.3205413788
-"CTM","Chatham Rail Station",51.3803760302,0.5211794412
-"CTN","Charlton Rail Station",51.4868121438,0.0312832554
-"CTO","Carlton Rail Station",52.9651058655,-1.0786513766
-"CTR","Chester Rail Station",53.1967089901,-2.8795954639
-"CTT","Church Stretton Rail Station",52.5374347501,-2.8036939757
-"CTW","Church & Oswaldtwistle Rail Station",53.7505339398,-2.3912114012
-"CUA","Culrain Rail Station",57.9194946106,-4.4042721672
-"CUB","Cumbernauld Rail Station",55.942019023,-3.9803257587
-"CUD","Cuddington Rail Station",53.2399328038,-2.5993047996
-"CUF","Cuffley Rail Station",51.708723054,-0.1097585788
-"CUH","Curriehill Rail Station",55.9005593257,-3.3187497327
-"CUM","Culham Rail Station",51.653795137,-1.2364953245
-"CUP","Cupar Rail Station",56.3169774524,-3.0087585168
-"CUW","Clunderwen Rail Station",51.8405496199,-4.731870145
-"CUX","Cuxton Rail Station",51.3739247395,0.4617373125
-"CWB","Colwyn Bay Rail Station",53.2963736339,-3.7254203797
-"CWC","Chappel & Wakes Colne Rail Station",51.9259156453,0.7585305397
-"CWD","Creswell (Derbys) Rail Station",53.2641317653,-1.2163932459
-"CWE","Crowle Rail Station",53.589752526,-0.8173624763
-"CWH","Crews Hill Rail Station",51.6844869604,-0.1068615213
-"CWL","Colwall Rail Station",52.0798767311,-2.3569466545
-"CWM","Cwmbran Rail Station",51.6565871606,-3.01621063
-"CWN","Cowden Rail Station",51.1556324991,0.1100591285
-"CWS","Caersws Rail Station",52.5161370252,-3.4325032748
-"CWU","Crowhurst Rail Station",50.8885735262,0.5013656464
-"CYB","Cefn-y-Bedd Rail Station",53.0988144368,-3.0310532391
-"CYK","Clydebank Rail Station",55.9006838001,-4.4043987103
-"CYN","Cynghordy Rail Station",52.0515055365,-3.7482227844
-"CYP","Crystal Palace Rail Station",51.4181067019,-0.0725839873
-"CYS","Cathays Rail Station",51.4888980023,-3.178691896
-"CYT","Cherry Tree Rail Station",53.7328842568,-2.5183765976
-"DAG","Dalgety Bay Rail Station",56.0420879876,-3.367719234
-"DAK","Dalmarnock Rail Station",55.8420793253,-4.2176948019
-"DAL","Dalmally Rail Station",56.40117566,-4.9835317937
-"DAM","Dalmeny Rail Station",55.9863117819,-3.381617481
-"DAN","Darnall Rail Station",53.3846003446,-1.4125666166
-"DAR","Darlington Rail Station",54.5204574957,-1.5473329223
-"DAT","Datchet Rail Station",51.4830766846,-0.5794049222
-"DBC","Dumbarton Central Rail Station",55.9466469118,-4.5669032007
-"DBD","Denby Dale Rail Station",53.5726454936,-1.6632128419
-"DBE","Dumbarton East Rail Station",55.9422389396,-4.5541195047
-"DBG","Mottisfont & Dunbridge Rail Station",51.0339180849,-1.5470733978
-"DBL","Dunblane Rail Station",56.1858813154,-3.9654784274
-"DBR","Derby Road (Ipswich) Rail Station",52.0505675726,1.182673697
-"DBY","Derby Rail Station",52.9165645679,-1.4633507475
-"DCG","Duncraig Rail Station",57.3369773237,-5.6371200748
-"DCH","Dorchester South Rail Station",50.7092808049,-2.43724064
-"DCT","Danescourt Rail Station",51.5005053214,-3.2339264723
-"DCW","Dorchester West Rail Station",50.7109424746,-2.4425389873
-"DDG","Dorridge Rail Station",52.3720819757,-1.7528919248
-"DDK","Dagenham Dock Rail Station",51.5260887461,0.1461308631
-"DDP","Dudley Port Rail Station",52.5246649483,-2.0494739583
-"DEA","Deal Rail Station",51.2230510827,1.3988758198
-"DEE","Dundee Rail Station",56.4564750929,-2.9712080372
-"DEN","Dean Rail Station",51.0424533409,-1.6348555051
-"DEP","Deptford Rail Station",51.4788466717,-0.0262441885
-"DEW","Dewsbury Rail Station",53.6921445094,-1.6331100451
-"DFD","Dartford Rail Station",51.4473695898,0.2192754223
-"DFE","Dunfermline Town Rail Station",56.0681835684,-3.4525246789
-"DFI","Duffield Rail Station",52.9884176714,-1.4859685231
-"DFL","Dunfermline Queen Margaret Rail Station",56.0805680436,-3.4214651879
-"DFR","Drumfrochar Rail Station",55.9412399388,-4.7747462431
-"DGC","Denham Golf Club Rail Station",51.5805981628,-0.5177663959
-"DGL","Dingle Road Rail Station",51.4400518803,-3.1805995641
-"DGT","Deansgate Rail Station",53.4741986483,-2.251049342
-"DGY","Deganwy Rail Station",53.2947621319,-3.8333901264
-"DHM","Durham Rail Station",54.7793980708,-1.5817625077
-"DHN","Deighton Rail Station",53.6684962139,-1.7518983268
-"DID","Didcot Parkway Rail Station",51.6109553482,-1.2428749913
-"DIG","Digby & Sowton Rail Station",50.7139764327,-3.4735740965
-"DIN","Dingwall Rail Station",57.5942168221,-4.4221973842
-"DIS","Diss Rail Station",52.3736757898,1.1237252182
-"DKD","Dunkeld & Birnam Rail Station",56.5570452529,-3.5783964404
-"DKG","Dorking Rail Station",51.2409257562,-0.3242277761
-"DKT","Dorking West Rail Station",51.2362217787,-0.3399557367
-"DLG","Dolgarrog Rail Station",53.1863628038,-3.8226405143
-"DLH","Doleham Rail Station",50.9185826306,0.6100042375
-"DLJ","Dalston Junction Rail Station",51.5461154595,-0.0751109378
-"DLK","Dalston Kingsland Rail Station",51.5481480385,-0.0756742388
-"DLM","Delamere Rail Station",53.2287882936,-2.6665587536
-"DLR","Dalreoch Rail Station",55.9474070119,-4.5778455124
-"DLS","Dalston (Cumbria) Rail Station",54.8461812399,-2.9888562179
-"DLT","Dalton Rail Station",54.1542436887,-3.1790013184
-"DLW","Dalwhinnie Rail Station",56.9351543012,-4.2461914619
-"DLY","Dalry Rail Station",55.7062150527,-4.7110594286
-"DMC","Drumchapel Rail Station",55.9048050133,-4.3628637433
-"DMF","Dumfries Rail Station",55.072559544,-3.604300351
-"DMG","Dinas (Rhondda) Rail Station",51.6178352115,-3.437552058
-"DMH","Dilton Marsh Rail Station",51.2489808553,-2.2079111292
-"DMK","Denmark Hill Rail Station",51.4682016412,-0.0893351949
-"DMP","Dumpton Park Rail Station",51.3457052089,1.4258444805
-"DMR","Dalmuir Rail Station",55.911921651,-4.4266657755
-"DMS","Dormans Rail Station",51.1557866779,-0.0042811467
-"DMY","Drumry Rail Station",55.9045847687,-4.3854571409
-"DND","Dinsdale Rail Station",54.5147386026,-1.4670752041
-"DNG","Dunton Green Rail Station",51.2964873167,0.1709649125
-"DNL","Dunlop Rail Station",55.7118747945,-4.5323721773
-"DNM","Denham Rail Station",51.5788378122,-0.4974160111
-"DNO","Dunrobin Castle Rail Station",57.9855164027,-3.9489241071
-"DNS","Dinas Powys Rail Station",51.4316627486,-3.2183612689
-"DNT","Dent Rail Station",54.2824184109,-2.3636026167
-"DNY","Danby Rail Station",54.4661651822,-0.9109721492
-"DOC","Dockyard (Plymouth) Rail Station",50.3821534706,-4.1759268375
-"DOD","Dodworth Rail Station",53.5443407648,-1.5316921206
-"DOL","Dolau Rail Station",52.2953601526,-3.2636234021
-"DON","Doncaster Rail Station",53.522167905,-1.1398476982
-"DOR","Dore & Totley Rail Station",53.3276504838,-1.5152967348
-"DOT","Dunston Rail Station",54.9500607179,-1.6420561513
-"DOW","Downham Market Rail Station",52.6041264601,0.3656997898
-"DPD","Dorking Deepdene Rail Station",51.2388000949,-0.3246201844
-"DPT","Devonport Rail Station",50.3785177656,-4.1707389477
-"DRF","Driffield Rail Station",54.001546492,-0.4346760339
-"DRG","Drayton Green Rail Station",51.5166156836,-0.3301719985
-"DRI","Drigg Rail Station",54.3769668358,-3.443413857
-"DRM","Drem Rail Station",56.0051170654,-2.7860534175
-"DRN","Duirinish Rail Station",57.319951049,-5.6913048804
-"DRO","Dronfield Rail Station",53.3013854109,-1.4687777286
-"DRT","Darton Rail Station",53.5883833705,-1.5316604623
-"DRU","Drumgelloch Rail Station",55.8673480624,-3.9488717169
-"DSL","Disley Rail Station",53.3581971647,-2.0424809658
-"DSM","Darsham Rail Station",52.2730184572,1.5235008921
-"DST","Duke Street Rail Station",55.8584302018,-4.213033844
-"DSY","Daisy Hill Rail Station",53.5394676714,-2.5158611336
-"DTG","Dinting Rail Station",53.4493453873,-1.9702958822
-"DTN","Denton Rail Station",53.456880489,-2.1316584707
-"DTW","Droitwich Spa Rail Station",52.2682155287,-2.1583562459
-"DUD","Duddeston Rail Station",52.4883756068,-1.8713859825
-"DUL","Dullingham Rail Station",52.2016639915,0.3666921781
-"DUM","Dumbreck Rail Station",55.8446425043,-4.3012244995
-"DUN","Dunbar Rail Station",55.9982866312,-2.513351643
-"DUR","Durrington-on-Sea Rail Station",50.817518034,-0.4114439
-"DVC","Dovercourt Rail Station",51.9387503243,1.2806410709
-"DVH","Dove Holes Rail Station",53.3000420778,-1.8897505662
-"DVN","Davenport Rail Station",53.3909155002,-2.1529566556
-"DVP","Dover Priory Rail Station",51.1257054631,1.3053252348
-"DVY","Dovey Junction Rail Station",52.5643723647,-3.9239110192
-"DWD","Dolwyddelan Rail Station",53.0520264903,-3.885137383
-"DWL","Dawlish Rail Station",50.5808060844,-3.4646385825
-"DWN","Darwen Rail Station",53.6980500658,-2.4649373867
-"DWW","Dawlish Warren Rail Station",50.5986963334,-3.4435746881
-"DYC","Dyce Rail Station",57.2056334738,-2.1923277179
-"DYF","Dyffryn Ardudwy Rail Station",52.7888658497,-4.1046506676
-"DYP","Drayton Park Rail Station",51.5527705023,-0.1054827348
-"DZY","Danzey Rail Station",52.3248260043,-1.8208686258
-"EAD","Earlsfield Rail Station",51.4423352541,-0.1876904006
-"EAG","Eaglescliffe Rail Station",54.529441791,-1.3494493173
-"EAL","Ealing Broadway Rail Station",51.5148407171,-0.3017293164
-"EAR","Earley Rail Station",51.4410992799,-0.9179692021
-"EBA","Euxton Balshaw Lane Rail Station",53.6604940469,-2.6720207861
-"EBB","Ebbw Vale Town Rail Station",51.7766906034,-3.2025853559
-"EBD","Ebbsfleet International Rail Station",51.4429711416,0.3209500322
-"EBK","Eastbrook Rail Station",51.4376339068,-3.206146908
-"EBL","East Boldon Rail Station",54.9464212649,-1.4203275453
-"EBN","Eastbourne Rail Station",50.7693712403,0.2812755597
-"EBR","Edenbridge Rail Station",51.2084314886,0.0606723709
-"EBT","Edenbridge Town Rail Station",51.2000785009,0.0671991686
-"EBV","Ebbw Vale Parkway Rail Station",51.7571458261,-3.1961117844
-"ECC","Eccles Rail Station",53.4853736806,-2.3345132824
-"ECL","Eccleston Park Rail Station",53.4308004759,-2.7800407784
-"ECP","Energlyn & Churchill Park Rail Station",51.5832131774,-3.2288061419
-"ECR","East Croydon Rail Station",51.3754518482,-0.0927543224
-"ECS","Eccles Road Rail Station",52.4709032665,0.9699418209
-"EDB","Edinburgh Rail Station",55.9523865322,-3.1882291087
-"EDG","Edge Hill Rail Station",53.402631221,-2.9464830162
-"EDL","Edale Rail Station",53.3649856666,-1.8166247959
-"EDN","Eden Park Rail Station",51.3900885752,-0.0263287699
-"EDP","Edinburgh Park Rail Station",55.9275440803,-3.3076630256
-"EDR","Edmonton Green Rail Station",51.6249290203,-0.0610875153
-"EDW","East Dulwich Rail Station",51.4614932275,-0.080545987
-"EDY","East Didsbury Rail Station",53.4093226957,-2.221995354
-"EFF","Effingham Junction Rail Station",51.2914916148,-0.4199426403
-"EFL","East Farleigh Rail Station",51.2552346504,0.484758691
-"EGF","East Garforth Rail Station",53.7919924434,-1.3705405592
-"EGG","Eggesford Rail Station",50.887727229,-3.8747670951
-"EGH","Egham Rail Station",51.4296448509,-0.5464936108
-"EGN","Eastrington Rail Station",53.7551798175,-0.7876353437
-"EGR","East Grinstead Rail Station",51.1262681111,-0.0178726978
-"EGT","Egton Rail Station",54.4374940456,-0.7614806216
-"EGY","Edinburgh Gateway Rail Station",55.940932789,-3.3202500314
-"EKB","Eskbank Rail Station",55.8817963943,-3.0830769228
-"EKL","East Kilbride Rail Station",55.7659978238,-4.1802138231
-"ELD","Earlswood (Surrey) Rail Station",51.2273248317,-0.1707971701
-"ELE","Elmers End Rail Station",51.398489582,-0.0495441803
-"ELG","Elgin Rail Station",57.6428926912,-3.3112425277
-"ELO","Elton & Orston Rail Station",52.9521557025,-0.8555074435
-"ELP","Ellesmere Port Rail Station",53.2822052615,-2.8964224623
-"ELR","Elsecar Rail Station",53.4986759683,-1.4274252148
-"ELS","Elstree & Borehamwood Rail Station",51.6530715786,-0.2800577261
-"ELW","Eltham Rail Station",51.4556421114,0.0524986776
-"ELY","Ely Rail Station",52.391244221,0.2668510603
-"EMD","East Midlands Parkway Rail Station",52.8625182507,-1.2632265891
-"EML","East Malling Rail Station",51.2858069522,0.439309906
-"EMP","Emerson Park Rail Station",51.5686424022,0.2201396373
-"EMS","Emsworth Rail Station",50.8516027835,-0.9384144303
-"ENC","Enfield Chase Rail Station",51.6532550128,-0.0906697288
-"ENF","Enfield Town Rail Station",51.6520265184,-0.0793010146
-"ENL","Enfield Lock Rail Station",51.6709227126,-0.0285062955
-"ENT","Entwistle Rail Station",53.6559908688,-2.4145427951
-"EPD","Epsom Downs Rail Station",51.3236845001,-0.23892976
-"EPH","Elephant & Castle Rail Station",51.4940282398,-0.098700214
-"EPS","Epsom Rail Station",51.334389925,-0.2687531384
-"ERA","Eastham Rake Rail Station",53.307552763,-2.9811322454
-"ERD","Erdington Rail Station",52.5282972975,-1.8395023401
-"ERH","Erith Rail Station",51.481669408,0.1750812719
-"ERI","Eridge Rail Station",51.0889610517,0.2014592494
-"ERL","Earlestown Rail Station",53.451151143,-2.6376624607
-"ESD","Elmstead Woods Rail Station",51.4171157446,0.0442997314
-"ESH","Esher Rail Station",51.3798880712,-0.3533154601
-"ESL","Eastleigh Rail Station",50.9692403635,-1.350073969
-"ESM","Elsenham Rail Station",51.920551892,0.228097059
-"EST","Easterhouse Rail Station",55.8597505142,-4.1071641367
-"ESW","Elmswell Rail Station",52.2380555449,0.9126215916
-"ETC","Etchingham Rail Station",51.0105413018,0.4423847838
-"ETL","East Tilbury Rail Station",51.4848306628,0.4129581196
-"EUS","London Euston Rail Station",51.5281364316,-0.1338981275
-"EVE","Evesham Rail Station",52.0984067663,-1.9473049925
-"EWD","Earlswood (West Midlands) Rail Station",52.3665938407,-1.861161636
-"EWE","Ewell East Rail Station",51.3452967584,-0.2415048775
-"EWR","East Worthing Rail Station",50.8216357611,-0.3548680158
-"EWW","Ewell West Rail Station",51.350041877,-0.2569621791
-"EXC","Exeter Central Rail Station",50.7264717379,-3.5332911791
-"EXD","Exeter St Davids Rail Station",50.7292625509,-3.5433010662
-"EXG","Exhibition Centre (Glasgow) Rail Station",55.8615443927,-4.2835742363
-"EXM","Exmouth Rail Station",50.6216212923,-3.4149848889
-"EXN","Exton Rail Station",50.6682904818,-3.4441097276
-"EXR","Essex Road Rail Station",51.5407057256,-0.0962497405
-"EXT","Exeter St Thomas Rail Station",50.717135131,-3.5388511334
-"EYN","Eynsford Rail Station",51.3627174333,0.2044201754
-"FAL","Falmouth Docks Rail Station",50.1506931982,-5.0560746226
-"FAV","Faversham Rail Station",51.3117150831,0.8910755277
-"FAZ","Fazakerley Rail Station",53.4690990636,-2.936722397
-"FBY","Formby Rail Station",53.5534917106,-3.0709054604
-"FCN","Falconwood Rail Station",51.4591529464,0.079330998
-"FEA","Featherstone Rail Station",53.6790826979,-1.358447032
-"FEL","Feltham Rail Station",51.4478965298,-0.4098171801
-"FEN","Fenny Stratford Rail Station",52.0000768774,-0.7159762313
-"FER","Fernhill Rail Station",51.6864981097,-3.3958946145
-"FFA","Ffairfach Rail Station",51.8724808498,-3.9928787809
-"FFD","Freshford Rail Station",51.3420243729,-2.3010063939
-"FGH","Fishguard Harbour Rail Station",52.011557061,-4.985670408
-"FGT","Faygate Rail Station",51.0958843958,-0.2629910043
-"FGW","Fishguard & Goodwick Rail Station",52.0041284781,-4.9948666231
-"FIL","Filey Rail Station",54.2098758908,-0.2938654062
-"FIN","Finstock Rail Station",51.8527876529,-1.4693269485
-"FIT","Filton Abbey Wood Rail Station",51.5049359236,-2.5624320807
-"FKC","Folkestone Central Rail Station",51.0828894709,1.1695144099
-"FKG","Falkirk Grahamston Rail Station",56.0026075153,-3.7850391932
-"FKK","Falkirk High Rail Station",55.9918091725,-3.7922363145
-"FKW","Folkestone West Rail Station",51.0845880696,1.1539352777
-"FLD","Fauldhouse Rail Station",55.8224687949,-3.7193103999
-"FLE","Fleet Rail Station",51.2906324021,-0.8307895054
-"FLF","Flowery Field Rail Station",53.4618690949,-2.0810528443
-"FLI","Flixton Rail Station",53.4438220233,-2.3842455243
-"FLM","Flimby Rail Station",54.6896927165,-3.5207405823
-"FLN","Flint Rail Station",53.2495386637,-3.1329931372
-"FLT","Flitwick Rail Station",52.0036505318,-0.4952335864
-"FLW","Fulwell Rail Station",51.4339333056,-0.3494462747
-"FLX","Felixstowe Rail Station",51.9670846947,1.3504650975
-"FML","Frimley Rail Station",51.3118599318,-0.7469740068
-"FMR","Falmer Rail Station",50.8621216711,-0.0873578378
-"FMT","Falmouth Town Rail Station",50.1483262428,-5.0649815419
-"FNB","Farnborough (Main) Rail Station",51.2966031825,-0.7557080158
-"FNC","Farncombe Rail Station",51.1971482209,-0.6045286271
-"FNH","Farnham Rail Station",51.2119005959,-0.7924099968
-"FNN","Farnborough North Rail Station",51.3020427564,-0.7430095202
-"FNR","Farningham Road Rail Station",51.40166365,0.235479766
-"FNT","Feniton Rail Station",50.7866658255,-3.2854308727
-"FNV","Furness Vale Rail Station",53.3487660512,-1.9888438055
-"FNW","Farnworth Rail Station",53.5500180154,-2.3878478205
-"FNY","Finchley Road & Frognal Rail Station",51.5502664369,-0.1831154061
-"FOC","Falls of Cruachan Rail Station",56.3938689413,-5.1124566704
-"FOD","Ford Rail Station",50.8293824048,-0.5783872727
-"FOG","Forest Gate Rail Station",51.549431694,0.0243798935
-"FOH","Forest Hill Rail Station",51.4392780589,-0.0531313997
-"FOK","Four Oaks Rail Station",52.5797939503,-1.8280248803
-"FOR","Forres Rail Station",57.6111680406,-3.6248718523
-"FOX","Foxfield Rail Station",54.2586748544,-3.216062854
-"FPK","Finsbury Park Rail Station",51.5643025324,-0.1062590007
-"FRB","Fairbourne Rail Station",52.6960557759,-4.0494218463
-"FRD","Frodsham Rail Station",53.2958284679,-2.7235668244
-"FRE","Freshfield Rail Station",53.5660676569,-3.0718271848
-"FRF","Fairfield Rail Station",53.4713083714,-2.1457740263
-"FRI","Frinton-on-Sea Rail Station",51.8376925676,1.2432006998
-"FRL","Fairlie Rail Station",55.7519366963,-4.8532464966
-"FRM","Fareham Rail Station",50.8530232101,-1.1920245124
-"FRN","Fearn Rail Station",57.778126445,-3.9939370006
-"FRO","Frome Rail Station",51.2272634789,-2.3099932958
-"FRR","Frosterley Rail Station",54.7270012002,-1.9644205566
-"FRS","Forsinard Rail Station",58.3568834527,-3.8968870161
-"FRT","Frant Rail Station",51.1040247127,0.2945703279
-"FRW","Fairwater Rail Station",51.4939058847,-3.2338488071
-"FRY","Ferriby Rail Station",53.7171721074,-0.5078355516
-"FSB","Fishbourne Rail Station",50.8390401424,-0.8150655546
-"FSG","Fishersgate Rail Station",50.834226328,-0.2193956669
-"FSK","Fiskerton Rail Station",53.0602929309,-0.9121833385
-"FST","London Fenchurch Street Rail Station",51.5116455824,-0.0788707296
-"FTM","Fort Matilda Rail Station",55.9590229231,-4.7952474713
-"FTN","Fratton Rail Station",50.7963261465,-1.0739689378
-"FTW","Fort William Rail Station",56.820425796,-5.1061294153
-"FWY","Five Ways Rail Station",52.4711078714,-1.9129492479
-"FXN","Foxton Rail Station",52.1192233456,0.0563363619
-"FYS","Ferryside Rail Station",51.7683736213,-4.3694828095
-"FZH","Frizinghall Rail Station",53.8203830612,-1.7690049748
-"FZP","Furze Platt Rail Station",51.533021301,-0.7284541823
-"FZW","Fitzwilliam Rail Station",53.6325161611,-1.3742749709
-"GAL","Galashiels Rail Station",55.618348945,-2.8069043382
-"GAR","Garrowhill Rail Station",55.8552326445,-4.1294477285
-"GBD","Gilberdyke Rail Station",53.7479824021,-0.7322489664
-"GBG","Gorebridge Rail Station",55.8402677085,-3.0465190236
-"GBK","Greenbank Rail Station",53.2514787515,-2.5342692507
-"GBL","Gainsborough Lea Road Rail Station",53.3861086871,-0.7685809379
-"GBS","Goring-by-Sea Rail Station",50.8177112854,-0.4330585625
-"GCH","Garelochhead Rail Station",56.0798548957,-4.8256979183
-"GCL","Glasgow Central Low Level Rail Station",55.858673532,-4.2584774599
-"GCR","Gloucester Rail Station",51.8655641361,-2.2384843439
-"GCT","Great Coates Rail Station",53.5757759251,-0.1302350444
-"GCW","Glan Conwy Rail Station",53.2674361965,-3.797731864
-"GDH","Gordon Hill Rail Station",51.6633360633,-0.0945839997
-"GDL","Godley Rail Station",53.4517179149,-2.0547723093
-"GDN","Godstone Rail Station",51.2181531133,-0.0500583421
-"GDP","Gidea Park Rail Station",51.5819043047,0.2059905265
-"GEA","Gretna Green Rail Station",55.0010507027,-3.0652008756
-"GER","Gerrards Cross Rail Station",51.5890237128,-0.5552555668
-"GFD","Greenford Rail Station",51.5423307069,-0.3458148281
-"GFF","Gilfach Fargoed Rail Station",51.6842505424,-3.2265776505
-"GFN","Giffnock Rail Station",55.8039838247,-4.2930005917
-"GGJ","Georgemas Junction Rail Station",58.5136083248,-3.4521277157
-"GGV","Gargrave Rail Station",53.9784289792,-2.1051749427
-"GIG","Giggleswick Rail Station",54.0618113766,-2.3028507825
-"GIL","Gillingham (Dorset) Rail Station",51.0340262862,-2.2726193805
-"GIP","Gipsy Hill Rail Station",51.424451003,-0.0838100922
-"GIR","Girvan Rail Station",55.2463156898,-4.8483590289
-"GKC","Greenock Central Rail Station",55.9453319247,-4.7526142906
-"GKW","Greenock West Rail Station",55.9473282882,-4.767813412
-"GLC","Glasgow Central Rail Station",55.8597496156,-4.2576290605
-"GLD","Guildford Rail Station",51.2369644453,-0.5804043303
-"GLE","Gleneagles Rail Station",56.2748401663,-3.7311626664
-"GLF","Glenfinnan Rail Station",56.8723822491,-5.449604955
-"GLG","Glengarnock Rail Station",55.7388819511,-4.6744823788
-"GLH","Glasshoughton Rail Station",53.7090594596,-1.3420084086
-"GLM","Gillingham (Kent) Rail Station",51.3865631854,0.5498787442
-"GLO","Glossop Rail Station",53.4444844182,-1.9490712229
-"GLQ","Glasgow Queen Street Rail Station",55.8621817762,-4.2514417118
-"GLS","Glaisdale Rail Station",54.4393938445,-0.7938035599
-"GLT","Glenrothes with Thornton Rail Station",56.1623481523,-3.1430172976
-"GLY","Glynde Rail Station",50.8591649295,0.0701049622
-"GLZ","Glazebrook Rail Station",53.4283742205,-2.459656827
-"GMB","Grimsby Town Rail Station",53.5634511917,-0.0869883746
-"GMD","Grimsby Docks Rail Station",53.5743443249,-0.0756224261
-"GMG","Garth (Bridgend) Rail Station",51.5964572422,-3.6414648286
-"GMN","Great Missenden Rail Station",51.7035218129,-0.7091187725
-"GMT","Grosmont Rail Station",54.43612578,-0.7249812388
-"GMV","Great Malvern Rail Station",52.1092074558,-2.3182662455
-"GMY","Goodmayes Rail Station",51.5655781413,0.1108335454
-"GNB","Gainsborough Central Rail Station",53.3996038827,-0.7696962039
-"GNF","Greenfield Rail Station",53.5388735659,-2.013841081
-"GNH","Greenhithe for Bluewater Rail Station",51.4503693938,0.2803176704
-"GNL","Green Lane Rail Station",53.3832695481,-3.0164148473
-"GNR","Green Road Rail Station",54.2445321604,-3.2455716728
-"GNT","Gunton Rail Station",52.8663732165,1.3491365444
-"GNW","Greenwich Rail Station",51.4781335778,-0.0133139144
-"GOB","Gobowen Rail Station",52.8935276407,-3.0371715591
-"GOD","Godalming Rail Station",51.1865810902,-0.6188424046
-"GOE","Goldthorpe Rail Station",53.5342068606,-1.3128096411
-"GOF","Golf Street Rail Station",56.4977824375,-2.7195495703
-"GOL","Golspie Rail Station",57.9714474115,-3.9872179776
-"GOM","Gomshall Rail Station",51.2193937984,-0.4418288518
-"GOO","Goole Rail Station",53.7049327129,-0.8742176314
-"GOR","Goring & Streatley Rail Station",51.5214927112,-1.133029148
-"GOS","Grange-over-Sands Rail Station",54.1957302552,-2.9027471889
-"GOX","Goxhill Rail Station",53.6767222975,-0.3371266253
-"GPK","Grange Park Rail Station",51.6426082109,-0.0973320762
-"GPO","Gospel Oak Rail Station",51.5553362208,-0.1507445033
-"GQL","Glasgow Queen Street Low Level Rail Station",55.8623403235,-4.2506358523
-"GRA","Grantham Rail Station",52.9064924179,-0.6424450707
-"GRB","Great Bentley Rail Station",51.8517695139,1.0651844079
-"GRC","Great Chesterford Rail Station",52.0598200469,0.1935488673
-"GRF","Garforth Rail Station",53.7965926372,-1.3823135001
-"GRH","Gartcosh Rail Station",55.8856546592,-4.0794827931
-"GRK","Gourock Rail Station",55.962310977,-4.8166374785
-"GRL","Greenfaulds Rail Station",55.9352259193,-3.9930912233
-"GRN","Grindleford Rail Station",53.3055770449,-1.6262956215
-"GRP","Grove Park Rail Station",51.4308613738,0.0217517094
-"GRS","Garscadden Rail Station",55.8876875396,-4.3649893754
-"GRT","Grateley Rail Station",51.1700524514,-1.6207622447
-"GRV","Gravesend Rail Station",51.4413470696,0.3666726966
-"GRY","Grays Rail Station",51.4762461335,0.3218603146
-"GSC","Gilshochill Rail Station",55.8973310545,-4.2826700794
-"GSD","Garsdale Rail Station",54.3214395016,-2.3263576927
-"GSL","Gunnislake Rail Station",50.5160691161,-4.2194356583
-"GSN","Garston (Herts) Rail Station",51.6866190925,-0.3817173062
-"GST","Gathurst Rail Station",53.5594164707,-2.694392781
-"GSW","Garswood Rail Station",53.4885342343,-2.6721346367
-"GSY","Guiseley Rail Station",53.8759473312,-1.7150832878
-"GTA","Great Ayton Rail Station",54.4895819243,-1.1153591094
-"GTH","Garth (Powys) Rail Station",52.1332443119,-3.5299153647
-"GTN","Grangetown (Cardiff) Rail Station",51.4676101723,-3.1897328323
-"GTO","Gorton Rail Station",53.4690883466,-2.1662083592
-"GTR","Goostrey Rail Station",53.2225673734,-2.3264689479
-"GTW","Gatwick Airport Rail Station",51.1564852744,-0.1610141074
-"GTY","Gatley Rail Station",53.3929193229,-2.2312340568
-"GUI","Guide Bridge Rail Station",53.4746422166,-2.1137102403
-"GUN","Gunnersbury Rail Station",51.4916766051,-0.2752639989
-"GVE","Garve Rail Station",57.6130218771,-4.6883911143
-"GVH","Gravelly Hill Rail Station",52.5150091168,-1.8525928905
-"GWE","Gwersyllt Rail Station",53.0725888841,-3.0178887352
-"GWN","Gowerton Rail Station",51.6487287822,-4.0359546516
-"GYM","Great Yarmouth Rail Station",52.6121840141,1.7209095669
-"GYP","Gypsy Lane Rail Station",54.5329024718,-1.1794055894
-"HAB","Habrough Rail Station",53.6060967313,-0.2694661266
-"HAC","Hackney Downs Rail Station",51.548757028,-0.0607923652
-"HAD","Haddiscoe Rail Station",52.5288110907,1.6230311744
-"HAF","Heathrow Terminal 4 Rail Station",51.458265962,-0.4454428215
-"HAG","Hagley Rail Station",52.4225023907,-2.1464119812
-"HAI","Halling Rail Station",51.352475791,0.4449605383
-"HAL","Hale Rail Station",53.3787324238,-2.3473557978
-"HAM","Hamworthy Rail Station",50.7251804312,-2.0193512479
-"HAN","Hanwell Rail Station",51.5118339425,-0.3385615111
-"HAP","Hatfield Peverel Rail Station",51.7798704228,0.5921498316
-"HAS","Halesworth Rail Station",52.3468365087,1.505697432
-"HAT","Hatfield (Herts) Rail Station",51.7638834885,-0.215564807
-"HAV","Havant Rail Station",50.8544157698,-0.9815958592
-"HAY","Hayes & Harlington Rail Station",51.5030948614,-0.4206635166
-"HAZ","Hazel Grove Rail Station",53.3775580792,-2.1220186129
-"HBB","Hubberts Bridge Rail Station",52.9753742831,-0.1105219846
-"HBD","Hebden Bridge Rail Station",53.7376009105,-2.0090600757
-"HBN","Hollingbourne Rail Station",51.2651766997,0.6278786652
-"HBP","Hornbeam Park Rail Station",53.9798825753,-1.5268279163
-"HBY","Hartlebury Rail Station",52.3345074098,-2.2211143855
-"HCB","Hackbridge Rail Station",51.3778692696,-0.1538824466
-"HCH","Holmes Chapel Rail Station",53.1989461479,-2.3511385797
-"HCN","Headcorn Rail Station",51.1657113933,0.6275122421
-"HCT","Huncoat Rail Station",53.7717900997,-2.3475613545
-"HDB","Haydon Bridge Rail Station",54.9751799008,-2.247596044
-"HDE","Hedge End Rail Station",50.9323093202,-1.2944922291
-"HDF","Hadfield Rail Station",53.4607595075,-1.9653179115
-"HDG","Heald Green Rail Station",53.3694305097,-2.2366663043
-"HDH","Hampstead Heath Rail Station",51.555210868,-0.1656799709
-"HDL","Headstone Lane Rail Station",51.6026499985,-0.3571975148
-"HDM","Haddenham & Thame Parkway Rail Station",51.7708590202,-0.9421154353
-"HDN","Harlesden Rail Station",51.536289123,-0.2576441501
-"HDW","Hadley Wood Rail Station",51.6684984541,-0.1761475828
-"HDY","Headingley Rail Station",53.8179883371,-1.5941914379
-"HEC","Heckington Rail Station",52.9773390292,-0.2939371983
-"HED","Halewood Rail Station",53.3644936533,-2.8301342149
-"HEI","Heighington Rail Station",54.5969688714,-1.5817749363
-"HEL","Hensall Rail Station",53.6985625439,-1.1145223177
-"HEN","Hendon Rail Station",51.5800693984,-0.2386485815
-"HER","Hersham Rail Station",51.3768090642,-0.3899376365
-"HES","Hessle Rail Station",53.7174547293,-0.4418278411
-"HEV","Hever Rail Station",51.18140673,0.0950955245
-"HEW","Heworth Rail Station",54.951574003,-1.5557793317
-"HEX","Hexham Rail Station",54.9734640115,-2.0948036947
-"HFD","Hereford Rail Station",52.0611692914,-2.7082118767
-"HFE","Hertford East Rail Station",51.7990391609,-0.0729130019
-"HFN","Hertford North Rail Station",51.7988609689,-0.0917600735
-"HFS","Hatfield & Stainforth Rail Station",53.5887339868,-1.0233819902
-"HFX","Halifax Rail Station",53.7209739882,-1.853576757
-"HGD","Hungerford Rail Station",51.4149070262,-1.5122717583
-"HGF","Hag Fold Rail Station",53.5338672616,-2.494821366
-"HGG","Haggerston Rail Station",51.5387053397,-0.0756398309
-"HGM","Higham Rail Station",51.4265572516,0.4663063259
-"HGN","Hough Green Rail Station",53.3724056855,-2.7750665578
-"HGR","Hither Green Rail Station",51.4520235715,-0.0009184787
-"HGS","Hastings Rail Station",50.8578901133,0.5767707918
-"HGT","Harrogate Rail Station",53.9931903958,-1.5376134519
-"HGY","Harringay Rail Station",51.577359069,-0.1051105218
-"HHB","Heysham Port Rail Station",54.0331542281,-2.9131111175
-"HHD","Holyhead Rail Station",53.3076995179,-4.6310080997
-"HHE","Haywards Heath Rail Station",51.0056759707,-0.105050763
-"HHL","Heath High Level Rail Station",51.5164298424,-3.181549994
-"HHY","Highbury & Islington Rail Station",51.5461777019,-0.103737426
-"HIA","Hampton-in-Arden Rail Station",52.4290462911,-1.69992295
-"HIB","High Brooms Rail Station",51.1494010314,0.2773589795
-"HID","Hall i' th' Wood Rail Station",53.5974371057,-2.413107867
-"HIG","Highbridge & Burnham-on-Sea Rail Station",51.2181503748,-2.9721630499
-"HII","Highbury & Islington Rail Station",51.5460878363,-0.1037411643
-"HIL","Hillside Rail Station",53.6221202826,-3.0247137204
-"HIN","Hindley Rail Station",53.5422508577,-2.575501122
-"HIP","Highams Park Rail Station",51.6083496344,-0.000196266
-"HIR","Horton-in-Ribblesdale Rail Station",54.149396209,-2.3020360937
-"HIT","Hitchin Rail Station",51.9532881959,-0.2634564466
-"HKC","Hackney Central Rail Station",51.5471044422,-0.0560308162
-"HKH","Hawkhead Rail Station",55.8421839094,-4.3988362292
-"HKM","Hykeham Rail Station",53.1950249324,-0.6001954228
-"HKN","Hucknall Rail Station",53.0383014288,-1.1958079305
-"HKW","Hackney Wick Rail Station",51.5434103591,-0.0248923154
-"HLB","Hildenborough Rail Station",51.2144822954,0.227617147
-"HLC","Helensburgh Central Rail Station",56.0041995399,-4.7327385924
-"HLD","Hellifield Rail Station",54.0108742019,-2.2278480504
-"HLE","Hillington East Rail Station",55.8541758548,-4.3549953963
-"HLF","Hillfoot Rail Station",55.9200849636,-4.3202587624
-"HLG","Hall Green Rail Station",52.4369222096,-1.8456449276
-"HLI","Healing Rail Station",53.5818205021,-0.1606345765
-"HLL","Heath Low Level Rail Station",51.5156612205,-3.1819768215
-"HLM","Holmwood Rail Station",51.1811903162,-0.3207835997
-"HLN","Harlington (Beds) Rail Station",51.9620697513,-0.4956650065
-"HLR","Hall Road Rail Station",53.4975007979,-3.049624671
-"HLS","Hilsea Rail Station",50.828264455,-1.0587831528
-"HLU","Helensburgh Upper Rail Station",56.0123545737,-4.7297849071
-"HLW","Hillington West Rail Station",55.8560145655,-4.3715655801
-"HLY","Holytown Rail Station",55.8128931888,-3.9739183285
-"HMC","Hampton Court Rail Station",51.402553453,-0.3427264701
-"HMD","Hampden Park (Sussex) Rail Station",50.7963992867,0.2793840646
-"HME","Hamble Rail Station",50.8713629565,-1.3291521514
-"HML","Hemel Hempstead Rail Station",51.7423380827,-0.4907522249
-"HMM","Hammerton Rail Station",53.9963447909,-1.2841021471
-"HMN","Homerton Rail Station",51.547011697,-0.0423325837
-"HMP","Hampton (London) Rail Station",51.415932868,-0.3720976323
-"HMS","Helmsdale Rail Station",58.1174231841,-3.6586930118
-"HMT","Ham Street Rail Station",51.0683758331,0.8545396144
-"HMW","Hampton Wick Rail Station",51.414522516,-0.3124680243
-"HMY","Hairmyres Rail Station",55.761959437,-4.2199969848
-"HNA","Hinton Admiral Rail Station",50.7526280082,-1.7141197084
-"HNB","Herne Bay Rail Station",51.364595492,1.1177553962
-"HNC","Hamilton Central Rail Station",55.7731886703,-4.0388743726
-"HND","Hanborough Rail Station",51.8251625822,-1.3735084455
-"HNF","Hednesford Rail Station",52.7101262196,-2.0017747098
-"HNG","Hengoed Rail Station",51.6474099206,-3.2241373274
-"HNH","Herne Hill Rail Station",51.4533037255,-0.102263463
-"HNK","Hinckley Rail Station",52.5350144159,-1.3719130606
-"HNL","Henley-in-Arden Rail Station",52.2915002317,-1.7839820888
-"HNT","Huntly Rail Station",57.4444716353,-2.7757412945
-"HNW","Hamilton West Rail Station",55.7788548735,-4.0547968763
-"HNX","Hunts Cross Rail Station",53.3607253407,-2.8558609579
-"HOC","Hockley Rail Station",51.6035599652,0.6590284828
-"HOH","Harrow-on-the-Hill Rail Station",51.5791855381,-0.3372032129
-"HOK","Hook Rail Station",51.279996325,-0.9616187573
-"HOL","Holton Heath Rail Station",50.7113964673,-2.0778391092
-"HON","Honiton Rail Station",50.7965702123,-3.1867284121
-"HOO","Hooton Rail Station",53.2972130919,-2.9770090629
-"HOP","Hope (Derbyshire) Rail Station",53.3461251048,-1.7298854225
-"HOR","Horley Rail Station",51.1687701925,-0.1610261883
-"HOT","Henley-on-Thames Rail Station",51.5341810915,-0.9001927563
-"HOU","Hounslow Rail Station",51.4619441377,-0.3622557388
-"HOV","Hove Rail Station",50.8352085815,-0.1706597369
-"HOW","Howden Rail Station",53.7647299348,-0.8604679516
-"HOX","Hoxton Rail Station",51.5315115893,-0.075655026
-"HOY","Honley Rail Station",53.6082419978,-1.7809663313
-"HOZ","Howwood (Renfrewshire) Rail Station",55.8105581084,-4.5630406539
-"HPA","Honor Oak Park Rail Station",51.4499871094,-0.0454798264
-"HPD","Harpenden Rail Station",51.8146501449,-0.3514563418
-"HPE","Hope (Flintshire) Rail Station",53.117371815,-3.03687622
-"HPL","Hartlepool Rail Station",54.6867644231,-1.2073308234
-"HPN","Hapton Rail Station",53.7816268971,-2.3169116789
-"HPQ","Harwich International Rail Station",51.9473012514,1.2551547397
-"HPT","Hopton Heath Rail Station",52.3914278931,-2.9120578549
-"HRD","Harling Road Rail Station",52.4537084708,0.9091672143
-"HRH","Horsham Rail Station",51.0660592013,-0.3192431154
-"HRL","Harlech Rail Station",52.8613425321,-4.1091973982
-"HRM","Harrietsham Rail Station",51.2448308208,0.6724297963
-"HRN","Hornsey Rail Station",51.5864618559,-0.1119495944
-"HRO","Harold Wood Rail Station",51.592766307,0.2331539888
-"HRR","Harrington Rail Station",54.6134911874,-3.5655149544
-"HRS","Horsforth Rail Station",53.8477194776,-1.6302327899
-"HRW","Harrow & Wealdstone Rail Station",51.5921690735,-0.3345489082
-"HRY","Harringay Green Lanes Rail Station",51.5771828877,-0.0981182196
-"HSB","Helsby Rail Station",53.2752149638,-2.7712062956
-"HSC","Hoscar Rail Station",53.5977824276,-2.8044204789
-"HSD","Hamstead (Birmingham) Rail Station",52.5310822389,-1.9289728746
-"HSG","Hathersage Rail Station",53.3257885551,-1.6517174825
-"HSK","Hassocks Rail Station",50.9246090606,-0.1459258012
-"HSL","Haslemere Rail Station",51.0886414366,-0.7191423803
-"HST","High Street (Glasgow) Rail Station",55.8595578077,-4.2401039264
-"HSW","Heswall Rail Station",53.329731232,-3.073702346
-"HSY","Horsley Rail Station",51.2793430837,-0.4353859424
-"HTC","Heaton Chapel Rail Station",53.4255745892,-2.1790400211
-"HTE","Hatch End Rail Station",51.609418318,-0.3685792009
-"HTF","Hartford Rail Station",53.2417720752,-2.5536278419
-"HTH","Handforth Rail Station",53.3465081231,-2.2136326157
-"HTN","Hatton (Warks) Rail Station",52.2952909349,-1.6729642026
-"HTO","Hightown Rail Station",53.5251206717,-3.0570655927
+"COH","Crowborough",51.0463770048,0.1880407337
+"COI","Crosshill",55.8332791971,-4.2567970862
+"COL","Colchester",51.9007230246,0.8926284517
+"COM","Commondale",54.4812856119,-0.9751641461
+"CON","Connel Ferry",56.45233723,-5.3854201352
+"COO","Cookham",51.5574642725,-0.7220603119
+"COP","Copplestone",50.8144563375,-3.751590555
+"COR","Corby",52.4888659511,-0.6883213327
+"COS","Cosford",52.6448470661,-2.3002712165
+"COT","Cottingley",53.7678308023,-1.5877119373
+"COV","Coventry",52.4008284145,-1.5134504816
+"COW","Cowdenbeath",56.112083991,-3.3431844925
+"COY","Coryton",51.5204358321,-3.2318279619
+"CPA","Corpach",56.8428086004,-5.121943037
+"CPH","Caerphilly",51.5715771276,-3.2184921838
+"CPK","Carpenders Park",51.6283534546,-0.3859168008
+"CPM","Chippenham",51.4624852566,-2.1153890334
+"CPN","Chapelton (Devon)",51.0165289386,-4.0247448242
+"CPT","Clapton",51.5616436677,-0.0569984893
+"CPU","Capenhurst",53.2601877687,-2.9422844784
+"CPW","Chepstow",51.6401793133,-2.6719110922
+"CPY","Clapham (N Yorks)",54.1053962118,-2.4103793434
+"CRA","Cradley Heath",52.4696668258,-2.0904823836
+"CRB","Corbridge",54.9662659971,-2.0184091796
+"CRD","Chester Road",52.5356593313,-1.832472162
+"CRE","Crewe",53.089639576,-2.4329694874
+"CRF","Carfin",55.8073342674,-3.9562432142
+"CRG","Cross Gates",53.8049283962,-1.4515849362
+"CRH","Crouch Hill",51.5713028362,-0.11712295
+"CRI","Cricklewood",51.5584538453,-0.212652067
+"CRK","Chirk",52.9330999763,-3.0656421264
+"CRL","Chorley",53.6525509696,-2.6268378803
+"CRM","Cramlington",55.0877729503,-1.5986098387
+"CRN","Crowthorne",51.3667259688,-0.8192566155
+"CRO","Croy",55.9556707554,-4.0359670002
+"CRR","Corrour",56.7601959475,-4.6905898827
+"CRS","Carstairs",55.6910435615,-3.6684653164
+"CRT","Chartham",51.2572676132,1.0180692196
+"CRV","Craven Arms",52.4425511842,-2.8374211059
+"CRW","Crawley",51.1122079127,-0.1866457301
+"CRY","Crayford",51.4482784318,0.1789624549
+"CSA","Cosham",50.8419131216,-1.0673147963
+"CSB","Carshalton Beeches",51.3574078701,-0.1697719787
+"CSD","Cobham & Stoke d'Abernon",51.3180974283,-0.389323466
+"CSG","Cressington",53.3587637655,-2.9120028641
+"CSH","Carshalton",51.368451556,-0.166343454
+"CSK","Calstock",50.497783854,-4.2090174117
+"CSL","Codsall",52.6273016994,-2.2017584348
+"CSM","Castleton Moor",54.4671552873,-0.9466648318
+"CSN","Chessington North",51.3640376909,-0.3006757682
+"CSO","Croston",53.6675742668,-2.7777477556
+"CSR","Chassen Road",53.4461736991,-2.3682321593
+"CSS","Chessington South",51.3565467942,-0.3081340168
+"CST","London Cannon Street",51.5113821708,-0.0902671514
+"CSW","Chestfield & Swalecliffe",51.3602434955,1.0669610537
+"CSY","Coseley",52.545096174,-2.0857720388
+"CTE","Chatelherault",55.7652139884,-4.004665396
+"CTF","Catford",51.4444046468,-0.0262908765
+"CTH","Chadwell Heath",51.5680380571,0.1289849608
+"CTK","City Thameslink",51.5139360643,-0.1035639706
+"CTL","Cattal",53.997454781,-1.3205413788
+"CTM","Chatham",51.3803760302,0.5211794412
+"CTN","Charlton",51.4868121438,0.0312832554
+"CTO","Carlton",52.9651058655,-1.0786513766
+"CTR","Chester",53.1967089901,-2.8795954639
+"CTT","Church Stretton",52.5374347501,-2.8036939757
+"CTW","Church & Oswaldtwistle",53.7505339398,-2.3912114012
+"CUA","Culrain",57.9194946106,-4.4042721672
+"CUB","Cumbernauld",55.942019023,-3.9803257587
+"CUD","Cuddington",53.2399328038,-2.5993047996
+"CUF","Cuffley",51.708723054,-0.1097585788
+"CUH","Curriehill",55.9005593257,-3.3187497327
+"CUM","Culham",51.653795137,-1.2364953245
+"CUP","Cupar",56.3169774524,-3.0087585168
+"CUW","Clunderwen",51.8405496199,-4.731870145
+"CUX","Cuxton",51.3739247395,0.4617373125
+"CWB","Colwyn Bay",53.2963736339,-3.7254203797
+"CWC","Chappel & Wakes Colne",51.9259156453,0.7585305397
+"CWD","Creswell (Derbys)",53.2641317653,-1.2163932459
+"CWE","Crowle",53.589752526,-0.8173624763
+"CWH","Crews Hill",51.6844869604,-0.1068615213
+"CWL","Colwall",52.0798767311,-2.3569466545
+"CWM","Cwmbran",51.6565871606,-3.01621063
+"CWN","Cowden",51.1556324991,0.1100591285
+"CWS","Caersws",52.5161370252,-3.4325032748
+"CWU","Crowhurst",50.8885735262,0.5013656464
+"CWX","Canary Wharf",51.5061,-0.01578
+"CYB","Cefn-y-Bedd",53.0988144368,-3.0310532391
+"CYK","Clydebank",55.9006838001,-4.4043987103
+"CYN","Cynghordy",52.0515055365,-3.7482227844
+"CYP","Crystal Palace",51.4181067019,-0.0725839873
+"CYS","Cathays",51.4888980023,-3.178691896
+"CYT","Cherry Tree",53.7328842568,-2.5183765976
+"DAG","Dalgety Bay",56.0420879876,-3.367719234
+"DAK","Dalmarnock",55.8420793253,-4.2176948019
+"DAL","Dalmally",56.40117566,-4.9835317937
+"DAM","Dalmeny",55.9863117819,-3.381617481
+"DAN","Darnall",53.3846003446,-1.4125666166
+"DAR","Darlington",54.5204574957,-1.5473329223
+"DAT","Datchet",51.4830766846,-0.5794049222
+"DBC","Dumbarton Central",55.9466469118,-4.5669032007
+"DBD","Denby Dale",53.5726454936,-1.6632128419
+"DBE","Dumbarton East",55.9422389396,-4.5541195047
+"DBG","Mottisfont & Dunbridge",51.0339180849,-1.5470733978
+"DBL","Dunblane",56.1858813154,-3.9654784274
+"DBR","Derby Road (Ipswich)",52.0505675726,1.182673697
+"DBY","Derby",52.9165645679,-1.4633507475
+"DCG","Duncraig",57.3369773237,-5.6371200748
+"DCH","Dorchester South",50.7092808049,-2.43724064
+"DCT","Danescourt",51.5005053214,-3.2339264723
+"DCW","Dorchester West",50.7109424746,-2.4425389873
+"DDG","Dorridge",52.3720819757,-1.7528919248
+"DDK","Dagenham Dock",51.5260887461,0.1461308631
+"DDP","Dudley Port",52.5246649483,-2.0494739583
+"DEA","Deal",51.2230510827,1.3988758198
+"DEE","Dundee",56.4564750929,-2.9712080372
+"DEN","Dean",51.0424533409,-1.6348555051
+"DEP","Deptford",51.4788466717,-0.0262441885
+"DEW","Dewsbury",53.6921445094,-1.6331100451
+"DFD","Dartford",51.4473695898,0.2192754223
+"DFE","Dunfermline Town",56.0681835684,-3.4525246789
+"DFI","Duffield",52.9884176714,-1.4859685231
+"DFL","Dunfermline Queen Margaret",56.0805680436,-3.4214651879
+"DFR","Drumfrochar",55.9412399388,-4.7747462431
+"DGC","Denham Golf Club",51.5805981628,-0.5177663959
+"DGL","Dingle Road",51.4400518803,-3.1805995641
+"DGT","Deansgate",53.4741986483,-2.251049342
+"DGY","Deganwy",53.2947621319,-3.8333901264
+"DHM","Durham",54.7793980708,-1.5817625077
+"DHN","Deighton",53.6684962139,-1.7518983268
+"DID","Didcot Parkway",51.6109553482,-1.2428749913
+"DIG","Digby & Sowton",50.7139764327,-3.4735740965
+"DIN","Dingwall",57.5942168221,-4.4221973842
+"DIS","Diss",52.3736757898,1.1237252182
+"DKD","Dunkeld & Birnam",56.5570452529,-3.5783964404
+"DKG","Dorking",51.2409257562,-0.3242277761
+"DKT","Dorking West",51.2362217787,-0.3399557367
+"DLG","Dolgarrog",53.1863628038,-3.8226405143
+"DLH","Doleham",50.9185826306,0.6100042375
+"DLJ","Dalston Junction",51.5461154595,-0.0751109378
+"DLK","Dalston Kingsland",51.5481480385,-0.0756742388
+"DLM","Delamere",53.2287882936,-2.6665587536
+"DLR","Dalreoch",55.9474070119,-4.5778455124
+"DLS","Dalston (Cumbria)",54.8461812399,-2.9888562179
+"DLT","Dalton",54.1542436887,-3.1790013184
+"DLW","Dalwhinnie",56.9351543012,-4.2461914619
+"DLY","Dalry",55.7062150527,-4.7110594286
+"DMC","Drumchapel",55.9048050133,-4.3628637433
+"DMF","Dumfries",55.072559544,-3.604300351
+"DMG","Dinas (Rhondda)",51.6178352115,-3.437552058
+"DMH","Dilton Marsh",51.2489808553,-2.2079111292
+"DMK","Denmark Hill",51.4682016412,-0.0893351949
+"DMP","Dumpton Park",51.3457052089,1.4258444805
+"DMR","Dalmuir",55.911921651,-4.4266657755
+"DMS","Dormans",51.1557866779,-0.0042811467
+"DMY","Drumry",55.9045847687,-4.3854571409
+"DND","Dinsdale",54.5147386026,-1.4670752041
+"DNG","Dunton Green",51.2964873167,0.1709649125
+"DNL","Dunlop",55.7118747945,-4.5323721773
+"DNM","Denham",51.5788378122,-0.4974160111
+"DNO","Dunrobin Castle",57.9855164027,-3.9489241071
+"DNS","Dinas Powys",51.4316627486,-3.2183612689
+"DNT","Dent",54.2824184109,-2.3636026167
+"DNY","Danby",54.4661651822,-0.9109721492
+"DOC","Dockyard (Plymouth)",50.3821534706,-4.1759268375
+"DOD","Dodworth",53.5443407648,-1.5316921206
+"DOL","Dolau",52.2953601526,-3.2636234021
+"DON","Doncaster",53.522167905,-1.1398476982
+"DOR","Dore & Totley",53.3276504838,-1.5152967348
+"DOT","Dunston",54.9500607179,-1.6420561513
+"DOW","Downham Market",52.6041264601,0.3656997898
+"DPD","Dorking Deepdene",51.2388000949,-0.3246201844
+"DPT","Devonport",50.3785177656,-4.1707389477
+"DRF","Driffield",54.001546492,-0.4346760339
+"DRG","Drayton Green",51.5166156836,-0.3301719985
+"DRI","Drigg",54.3769668358,-3.443413857
+"DRM","Drem",56.0051170654,-2.7860534175
+"DRN","Duirinish",57.319951049,-5.6913048804
+"DRO","Dronfield",53.3013854109,-1.4687777286
+"DRT","Darton",53.5883833705,-1.5316604623
+"DRU","Drumgelloch",55.8673480624,-3.9488717169
+"DSL","Disley",53.3581971647,-2.0424809658
+"DSM","Darsham",52.2730184572,1.5235008921
+"DST","Duke Street",55.8584302018,-4.213033844
+"DSY","Daisy Hill",53.5394676714,-2.5158611336
+"DTG","Dinting",53.4493453873,-1.9702958822
+"DTN","Denton",53.456880489,-2.1316584707
+"DTW","Droitwich Spa",52.2682155287,-2.1583562459
+"DUD","Duddeston",52.4883756068,-1.8713859825
+"DUL","Dullingham",52.2016639915,0.3666921781
+"DUM","Dumbreck",55.8446425043,-4.3012244995
+"DUN","Dunbar",55.9982866312,-2.513351643
+"DUR","Durrington-on-Sea",50.817518034,-0.4114439
+"DVC","Dovercourt",51.9387503243,1.2806410709
+"DVH","Dove Holes",53.3000420778,-1.8897505662
+"DVN","Davenport",53.3909155002,-2.1529566556
+"DVP","Dover Priory",51.1257054631,1.3053252348
+"DVY","Dovey Junction",52.5643723647,-3.9239110192
+"DWD","Dolwyddelan",53.0520264903,-3.885137383
+"DWL","Dawlish",50.5808060844,-3.4646385825
+"DWN","Darwen",53.6980500658,-2.4649373867
+"DWW","Dawlish Warren",50.5986963334,-3.4435746881
+"DYC","Dyce",57.2056334738,-2.1923277179
+"DYF","Dyffryn Ardudwy",52.7888658497,-4.1046506676
+"DYP","Drayton Park",51.5527705023,-0.1054827348
+"DZY","Danzey",52.3248260043,-1.8208686258
+"EAD","Earlsfield",51.4423352541,-0.1876904006
+"EAG","Eaglescliffe",54.529441791,-1.3494493173
+"EAL","Ealing Broadway",51.5148407171,-0.3017293164
+"EAR","Earley",51.4410992799,-0.9179692021
+"EBA","Euxton Balshaw Lane",53.6604940469,-2.6720207861
+"EBB","Ebbw Vale Town",51.7766906034,-3.2025853559
+"EBD","Ebbsfleet International",51.4429711416,0.3209500322
+"EBK","Eastbrook",51.4376339068,-3.206146908
+"EBL","East Boldon",54.9464212649,-1.4203275453
+"EBN","Eastbourne",50.7693712403,0.2812755597
+"EBR","Edenbridge",51.2084314886,0.0606723709
+"EBT","Edenbridge Town",51.2000785009,0.0671991686
+"EBV","Ebbw Vale Parkway",51.7571458261,-3.1961117844
+"ECC","Eccles",53.4853736806,-2.3345132824
+"ECL","Eccleston Park",53.4308004759,-2.7800407784
+"ECP","Energlyn & Churchill Park",51.5832131774,-3.2288061419
+"ECR","East Croydon",51.3754518482,-0.0927543224
+"ECS","Eccles Road",52.4709032665,0.9699418209
+"EDB","Edinburgh",55.9523865322,-3.1882291087
+"EDG","Edge Hill",53.402631221,-2.9464830162
+"EDL","Edale",53.3649856666,-1.8166247959
+"EDN","Eden Park",51.3900885752,-0.0263287699
+"EDP","Edinburgh Park",55.9275440803,-3.3076630256
+"EDR","Edmonton Green",51.6249290203,-0.0610875153
+"EDW","East Dulwich",51.4614932275,-0.080545987
+"EDY","East Didsbury",53.4093226957,-2.221995354
+"EFF","Effingham Junction",51.2914916148,-0.4199426403
+"EFL","East Farleigh",51.2552346504,0.484758691
+"EGF","East Garforth",53.7919924434,-1.3705405592
+"EGG","Eggesford",50.887727229,-3.8747670951
+"EGH","Egham",51.4296448509,-0.5464936108
+"EGN","Eastrington",53.7551798175,-0.7876353437
+"EGR","East Grinstead",51.1262681111,-0.0178726978
+"EGT","Egton",54.4374940456,-0.7614806216
+"EGY","Edinburgh Gateway",55.940932789,-3.3202500314
+"EKB","Eskbank",55.8817963943,-3.0830769228
+"EKL","East Kilbride",55.7659978238,-4.1802138231
+"ELD","Earlswood (Surrey)",51.2273248317,-0.1707971701
+"ELE","Elmers End",51.398489582,-0.0495441803
+"ELG","Elgin",57.6428926912,-3.3112425277
+"ELO","Elton & Orston",52.9521557025,-0.8555074435
+"ELP","Ellesmere Port",53.2822052615,-2.8964224623
+"ELR","Elsecar",53.4986759683,-1.4274252148
+"ELS","Elstree & Borehamwood",51.6530715786,-0.2800577261
+"ELT","East Linton",55.9856,-2.6579
+"ELW","Eltham",51.4556421114,0.0524986776
+"ELY","Ely",52.391244221,0.2668510603
+"EMD","East Midlands Parkway",52.8625182507,-1.2632265891
+"EML","East Malling",51.2858069522,0.439309906
+"EMP","Emerson Park",51.5686424022,0.2201396373
+"EMS","Emsworth",50.8516027835,-0.9384144303
+"ENC","Enfield Chase",51.6532550128,-0.0906697288
+"ENF","Enfield Town",51.6520265184,-0.0793010146
+"ENL","Enfield Lock",51.6709227126,-0.0285062955
+"ENT","Entwistle",53.6559908688,-2.4145427951
+"EPD","Epsom Downs",51.3236845001,-0.23892976
+"EPH","Elephant & Castle",51.4940282398,-0.098700214
+"EPS","Epsom",51.334389925,-0.2687531384
+"ERA","Eastham Rake",53.307552763,-2.9811322454
+"ERD","Erdington",52.5282972975,-1.8395023401
+"ERH","Erith",51.481669408,0.1750812719
+"ERI","Eridge",51.0889610517,0.2014592494
+"ERL","Earlestown",53.451151143,-2.6376624607
+"ESD","Elmstead Woods",51.4171157446,0.0442997314
+"ESH","Esher",51.3798880712,-0.3533154601
+"ESL","Eastleigh",50.9692403635,-1.350073969
+"ESM","Elsenham",51.920551892,0.228097059
+"EST","Easterhouse",55.8597505142,-4.1071641367
+"ESW","Elmswell",52.2380555449,0.9126215916
+"ETC","Etchingham",51.0105413018,0.4423847838
+"ETL","East Tilbury",51.4848306628,0.4129581196
+"EUS","London Euston",51.5281364316,-0.1338981275
+"EVE","Evesham",52.0984067663,-1.9473049925
+"EWD","Earlswood (West Midlands)",52.3665938407,-1.861161636
+"EWE","Ewell East",51.3452967584,-0.2415048775
+"EWR","East Worthing",50.8216357611,-0.3548680158
+"EWW","Ewell West",51.350041877,-0.2569621791
+"EXC","Exeter Central",50.7264717379,-3.5332911791
+"EXD","Exeter St Davids",50.7292625509,-3.5433010662
+"EXG","Exhibition Centre (Glasgow)",55.8615443927,-4.2835742363
+"EXM","Exmouth",50.6216212923,-3.4149848889
+"EXN","Exton",50.6682904818,-3.4441097276
+"EXR","Essex Road",51.5407057256,-0.0962497405
+"EXT","Exeter St Thomas",50.717135131,-3.5388511334
+"EYN","Eynsford",51.3627174333,0.2044201754
+"FAL","Falmouth Docks",50.1506931982,-5.0560746226
+"FAV","Faversham",51.3117150831,0.8910755277
+"FAZ","Fazakerley",53.4690990636,-2.936722397
+"FBY","Formby",53.5534917106,-3.0709054604
+"FCN","Falconwood",51.4591529464,0.079330998
+"FEA","Featherstone",53.6790826979,-1.358447032
+"FEL","Feltham",51.4478965298,-0.4098171801
+"FEN","Fenny Stratford",52.0000768774,-0.7159762313
+"FER","Fernhill",51.6864981097,-3.3958946145
+"FFA","Ffairfach",51.8724808498,-3.9928787809
+"FFD","Freshford",51.3420243729,-2.3010063939
+"FGH","Fishguard Harbour",52.011557061,-4.985670408
+"FGT","Faygate",51.0958843958,-0.2629910043
+"FGW","Fishguard & Goodwick",52.0041284781,-4.9948666231
+"FIL","Filey",54.2098758908,-0.2938654062
+"FIN","Finstock",51.8527876529,-1.4693269485
+"FIT","Filton Abbey Wood",51.5049359236,-2.5624320807
+"FKC","Folkestone Central",51.0828894709,1.1695144099
+"FKG","Falkirk Grahamston",56.0026075153,-3.7850391932
+"FKK","Falkirk High",55.9918091725,-3.7922363145
+"FKW","Folkestone West",51.0845880696,1.1539352777
+"FLD","Fauldhouse",55.8224687949,-3.7193103999
+"FLE","Fleet",51.2906324021,-0.8307895054
+"FLF","Flowery Field",53.4618690949,-2.0810528443
+"FLI","Flixton",53.4438220233,-2.3842455243
+"FLM","Flimby",54.6896927165,-3.5207405823
+"FLN","Flint",53.2495386637,-3.1329931372
+"FLT","Flitwick",52.0036505318,-0.4952335864
+"FLW","Fulwell",51.4339333056,-0.3494462747
+"FLX","Felixstowe",51.9670846947,1.3504650975
+"FML","Frimley",51.3118599318,-0.7469740068
+"FMR","Falmer",50.8621216711,-0.0873578378
+"FMT","Falmouth Town",50.1483262428,-5.0649815419
+"FNB","Farnborough (Main)",51.2966031825,-0.7557080158
+"FNC","Farncombe",51.1971482209,-0.6045286271
+"FNH","Farnham",51.2119005959,-0.7924099968
+"FNN","Farnborough North",51.3020427564,-0.7430095202
+"FNR","Farningham Road",51.40166365,0.235479766
+"FNT","Feniton",50.7866658255,-3.2854308727
+"FNV","Furness Vale",53.3487660512,-1.9888438055
+"FNW","Farnworth",53.5500180154,-2.3878478205
+"FNY","Finchley Road & Frognal",51.5502664369,-0.1831154061
+"FOC","Falls of Cruachan",56.3938689413,-5.1124566704
+"FOD","Ford",50.8293824048,-0.5783872727
+"FOG","Forest Gate",51.549431694,0.0243798935
+"FOH","Forest Hill",51.4392780589,-0.0531313997
+"FOK","Four Oaks",52.5797939503,-1.8280248803
+"FOR","Forres",57.6111680406,-3.6248718523
+"FOX","Foxfield",54.2586748544,-3.216062854
+"FPK","Finsbury Park",51.5643025324,-0.1062590007
+"FRB","Fairbourne",52.6960557759,-4.0494218463
+"FRD","Frodsham",53.2958284679,-2.7235668244
+"FRE","Freshfield",53.5660676569,-3.0718271848
+"FRF","Fairfield",53.4713083714,-2.1457740263
+"FRI","Frinton-on-Sea",51.8376925676,1.2432006998
+"FRL","Fairlie",55.7519366963,-4.8532464966
+"FRM","Fareham",50.8530232101,-1.1920245124
+"FRN","Fearn",57.778126445,-3.9939370006
+"FRO","Frome",51.2272634789,-2.3099932958
+"FRR","Frosterley",54.7270012002,-1.9644205566
+"FRS","Forsinard",58.3568834527,-3.8968870161
+"FRT","Frant",51.1040247127,0.2945703279
+"FRW","Fairwater",51.4939058847,-3.2338488071
+"FRY","Ferriby",53.7171721074,-0.5078355516
+"FSB","Fishbourne",50.8390401424,-0.8150655546
+"FSG","Fishersgate",50.834226328,-0.2193956669
+"FSK","Fiskerton",53.0602929309,-0.9121833385
+"FST","London Fenchurch Street",51.5116455824,-0.0788707296
+"FTM","Fort Matilda",55.9590229231,-4.7952474713
+"FTN","Fratton",50.7963261465,-1.0739689378
+"FTW","Fort William",56.820425796,-5.1061294153
+"FWY","Five Ways",52.4711078714,-1.9129492479
+"FXN","Foxton",52.1192233456,0.0563363619
+"FYS","Ferryside",51.7683736213,-4.3694828095
+"FZH","Frizinghall",53.8203830612,-1.7690049748
+"FZP","Furze Platt",51.533021301,-0.7284541823
+"FZW","Fitzwilliam",53.6325161611,-1.3742749709
+"GAL","Galashiels",55.618348945,-2.8069043382
+"GAR","Garrowhill",55.8552326445,-4.1294477285
+"GBD","Gilberdyke",53.7479824021,-0.7322489664
+"GBG","Gorebridge",55.8402677085,-3.0465190236
+"GBK","Greenbank",53.2514787515,-2.5342692507
+"GBL","Gainsborough Lea Road",53.3861086871,-0.7685809379
+"GBS","Goring-by-Sea",50.8177112854,-0.4330585625
+"GCH","Garelochhead",56.0798548957,-4.8256979183
+"GCL","Glasgow Central Low Level",55.858673532,-4.2584774599
+"GCR","Gloucester",51.8655641361,-2.2384843439
+"GCT","Great Coates",53.5757759251,-0.1302350444
+"GCW","Glan Conwy",53.2674361965,-3.797731864
+"GDH","Gordon Hill",51.6633360633,-0.0945839997
+"GDL","Godley",53.4517179149,-2.0547723093
+"GDN","Godstone",51.2181531133,-0.0500583421
+"GDP","Gidea Park",51.5819043047,0.2059905265
+"GEA","Gretna Green",55.0010507027,-3.0652008756
+"GER","Gerrards Cross",51.5890237128,-0.5552555668
+"GFD","Greenford",51.5423307069,-0.3458148281
+"GFF","Gilfach Fargoed",51.6842505424,-3.2265776505
+"GFN","Giffnock",55.8039838247,-4.2930005917
+"GGJ","Georgemas Junction",58.5136083248,-3.4521277157
+"GGV","Gargrave",53.9784289792,-2.1051749427
+"GIG","Giggleswick",54.0618113766,-2.3028507825
+"GIL","Gillingham (Dorset)",51.0340262862,-2.2726193805
+"GIP","Gipsy Hill",51.424451003,-0.0838100922
+"GIR","Girvan",55.2463156898,-4.8483590289
+"GKC","Greenock Central",55.9453319247,-4.7526142906
+"GKW","Greenock West",55.9473282882,-4.767813412
+"GLC","Glasgow Central",55.8597496156,-4.2576290605
+"GLD","Guildford",51.2369644453,-0.5804043303
+"GLE","Gleneagles",56.2748401663,-3.7311626664
+"GLF","Glenfinnan",56.8723822491,-5.449604955
+"GLG","Glengarnock",55.7388819511,-4.6744823788
+"GLH","Glasshoughton",53.7090594596,-1.3420084086
+"GLM","Gillingham (Kent)",51.3865631854,0.5498787442
+"GLO","Glossop",53.4444844182,-1.9490712229
+"GLQ","Glasgow Queen Street",55.8621817762,-4.2514417118
+"GLS","Glaisdale",54.4393938445,-0.7938035599
+"GLT","Glenrothes with Thornton",56.1623481523,-3.1430172976
+"GLY","Glynde",50.8591649295,0.0701049622
+"GLZ","Glazebrook",53.4283742205,-2.459656827
+"GMB","Grimsby Town",53.5634511917,-0.0869883746
+"GMD","Grimsby Docks",53.5743443249,-0.0756224261
+"GMG","Garth (Bridgend)",51.5964572422,-3.6414648286
+"GMN","Great Missenden",51.7035218129,-0.7091187725
+"GMT","Grosmont",54.43612578,-0.7249812388
+"GMV","Great Malvern",52.1092074558,-2.3182662455
+"GMY","Goodmayes",51.5655781413,0.1108335454
+"GNB","Gainsborough Central",53.3996038827,-0.7696962039
+"GNF","Greenfield",53.5388735659,-2.013841081
+"GNH","Greenhithe for Bluewater",51.4503693938,0.2803176704
+"GNL","Green Lane",53.3832695481,-3.0164148473
+"GNR","Green Road",54.2445321604,-3.2455716728
+"GNT","Gunton",52.8663732165,1.3491365444
+"GNW","Greenwich",51.4781335778,-0.0133139144
+"GOB","Gobowen",52.8935276407,-3.0371715591
+"GOD","Godalming",51.1865810902,-0.6188424046
+"GOE","Goldthorpe",53.5342068606,-1.3128096411
+"GOF","Golf Street",56.4977824375,-2.7195495703
+"GOL","Golspie",57.9714474115,-3.9872179776
+"GOM","Gomshall",51.2193937984,-0.4418288518
+"GOO","Goole",53.7049327129,-0.8742176314
+"GOR","Goring & Streatley",51.5214927112,-1.133029148
+"GOS","Grange-over-Sands",54.1957302552,-2.9027471889
+"GOX","Goxhill",53.6767222975,-0.3371266253
+"GPK","Grange Park",51.6426082109,-0.0973320762
+"GPO","Gospel Oak",51.5553362208,-0.1507445033
+"GQL","Glasgow Queen Street Low Level",55.8623403235,-4.2506358523
+"GRA","Grantham",52.9064924179,-0.6424450707
+"GRB","Great Bentley",51.8517695139,1.0651844079
+"GRC","Great Chesterford",52.0598200469,0.1935488673
+"GRF","Garforth",53.7965926372,-1.3823135001
+"GRH","Gartcosh",55.8856546592,-4.0794827931
+"GRK","Gourock",55.962310977,-4.8166374785
+"GRL","Greenfaulds",55.9352259193,-3.9930912233
+"GRN","Grindleford",53.3055770449,-1.6262956215
+"GRP","Grove Park",51.4308613738,0.0217517094
+"GRS","Garscadden",55.8876875396,-4.3649893754
+"GRT","Grateley",51.1700524514,-1.6207622447
+"GRV","Gravesend",51.4413470696,0.3666726966
+"GRY","Grays",51.4762461335,0.3218603146
+"GSC","Gilshochill",55.8973310545,-4.2826700794
+"GSD","Garsdale",54.3214395016,-2.3263576927
+"GSL","Gunnislake",50.5160691161,-4.2194356583
+"GSN","Garston (Herts)",51.6866190925,-0.3817173062
+"GST","Gathurst",53.5594164707,-2.694392781
+"GSW","Garswood",53.4885342343,-2.6721346367
+"GSY","Guiseley",53.8759473312,-1.7150832878
+"GTA","Great Ayton",54.4895819243,-1.1153591094
+"GTH","Garth (Powys)",52.1332443119,-3.5299153647
+"GTN","Grangetown (Cardiff)",51.4676101723,-3.1897328323
+"GTO","Gorton",53.4690883466,-2.1662083592
+"GTR","Goostrey",53.2225673734,-2.3264689479
+"GTW","Gatwick Airport",51.1564852744,-0.1610141074
+"GTY","Gatley",53.3929193229,-2.2312340568
+"GUI","Guide Bridge",53.4746422166,-2.1137102403
+"GUN","Gunnersbury",51.4916766051,-0.2752639989
+"GVE","Garve",57.6130218771,-4.6883911143
+"GVH","Gravelly Hill",52.5150091168,-1.8525928905
+"GWE","Gwersyllt",53.0725888841,-3.0178887352
+"GWN","Gowerton",51.6487287822,-4.0359546516
+"GYM","Great Yarmouth",52.6121840141,1.7209095669
+"GYP","Gypsy Lane",54.5329024718,-1.1794055894
+"HAB","Habrough",53.6060967313,-0.2694661266
+"HAC","Hackney Downs",51.548757028,-0.0607923652
+"HAD","Haddiscoe",52.5288110907,1.6230311744
+"HAF","Heathrow Terminal 4",51.458265962,-0.4454428215
+"HAG","Hagley",52.4225023907,-2.1464119812
+"HAI","Halling",51.352475791,0.4449605383
+"HAL","Hale",53.3787324238,-2.3473557978
+"HAM","Hamworthy",50.7251804312,-2.0193512479
+"HAN","Hanwell",51.5118339425,-0.3385615111
+"HAP","Hatfield Peverel",51.7798704228,0.5921498316
+"HAS","Halesworth",52.3468365087,1.505697432
+"HAT","Hatfield (Herts)",51.7638834885,-0.215564807
+"HAV","Havant",50.8544157698,-0.9815958592
+"HAY","Hayes & Harlington",51.5030948614,-0.4206635166
+"HAZ","Hazel Grove",53.3775580792,-2.1220186129
+"HBB","Hubberts Bridge",52.9753742831,-0.1105219846
+"HBD","Hebden Bridge",53.7376009105,-2.0090600757
+"HBL","Headbolt Lane",53.4911,-2.8856
+"HBN","Hollingbourne",51.2651766997,0.6278786652
+"HBP","Hornbeam Park",53.9798825753,-1.5268279163
+"HBY","Hartlebury",52.3345074098,-2.2211143855
+"HCB","Hackbridge",51.3778692696,-0.1538824466
+"HCH","Holmes Chapel",53.1989461479,-2.3511385797
+"HCN","Headcorn",51.1657113933,0.6275122421
+"HCT","Huncoat",53.7717900997,-2.3475613545
+"HDB","Haydon Bridge",54.9751799008,-2.247596044
+"HDE","Hedge End",50.9323093202,-1.2944922291
+"HDF","Hadfield",53.4607595075,-1.9653179115
+"HDG","Heald Green",53.3694305097,-2.2366663043
+"HDH","Hampstead Heath",51.555210868,-0.1656799709
+"HDL","Headstone Lane",51.6026499985,-0.3571975148
+"HDM","Haddenham & Thame Parkway",51.7708590202,-0.9421154353
+"HDN","Harlesden",51.536289123,-0.2576441501
+"HDW","Hadley Wood",51.6684984541,-0.1761475828
+"HDY","Headingley",53.8179883371,-1.5941914379
+"HEC","Heckington",52.9773390292,-0.2939371983
+"HED","Halewood",53.3644936533,-2.8301342149
+"HEI","Heighington",54.5969688714,-1.5817749363
+"HEL","Hensall",53.6985625439,-1.1145223177
+"HEN","Hendon",51.5800693984,-0.2386485815
+"HER","Hersham",51.3768090642,-0.3899376365
+"HES","Hessle",53.7174547293,-0.4418278411
+"HEV","Hever",51.18140673,0.0950955245
+"HEW","Heworth",54.951574003,-1.5557793317
+"HEX","Hexham",54.9734640115,-2.0948036947
+"HFD","Hereford",52.0611692914,-2.7082118767
+"HFE","Hertford East",51.7990391609,-0.0729130019
+"HFN","Hertford North",51.7988609689,-0.0917600735
+"HFS","Hatfield & Stainforth",53.5887339868,-1.0233819902
+"HFX","Halifax",53.7209739882,-1.853576757
+"HGD","Hungerford",51.4149070262,-1.5122717583
+"HGF","Hag Fold",53.5338672616,-2.494821366
+"HGG","Haggerston",51.5387053397,-0.0756398309
+"HGM","Higham",51.4265572516,0.4663063259
+"HGN","Hough Green",53.3724056855,-2.7750665578
+"HGR","Hither Green",51.4520235715,-0.0009184787
+"HGS","Hastings",50.8578901133,0.5767707918
+"HGT","Harrogate",53.9931903958,-1.5376134519
+"HGY","Harringay",51.577359069,-0.1051105218
+"HHB","Heysham Port",54.0331542281,-2.9131111175
+"HHD","Holyhead",53.3076995179,-4.6310080997
+"HHE","Haywards Heath",51.0056759707,-0.105050763
+"HHL","Heath High Level",51.5164298424,-3.181549994
+"HHY","Highbury & Islington",51.5461777019,-0.103737426
+"HIA","Hampton-in-Arden",52.4290462911,-1.69992295
+"HIB","High Brooms",51.1494010314,0.2773589795
+"HID","Hall i' th' Wood",53.5974371057,-2.413107867
+"HIG","Highbridge & Burnham-on-Sea",51.2181503748,-2.9721630499
+"HII","Highbury & Islington",51.5460878363,-0.1037411643
+"HIL","Hillside",53.6221202826,-3.0247137204
+"HIN","Hindley",53.5422508577,-2.575501122
+"HIP","Highams Park",51.6083496344,-0.000196266
+"HIR","Horton-in-Ribblesdale",54.149396209,-2.3020360937
+"HIT","Hitchin",51.9532881959,-0.2634564466
+"HKC","Hackney Central",51.5471044422,-0.0560308162
+"HKH","Hawkhead",55.8421839094,-4.3988362292
+"HKM","Hykeham",53.1950249324,-0.6001954228
+"HKN","Hucknall",53.0383014288,-1.1958079305
+"HKW","Hackney Wick",51.5434103591,-0.0248923154
+"HLB","Hildenborough",51.2144822954,0.227617147
+"HLC","Helensburgh Central",56.0041995399,-4.7327385924
+"HLD","Hellifield",54.0108742019,-2.2278480504
+"HLE","Hillington East",55.8541758548,-4.3549953963
+"HLF","Hillfoot",55.9200849636,-4.3202587624
+"HLG","Hall Green",52.4369222096,-1.8456449276
+"HLI","Healing",53.5818205021,-0.1606345765
+"HLL","Heath Low Level",51.5156612205,-3.1819768215
+"HLM","Holmwood",51.1811903162,-0.3207835997
+"HLN","Harlington (Beds)",51.9620697513,-0.4956650065
+"HLR","Hall Road",53.4975007979,-3.049624671
+"HLS","Hilsea",50.828264455,-1.0587831528
+"HLU","Helensburgh Upper",56.0123545737,-4.7297849071
+"HLW","Hillington West",55.8560145655,-4.3715655801
+"HLY","Holytown",55.8128931888,-3.9739183285
+"HMC","Hampton Court",51.402553453,-0.3427264701
+"HMD","Hampden Park (Sussex)",50.7963992867,0.2793840646
+"HME","Hamble",50.8713629565,-1.3291521514
+"HML","Hemel Hempstead",51.7423380827,-0.4907522249
+"HMM","Hammerton",53.9963447909,-1.2841021471
+"HMN","Homerton",51.547011697,-0.0423325837
+"HMP","Hampton (London)",51.415932868,-0.3720976323
+"HMS","Helmsdale",58.1174231841,-3.6586930118
+"HMT","Ham Street",51.0683758331,0.8545396144
+"HMW","Hampton Wick",51.414522516,-0.3124680243
+"HMY","Hairmyres",55.761959437,-4.2199969848
+"HNA","Hinton Admiral",50.7526280082,-1.7141197084
+"HNB","Herne Bay",51.364595492,1.1177553962
+"HNC","Hamilton Central",55.7731886703,-4.0388743726
+"HND","Hanborough",51.8251625822,-1.3735084455
+"HNF","Hednesford",52.7101262196,-2.0017747098
+"HNG","Hengoed",51.6474099206,-3.2241373274
+"HNH","Herne Hill",51.4533037255,-0.102263463
+"HNK","Hinckley",52.5350144159,-1.3719130606
+"HNL","Henley-in-Arden",52.2915002317,-1.7839820888
+"HNT","Huntly",57.4444716353,-2.7757412945
+"HNW","Hamilton West",55.7788548735,-4.0547968763
+"HNX","Hunts Cross",53.3607253407,-2.8558609579
+"HOC","Hockley",51.6035599652,0.6590284828
+"HOH","Harrow-on-the-Hill",51.5791855381,-0.3372032129
+"HOK","Hook",51.279996325,-0.9616187573
+"HOL","Holton Heath",50.7113964673,-2.0778391092
+"HON","Honiton",50.7965702123,-3.1867284121
+"HOO","Hooton",53.2972130919,-2.9770090629
+"HOP","Hope (Derbyshire)",53.3461251048,-1.7298854225
+"HOR","Horley",51.1687701925,-0.1610261883
+"HOT","Henley-on-Thames",51.5341810915,-0.9001927563
+"HOU","Hounslow",51.4619441377,-0.3622557388
+"HOV","Hove",50.8352085815,-0.1706597369
+"HOW","Howden",53.7647299348,-0.8604679516
+"HOX","Hoxton",51.5315115893,-0.075655026
+"HOY","Honley",53.6082419978,-1.7809663313
+"HOZ","Howwood (Renfrewshire)",55.8105581084,-4.5630406539
+"HPA","Honor Oak Park",51.4499871094,-0.0454798264
+"HPD","Harpenden",51.8146501449,-0.3514563418
+"HPE","Hope (Flintshire)",53.117371815,-3.03687622
+"HPL","Hartlepool",54.6867644231,-1.2073308234
+"HPN","Hapton",53.7816268971,-2.3169116789
+"HPQ","Harwich International",51.9473012514,1.2551547397
+"HPT","Hopton Heath",52.3914278931,-2.9120578549
+"HRD","Harling Road",52.4537084708,0.9091672143
+"HRE","Horden", 54.763879, -1.307347
+"HRH","Horsham",51.0660592013,-0.3192431154
+"HRL","Harlech",52.8613425321,-4.1091973982
+"HRM","Harrietsham",51.2448308208,0.6724297963
+"HRN","Hornsey",51.5864618559,-0.1119495944
+"HRO","Harold Wood",51.592766307,0.2331539888
+"HRR","Harrington",54.6134911874,-3.5655149544
+"HRS","Horsforth",53.8477194776,-1.6302327899
+"HRW","Harrow & Wealdstone",51.5921690735,-0.3345489082
+"HRY","Harringay Green Lanes",51.5771828877,-0.0981182196
+"HSB","Helsby",53.2752149638,-2.7712062956
+"HSC","Hoscar",53.5977824276,-2.8044204789
+"HSD","Hamstead (Birmingham)",52.5310822389,-1.9289728746
+"HSG","Hathersage",53.3257885551,-1.6517174825
+"HSK","Hassocks",50.9246090606,-0.1459258012
+"HSL","Haslemere",51.0886414366,-0.7191423803
+"HST","High Street (Glasgow)",55.8595578077,-4.2401039264
+"HSW","Heswall",53.329731232,-3.073702346
+"HSY","Horsley",51.2793430837,-0.4353859424
+"HTC","Heaton Chapel",53.4255745892,-2.1790400211
+"HTE","Hatch End",51.609418318,-0.3685792009
+"HTF","Hartford",53.2417720752,-2.5536278419
+"HTH","Handforth",53.3465081231,-2.2136326157
+"HTN","Hatton (Warks)",52.2952909349,-1.6729642026
+"HTO","Hightown",53.5251206717,-3.0570655927
 "HTR","Heathrow Airport Central Bus Stn (Rail-Air)",51.4710943355,-0.4532864637
-"HTW","Hartwood Rail Station",55.8114760965,-3.8393119766
-"HTY","Hattersley Rail Station",53.4452970666,-2.0403099081
-"HUB","Hunmanby Rail Station",54.1739432859,-0.3145719426
-"HUD","Huddersfield Rail Station",53.6485157907,-1.7846917017
-"HUL","Hull Rail Station",53.7441695387,-0.3456862671
-"HUN","Huntingdon Rail Station",52.3286615315,-0.1920472657
-"HUP","Humphrey Park Rail Station",53.4522431612,-2.3275376643
-"HUR","Hurst Green Rail Station",51.2444268856,0.0039654468
-"HUT","Hutton Cranswick Rail Station",53.9558737241,-0.433871592
-"HUY","Huyton Rail Station",53.4096981525,-2.8429886413
-"HVF","Haverfordwest Rail Station",51.8026432765,-4.960235795
-"HVN","Havenhouse Rail Station",53.1144941819,0.2731698815
-"HWB","Hawarden Bridge Rail Station",53.2180881941,-3.0327167308
-"HWC","Harwich Town Rail Station",51.9441574404,1.2867119437
-"HWD","Hawarden Rail Station",53.1853727789,-3.0320807812
+"HTW","Hartwood",55.8114760965,-3.8393119766
+"HTY","Hattersley",53.4452970666,-2.0403099081
+"HUB","Hunmanby",54.1739432859,-0.3145719426
+"HUD","Huddersfield",53.6485157907,-1.7846917017
+"HUL","Hull",53.7441695387,-0.3456862671
+"HUN","Huntingdon",52.3286615315,-0.1920472657
+"HUP","Humphrey Park",53.4522431612,-2.3275376643
+"HUR","Hurst Green",51.2444268856,0.0039654468
+"HUT","Hutton Cranswick",53.9558737241,-0.433871592
+"HUY","Huyton",53.4096981525,-2.8429886413
+"HVF","Haverfordwest",51.8026432765,-4.960235795
+"HVN","Havenhouse",53.1144941819,0.2731698815
+"HWB","Hawarden Bridge",53.2180881941,-3.0327167308
+"HWC","Harwich Town",51.9441574404,1.2867119437
+"HWD","Hawarden",53.1853727789,-3.0320807812
 "HWF","Heathrow Terminal 4 (Rail-Air)",51.4593290581,-0.4469469959
-"HWH","Haltwhistle Rail Station",54.9678535356,-2.4635724781
-"HWI","Horwich Parkway Rail Station",53.5781205097,-2.5396661144
-"HWM","Harlow Mill Rail Station",51.7903700355,0.1323343315
-"HWN","Harlow Town Rail Station",51.7810744782,0.0951587231
-"HWV","Heathrow Terminal 5 Rail Station",51.4700517143,-0.490569702
-"HWW","How Wood (Herts) Rail Station",51.7177454662,-0.344647203
+"HWH","Haltwhistle",54.9678535356,-2.4635724781
+"HWI","Horwich Parkway",53.5781205097,-2.5396661144
+"HWM","Harlow Mill",51.7903700355,0.1323343315
+"HWN","Harlow Town",51.7810744782,0.0951587231
+"HWV","Heathrow Terminal 5",51.4700517143,-0.490569702
+"HWW","How Wood (Herts)",51.7177454662,-0.344647203
 "HWX","Heathrow Airport Terminal 5",51.4712499812,-0.4893495013
-"HWY","High Wycombe Rail Station",51.6295875603,-0.7453905204
-"HXM","Hoveton & Wroxham Rail Station",52.715595961,1.4080190978
-"HYB","Honeybourne Rail Station",52.1016109574,-1.8337328413
-"HYC","Hyde Central Rail Station",53.451897881,-2.0852494833
-"HYD","Heyford Rail Station",51.9191971629,-1.2992524985
-"HYH","Hythe (Essex) Rail Station",51.885649004,0.9275572674
-"HYK","Hoylake Rail Station",53.3902262538,-3.1788295823
-"HYL","Hayle Rail Station",50.1855516133,-5.4198876444
-"HYM","Haymarket Rail Station",55.9458020856,-3.2184499798
-"HYN","Hyndland Rail Station",55.8797471979,-4.314653649
-"HYR","Haydons Road Rail Station",51.4254457568,-0.188790104
-"HYS","Hayes (Kent) Rail Station",51.376332397,0.0105837729
-"HYT","Hyde North Rail Station",53.4648142912,-2.0854568359
-"HYW","Hinchley Wood Rail Station",51.3749950976,-0.3405015776
-"IBM","IBM (Greenock) Rail Station",55.9294397123,-4.8272199389
-"IFD","Ilford Rail Station",51.5591169252,0.0697060332
-"IFI","Ifield Rail Station",51.115616552,-0.214744158
-"IGD","Invergordon Rail Station",57.6890013885,-4.1748401883
-"ILK","Ilkley Rail Station",53.9247771648,-1.822030732
-"ILN","Ilkeston Rail Station",52.9796097784,-1.2949283917
-"IMW","Imperial Wharf Rail Station",51.4749481734,-0.1827985374
-"INC","Ince (Manchester) Rail Station",53.5389257232,-2.6115187679
-"INE","Ince & Elton Rail Station",53.2766213459,-2.8165221852
-"ING","Invergowrie Rail Station",56.4564629346,-3.0574006479
-"INH","Invershin Rail Station",57.9248506817,-4.3994794892
-"INK","Inverkeithing Rail Station",56.0346707647,-3.3961851331
-"INP","Inverkip Rail Station",55.906097486,-4.8725658517
-"INR","Inverurie Rail Station",57.2862510473,-2.3735646839
-"INS","Insch Rail Station",57.3374826347,-2.6171148112
-"INT","Ingatestone Rail Station",51.6670448119,0.3842732713
-"INV","Inverness Rail Station",57.4798523576,-4.2233591954
-"IPS","Ipswich Rail Station",52.050605185,1.1444561195
-"IRL","Irlam Rail Station",53.4343243953,-2.4332290912
-"IRV","Irvine Rail Station",55.610870787,-4.6751248885
-"ISL","Isleworth Rail Station",51.4747609931,-0.3368852384
-"ISP","Islip Rail Station",51.8257581652,-1.2381632634
-"IVR","Iver Rail Station",51.5085027345,-0.5067065231
-"IVY","Ivybridge Rail Station",50.3933952288,-3.9042285416
-"JCH","James Cook University Hospital Rail Station",54.552041983,-1.2085837079
-"JEQ","Jewellery Quarter Rail Station",52.489447723,-1.9132076451
-"JHN","Johnstone Rail Station",55.8347024844,-4.5036207425
-"JOH","Johnston (Pembrokeshire) Rail Station",51.7567579295,-4.9963630908
-"JOR","Jordanhill Rail Station",55.882699515,-4.3249029293
-"KBC","Kinbrace Rail Station",58.2582968272,-3.9412133227
-"KBF","Kirkby-in-Furness Rail Station",54.2327161445,-3.1873760397
-"KBK","Kents Bank Rail Station",54.172910528,-2.9252290041
-"KBN","Kilburn High Road Rail Station",51.5372777601,-0.1922126859
-"KBW","Knebworth Rail Station",51.8668603588,-0.1872649131
-"KBX","Kirby Cross Rail Station",51.841408258,1.2150236403
-"KCK","Knockholt Rail Station",51.3457884371,0.1308739721
-"KDB","Kidbrooke Rail Station",51.4621199896,0.0275232797
-"KDG","Kidsgrove Rail Station",53.0865804703,-2.2448159035
-"KDY","Kirkcaldy Rail Station",56.1120505901,-3.1670300049
-"KEH","Keith Rail Station",57.5508815659,-2.9540692665
-"KEI","Keighley Rail Station",53.8679755061,-1.9016526329
-"KEL","Kelvedon Rail Station",51.8407101631,0.7024132856
-"KEM","Kemble Rail Station",51.6769974883,-2.0228096226
-"KEN","Kendal Rail Station",54.3321036266,-2.7396488466
-"KET","Kettering Rail Station",52.3935680461,-0.7315471328
-"KEY","Keyham Rail Station",50.3898643425,-4.1796285768
-"KGE","Kingsknowe Rail Station",55.9188071296,-3.2649651648
-"KGH","Kinghorn Rail Station",56.0693308155,-3.1741555055
-"KGL","Kings Langley Rail Station",51.7063602029,-0.4384002341
-"KGM","Kingham Rail Station",51.9022564168,-1.6287732881
-"KGN","Kings Nympton Rail Station",50.936065096,-3.9054316221
-"KGP","Kings Park Rail Station",55.8195373532,-4.2465028963
-"KGS","Kings Sutton Rail Station",52.021359878,-1.2809139108
-"KGT","Kilgetty Rail Station",51.7321146696,-4.7151861813
-"KGX","London Kings Cross Rail Station",51.5308836375,-0.1229002946
-"KID","Kidderminster Rail Station",52.3844946608,-2.2384665613
-"KIL","Kildonan Rail Station",58.1707935283,-3.8691107621
-"KIN","Kingussie Rail Station",57.0777663698,-4.0521889967
-"KIR","Kirkby Rail Station",53.4862048537,-2.9028281809
-"KIT","Kintbury Rail Station",51.4025186724,-1.4459730106
-"KIV","Kiveton Bridge Rail Station",53.3409764694,-1.2671800273
-"KKB","Kirkby in Ashfield Rail Station",53.1001156743,-1.2530543087
-"KKD","Kirkdale Rail Station",53.4409136231,-2.9811163636
-"KKH","Kirkhill Rail Station",55.8139079243,-4.1670911014
-"KKM","Kirkham & Wesham Rail Station",53.7869285701,-2.8829376626
-"KKN","Kirknewton Rail Station",55.8886849182,-3.4325077075
-"KKS","Kirk Sandall Rail Station",53.5638967616,-1.074065509
-"KLD","Kildale Rail Station",54.4777686824,-1.0681580089
-"KLF","Kirkstall Forge Rail Station",53.8237339338,-1.6224823291
-"KLM","Kilmaurs Rail Station",55.6372048041,-4.530470324
-"KLN","Kings Lynn Rail Station",52.7539444878,0.4034623052
-"KLY","Kenley Rail Station",51.3247744025,-0.1008992757
-"KMH","Kempston Hardwick Rail Station",52.0922280746,-0.503891956
-"KMK","Kilmarnock Rail Station",55.6121152355,-4.4986646202
-"KML","Kemsley Rail Station",51.3624400702,0.7353874775
-"KMP","Kempton Park Rail Station",51.4209818235,-0.4097301104
-"KMS","Kemsing Rail Station",51.2971839907,0.2474553811
-"KNA","Knaresborough Rail Station",54.0090375731,-1.4704220018
-"KND","Kingswood Rail Station",51.2947217871,-0.2112222297
-"KNE","Kennett Rail Station",52.2772786496,0.490492211
-"KNF","Knutsford Rail Station",53.3018050357,-2.3717892715
-"KNG","Kingston Rail Station",51.412749207,-0.3011440528
-"KNI","Knighton Rail Station",52.3450836187,-3.0421947541
-"KNL","Kensal Green Rail Station",51.5305403206,-0.225063468
-"KNN","Kings Norton Rail Station",52.4143035181,-1.9323192635
-"KNO","Knottingley Rail Station",53.7065538515,-1.2591815208
-"KNR","Kensal Rise Rail Station",51.5345542153,-0.2199327512
-"KNS","Kennishead Rail Station",55.813309436,-4.3252321959
-"KNT","Kenton Rail Station",51.581801686,-0.3169583454
-"KNU","Knucklas Rail Station",52.3598728116,-3.0968778892
-"KNW","Kenilworth Rail Station",52.3427193518,-1.5727265434
-"KPA","Kensington (Olympia) Rail Station",51.4978982211,-0.2103405047
-"KPT","Kilpatrick Rail Station",55.9246935335,-4.4533967721
-"KRK","Kirkconnel Rail Station",55.3883045795,-3.9984909836
-"KSL","Kearsley Rail Station",53.5441534939,-2.3751177475
-"KSN","Kearsney Rail Station",51.1493801653,1.2720927524
-"KSW","Kirkby Stephen Rail Station",54.4548647986,-2.3686012903
-"KTH","Kent House Rail Station",51.4122125796,-0.0452213855
-"KTL","Kirton Lindsey Rail Station",53.4848601103,-0.5939161226
-"KTN","Kentish Town Rail Station",51.550495644,-0.1403392037
-"KTW","Kentish Town West Rail Station",51.546548457,-0.1466298744
-"KVD","Kelvindale Rail Station",55.8935487999,-4.3095577512
-"KVP","Kiveton Park Rail Station",53.3367337933,-1.2398447759
-"KWB","Kew Bridge Rail Station",51.489511729,-0.287085417
-"KWD","Kirkwood Rail Station",55.8541826133,-4.0483868931
-"KWG","Kew Gardens Rail Station",51.4770717225,-0.2850311799
-"KWL","Kidwelly Rail Station",51.7343478013,-4.3170097512
-"KWN","Kilwinning Rail Station",55.6559470119,-4.7099979638
-"KYL","Kyle of Lochalsh Rail Station",57.2797467149,-5.7138003131
-"KYN","Keynsham Rail Station",51.4179728415,-2.495628895
-"LAC","Lancing Rail Station",50.8270743359,-0.3230828778
-"LAD","Ladywell Rail Station",51.4562424895,-0.0190151041
-"LAG","Langwith - Whaley Thorns Rail Station",53.2318581892,-1.2093421054
-"LAI","Laindon Rail Station",51.5675245473,0.4243193409
-"LAK","Lakenheath Rail Station",52.4474170039,0.535221579
-"LAM","Lamphey Rail Station",51.6671952632,-4.8732909776
-"LAN","Lancaster Rail Station",54.0487386625,-2.8074539872
-"LAP","Lapford Rail Station",50.8569928871,-3.8106600905
-"LAR","Largs Rail Station",55.7927371132,-4.8671774606
-"LAS","Llansamlet Rail Station",51.661506083,-3.8847019198
-"LAU","Laurencekirk Rail Station",56.8363340087,-2.4659318685
-"LAW","Landywood Rail Station",52.656554762,-2.0207214262
-"LAY","Layton (Lancs) Rail Station",53.8352807966,-3.0299856202
-"LBG","London Bridge Rail Station",51.5050187718,-0.0860663187
-"LBK","Long Buckby Rail Station",52.2947305797,-1.0864517232
-"LBO","Loughborough (Leics) Rail Station",52.7789730706,-1.1959223029
-"LBR","Llanbedr Rail Station",52.8208652563,-4.1102042575
-"LBT","Larbert Rail Station",56.0226975731,-3.8305736309
-"LBZ","Leighton Buzzard Rail Station",51.9163138347,-0.6769823167
-"LCC","Lochluichart Rail Station",57.621737692,-4.8090441141
-"LCG","Lochgelly Rail Station",56.1353217097,-3.312938865
-"LCK","Lockwood Rail Station",53.634746673,-1.8007918923
-"LCL","Lochailort Rail Station",56.8809423369,-5.6633772414
-"LCN","Lincoln Central Rail Station",53.2261072888,-0.5399222885
-"LCS","Locheilside Rail Station",56.8553882734,-5.2900225827
-"LDN","Llandanwg Rail Station",52.8361759873,-4.1238635913
-"LDS","Leeds Rail Station",53.7956409037,-1.5480300934
-"LDY","Ladybank Rail Station",56.2737723207,-3.1222761516
-"LEA","Leagrave Rail Station",51.9051657736,-0.4584767531
-"LEB","Lea Bridge Rail Station",51.5665477908,-0.0366456064
-"LED","Ledbury Rail Station",52.0452583249,-2.4258582991
-"LEE","Lee Rail Station",51.4497532361,0.0135186891
-"LEG","Lea Green Rail Station",53.4268240445,-2.7249767465
-"LEH","Lea Hall Rail Station",52.480655776,-1.7860055303
-"LEI","Leicester Rail Station",52.6314416999,-1.1252675699
-"LEL","Lelant Rail Station",50.1841132154,-5.4365983681
-"LEM","Leyton Midland Road Rail Station",51.5697256477,-0.0080229844
-"LEN","Lenham Rail Station",51.2344839559,0.7077894244
-"LEO","Leominster Rail Station",52.2256915912,-2.730340766
-"LER","Leytonstone High Road Rail Station",51.5635545296,0.0084437379
-"LES","Leigh-on-Sea Rail Station",51.5412752344,0.6404394965
-"LET","Letchworth Rail Station",51.9799709665,-0.2292371062
-"LEU","Leuchars Rail Station",56.3750925172,-2.8937163252
-"LEW","Lewisham Rail Station",51.4656900464,-0.0139988836
-"LEY","Leyland Rail Station",53.6988690686,-2.6871416367
-"LFD","Lingfield Rail Station",51.1764479512,-0.0071377353
-"LGB","Langbank Rail Station",55.9245116809,-4.5852569156
-"LGD","Lingwood Rail Station",52.6221259547,1.4899676829
-"LGE","Long Eaton Rail Station",52.8850051381,-1.287515035
-"LGF","Longfield Rail Station",51.3961528278,0.3003927726
-"LGG","Langley Green Rail Station",52.4938847738,-2.0049580874
-"LGJ","Loughborough Junction Rail Station",51.4662966456,-0.1021564205
-"LGK","Longbeck Rail Station",54.5892295098,-1.0304881067
-"LGM","Langley Mill Rail Station",53.0180775906,-1.3312416884
-"LGN","Longton Rail Station",52.9899681856,-2.1370099565
-"LGO","Llangynllo Rail Station",52.3496362697,-3.1613704736
-"LGS","Langside Rail Station",55.8211269753,-4.2773259977
-"LGW","Langwathby Rail Station",54.6943634202,-2.6636891905
-"LHA","Loch Awe Rail Station",56.4020023455,-5.0419541347
-"LHD","Leatherhead Rail Station",51.2988144436,-0.3332088593
-"LHE","Loch Eil Outward Bound Rail Station",56.8552494299,-5.1915632271
-"LHM","Lealholm Rail Station",54.4606042623,-0.8257310498
-"LHO","Langho Rail Station",53.8048444025,-2.4486582114
-"LHR","Heathrow Terminals 1-3 Rail Station",51.4714046459,-0.4543126778
-"LHS","Limehouse Rail Station",51.5125361684,-0.0397760782
-"LHW","Lochwinnoch Rail Station",55.7871497964,-4.6160573245
-"LIC","Lichfield City Rail Station",52.6801615881,-1.8254127247
-"LID","Lidlington Rail Station",52.0415453254,-0.5589061726
-"LIF","Lichfield Trent Valley High Level Rail Station",52.6869091229,-1.8002367619
-"LIH","Leigh (Kent) Rail Station",51.1938967547,0.2105218236
-"LIN","Linlithgow Rail Station",55.9764464658,-3.5958472904
-"LIP","Liphook Rail Station",51.0713092222,-0.8002098038
-"LIS","Liss Rail Station",51.0435640733,-0.8928497986
-"LIT","Littlehampton Rail Station",50.8100978499,-0.5459719624
-"LIV","Liverpool Lime Street Rail Station",53.4073236407,-2.977726082
-"LKE","Lake (Isle of Wight) Rail Station",50.6464632785,-1.1663386012
-"LLA","Llanaber Rail Station",52.7415174068,-4.0771833809
-"LLC","Llandecwyn Rail Station",52.9206985859,-4.0570419611
-"LLD","Llandudno Rail Station",53.320931375,-3.8270045937
-"LLE","Llanelli Rail Station",51.6738710202,-4.1613259947
-"LLF","Llanfairfechan Rail Station",53.2573026611,-3.9832073298
-"LLG","Llangadog Rail Station",51.9402195807,-3.8931635456
-"LLH","Llangennech Rail Station",51.6911401855,-4.0789505342
-"LLI","Llandybie Rail Station",51.8210413519,-4.0036670781
-"LLJ","Llandudno Junction Rail Station",53.283958434,-3.8091060573
-"LLL","Llandeilo Rail Station",51.8853508121,-3.9869089385
-"LLM","Llangammarch Rail Station",52.1143061939,-3.5548258245
-"LLN","Llandaf Rail Station",51.5084380797,-3.2286220121
-"LLO","Llandrindod Rail Station",52.2423682996,-3.3791453356
-"LLR","Llanharan Rail Station",51.5375863272,-3.4407911115
-"LLS","Llanishen Rail Station",51.532745927,-3.1819878738
-"LLT","Llanbister Road Rail Station",52.3364359032,-3.2134226095
-"LLV","Llandovery Rail Station",51.995319454,-3.8028430574
-"LLW","Llwyngwril Rail Station",52.6667959978,-4.0876869996
-"LLY","Llwynypia Rail Station",51.6340038599,-3.4535242203
-"LMR","Low Moor Rail Station",53.7499403782,-1.7534074129
-"LMS","Leamington Spa Rail Station",52.284503537,-1.5361991242
-"LNB","Llanbradach Rail Station",51.6032561222,-3.2330580594
-"LND","Longniddry Rail Station",55.9764783228,-2.8883472596
-"LNG","Longcross Rail Station",51.3851709311,-0.5945509208
-"LNK","Lanark Rail Station",55.673604759,-3.7732799051
-"LNR","Llanwrda Rail Station",51.9625935234,-3.8716896629
-"LNW","Llanwrtyd Rail Station",52.1047187961,-3.632173997
-"LNY","Langley (Berks) Rail Station",51.5080622586,-0.5417374982
-"LNZ","Lenzie Rail Station",55.9213119495,-4.1538778824
-"LOB","Longbridge Rail Station",52.3964311105,-1.981283672
-"LOC","Lockerbie Rail Station",55.1230561909,-3.353531624
-"LOF","London Fields Rail Station",51.5411524205,-0.0577263865
-"LOH","Lostock Hall Rail Station",53.7242588593,-2.6874800806
-"LOO","Looe Rail Station",50.3592096258,-4.4561992266
-"LOS","Lostwithiel Rail Station",50.4071639994,-4.6660056695
-"LOT","Lostock Rail Station",53.572942054,-2.4942651922
-"LOW","Lowdham Rail Station",53.0063029264,-0.9984155088
-"LPG","Llanfairpwll Rail Station",53.2209605021,-4.2092216486
-"LPR","Long Preston Rail Station",54.0168488895,-2.255595159
-"LPT","Longport Rail Station",53.0418973325,-2.2164483623
-"LPW","Lapworth Rail Station",52.3422646161,-1.7256819125
-"LPY","Liverpool South Parkway Rail Station",53.3577585374,-2.8891427297
-"LRB","London Road (Brighton) Rail Station",50.8366553421,-0.1364746723
-"LRD","London Road (Guildford) Rail Station",51.2406441935,-0.565047885
-"LRG","Lairg Rail Station",58.0018108151,-4.3998916637
-"LRH","Larkhall Rail Station",55.7385910664,-3.9754997252
-"LSK","Liskeard Rail Station",50.4468508005,-4.4696103937
-"LSN","Livingston North Rail Station",55.9013777549,-3.5443460776
-"LST","London Liverpool Street Rail Station",51.5179909029,-0.0813998966
-"LSW","Leasowe Rail Station",53.4080616471,-3.0995918732
-"LSY","Lower Sydenham Rail Station",51.4248284049,-0.0333195275
-"LTG","Lostock Gralam Rail Station",53.2676790034,-2.4652014465
-"LTH","Llanhilleth Rail Station",51.7003015567,-3.1351956439
-"LTK","Little Kimble Rail Station",51.7522355985,-0.8084296111
-"LTL","Littleborough Rail Station",53.6430095698,-2.0946505145
-"LTM","Lytham Rail Station",53.7392940824,-2.9640373329
-"LTN","Luton Airport Parkway Rail Station",51.8724440314,-0.3958564573
-"LTP","Littleport Rail Station",52.4623961349,0.3165814324
-"LTS","Lelant Saltings Rail Station",50.1787654627,-5.4409776419
-"LTT","Little Sutton Rail Station",53.2855291567,-2.9432922123
-"LTV","Lichfield Trent Valley Rail Station",52.686909098,-1.8002219684
-"LUD","Ludlow Rail Station",52.3712898598,-2.7162155608
-"LUT","Luton Rail Station",51.882311449,-0.4140156557
-"LUX","Luxulyan Rail Station",50.3900215765,-4.7474248225
-"LVC","Liverpool Central Rail Station",53.4046152032,-2.9791681938
-"LVG","Livingston South Rail Station",55.8716872521,-3.5015651841
-"LVJ","Liverpool James Street Rail Station",53.4047793126,-2.9919576763
-"LVL","Liverpool Lime Street Low Level Rail Station",53.4082223458,-2.9777466846
-"LVM","Levenshulme Rail Station",53.44417758,-2.1926682497
-"LVN","Littlehaven Rail Station",51.0797455182,-0.3079538284
-"LVT","Lisvane & Thornhill Rail Station",51.5445785441,-3.1856117371
-"LWH","Lawrence Hill Rail Station",51.4580082791,-2.5644309056
-"LWM","Llantwit Major Rail Station",51.4097453635,-3.4816304262
-"LWR","Llanrwst Rail Station",53.1388647884,-3.7944055622
-"LWS","Lewes Rail Station",50.8706247466,0.0113583341
-"LWT","Lowestoft Rail Station",52.4744616279,1.7497332362
-"LYC","Lympstone Commando Rail Station",50.6622243505,-3.4408532407
-"LYD","Lydney Rail Station",51.7141382304,-2.5308648278
-"LYE","Lye (West Midlands) Rail Station",52.4599348586,-2.1159231742
-"LYM","Lympstone Village Rail Station",50.6482800194,-3.4310201406
-"LYP","Lymington Pier Rail Station",50.7582891862,-1.5294384152
-"LYT","Lymington Town Rail Station",50.7609009488,-1.5371535429
-"LZB","Lazonby & Kirkoswald Rail Station",54.7504423613,-2.7032136037
-"MAC","Macclesfield Rail Station",53.2593576131,-2.1219791655
-"MAG","Maghull Rail Station",53.5064842654,-2.930851711
-"MAI","Maidenhead Rail Station",51.5186697833,-0.7226423149
-"MAL","Malden Manor Rail Station",51.3847271859,-0.2612506017
-"MAN","Manchester Piccadilly Rail Station",53.4773757207,-2.2309078024
-"MAO","Martins Heron Rail Station",51.4074107796,-0.7243793482
-"MAR","Margate Rail Station",51.385433445,1.37202976
-"MAS","Manors Rail Station",54.9727702733,-1.6047541665
-"MAT","Matlock Rail Station",53.1384242777,-1.5589084294
-"MAU","Mauldeth Road Rail Station",53.4330757412,-2.2092498987
-"MAX","Maxwell Park Rail Station",55.8377227182,-4.2886774595
-"MAY","Maybole Rail Station",55.3547389681,-4.6852666045
-"MBK","Millbrook (Hants) Rail Station",50.9114857016,-1.433834394
-"MBR","Middlesbrough Rail Station",54.5791171412,-1.2347318713
-"MCB","Moulsecoomb Rail Station",50.846714382,-0.1188141333
-"MCE","Metrocentre Rail Station",54.9587542761,-1.6656377117
-"MCH","March Rail Station",52.5599099766,0.0912162426
-"MCM","Morecambe Rail Station",54.0703284997,-2.8693058453
-"MCN","Machynlleth Rail Station",52.5951498424,-3.8545361215
-"MCO","Manchester Oxford Road Rail Station",53.4740463537,-2.2419934877
-"MCV","Manchester Victoria Rail Station",53.4874823915,-2.2425968806
-"MDB","Maidstone Barracks Rail Station",51.27716692,0.5139899352
-"MDE","Maidstone East Rail Station",51.2778275358,0.5213244253
-"MDG","Midgham Rail Station",51.3959731964,-1.1776918335
-"MDL","Middlewood Rail Station",53.3599736747,-2.083352764
-"MDN","Maiden Newton Rail Station",50.7799951951,-2.5694292738
-"MDS","Morden South Rail Station",51.3961136271,-0.1994364409
-"MDW","Maidstone West Rail Station",51.2704636478,0.515803579
-"MEC","Meols Cop Rail Station",53.6462862013,-2.9758023054
-"MEL","Meldreth Rail Station",52.0907259969,0.0089697848
-"MEN","Menheniot Rail Station",50.4262142257,-4.4092572868
-"MEO","Meols Rail Station",53.3994554549,-3.1542676173
-"MEP","Meopham Rail Station",51.3864213569,0.3569805515
-"MER","Merthyr Tydfil Rail Station",51.7446246906,-3.3772616186
-"MES","Melton (Suffolk) Rail Station",52.1044529456,1.3382667481
-"MEV","Merthyr Vale Rail Station",51.6866484889,-3.3365879829
-"MEW","Maesteg (Ewenny Road) Rail Station",51.6053431085,-3.6490064767
-"MEX","Mexborough Rail Station",53.4910099658,-1.2885625776
-"MEY","Merryton Rail Station",55.7487021227,-3.9782420669
-"MFA","Morfa Mawddach Rail Station",52.7071419715,-4.032178053
+"HWY","High Wycombe",51.6295875603,-0.7453905204
+"HXM","Hoveton & Wroxham",52.715595961,1.4080190978
+"HYB","Honeybourne",52.1016109574,-1.8337328413
+"HYC","Hyde Central",53.451897881,-2.0852494833
+"HYD","Heyford",51.9191971629,-1.2992524985
+"HYH","Hythe (Essex)",51.885649004,0.9275572674
+"HYK","Hoylake",53.3902262538,-3.1788295823
+"HYL","Hayle",50.1855516133,-5.4198876444
+"HYM","Haymarket",55.9458020856,-3.2184499798
+"HYN","Hyndland",55.8797471979,-4.314653649
+"HYR","Haydons Road",51.4254457568,-0.188790104
+"HYS","Hayes (Kent)",51.376332397,0.0105837729
+"HYT","Hyde North",53.4648142912,-2.0854568359
+"HYW","Hinchley Wood",51.3749950976,-0.3405015776
+"IBM","IBM (Greenock)",55.9294397123,-4.8272199389
+"IFD","Ilford",51.5591169252,0.0697060332
+"IFI","Ifield",51.115616552,-0.214744158
+"IGD","Invergordon",57.6890013885,-4.1748401883
+"ILK","Ilkley",53.9247771648,-1.822030732
+"ILN","Ilkeston",52.9796097784,-1.2949283917
+"IMW","Imperial Wharf",51.4749481734,-0.1827985374
+"INC","Ince (Manchester)",53.5389257232,-2.6115187679
+"INE","Ince & Elton",53.2766213459,-2.8165221852
+"ING","Invergowrie",56.4564629346,-3.0574006479
+"INH","Invershin",57.9248506817,-4.3994794892
+"INK","Inverkeithing",56.0346707647,-3.3961851331
+"INP","Inverkip",55.906097486,-4.8725658517
+"INR","Inverurie",57.2862510473,-2.3735646839
+"INS","Insch",57.3374826347,-2.6171148112
+"INT","Ingatestone",51.6670448119,0.3842732713
+"INV","Inverness",57.4798523576,-4.2233591954
+"IPS","Ipswich",52.050605185,1.1444561195
+"IRL","Irlam",53.4343243953,-2.4332290912
+"IRV","Irvine",55.610870787,-4.6751248885
+"ISL","Isleworth",51.4747609931,-0.3368852384
+"ISP","Islip",51.8257581652,-1.2381632634
+"IVA","Inverness Airport",57.5335,-4.0552
+"IVR","Iver",51.5085027345,-0.5067065231
+"IVY","Ivybridge",50.3933952288,-3.9042285416
+"JCH","James Cook University Hospital",54.552041983,-1.2085837079
+"JEQ","Jewellery Quarter",52.489447723,-1.9132076451
+"JHN","Johnstone",55.8347024844,-4.5036207425
+"JOH","Johnston (Pembrokeshire)",51.7567579295,-4.9963630908
+"JOR","Jordanhill",55.882699515,-4.3249029293
+"KBC","Kinbrace",58.2582968272,-3.9412133227
+"KBF","Kirkby-in-Furness",54.2327161445,-3.1873760397
+"KBK","Kents Bank",54.172910528,-2.9252290041
+"KBN","Kilburn High Road",51.5372777601,-0.1922126859
+"KBW","Knebworth",51.8668603588,-0.1872649131
+"KBX","Kirby Cross",51.841408258,1.2150236403
+"KCK","Knockholt",51.3457884371,0.1308739721
+"KDB","Kidbrooke",51.4621199896,0.0275232797
+"KDG","Kidsgrove",53.0865804703,-2.2448159035
+"KDY","Kirkcaldy",56.1120505901,-3.1670300049
+"KEH","Keith",57.5508815659,-2.9540692665
+"KEI","Keighley",53.8679755061,-1.9016526329
+"KEL","Kelvedon",51.8407101631,0.7024132856
+"KEM","Kemble",51.6769974883,-2.0228096226
+"KEN","Kendal",54.3321036266,-2.7396488466
+"KET","Kettering",52.3935680461,-0.7315471328
+"KEY","Keyham",50.3898643425,-4.1796285768
+"KGE","Kingsknowe",55.9188071296,-3.2649651648
+"KGH","Kinghorn",56.0693308155,-3.1741555055
+"KGL","Kings Langley",51.7063602029,-0.4384002341
+"KGM","Kingham",51.9022564168,-1.6287732881
+"KGN","Kings Nympton",50.936065096,-3.9054316221
+"KGP","Kings Park",55.8195373532,-4.2465028963
+"KGS","Kings Sutton",52.021359878,-1.2809139108
+"KGT","Kilgetty",51.7321146696,-4.7151861813
+"KGX","London Kings Cross",51.5308836375,-0.1229002946
+"KID","Kidderminster",52.3844946608,-2.2384665613
+"KIL","Kildonan",58.1707935283,-3.8691107621
+"KIN","Kingussie",57.0777663698,-4.0521889967
+"KIR","Kirkby",53.4862048537,-2.9028281809
+"KIT","Kintbury",51.4025186724,-1.4459730106
+"KIV","Kiveton Bridge",53.3409764694,-1.2671800273
+"KKB","Kirkby in Ashfield",53.1001156743,-1.2530543087
+"KKD","Kirkdale",53.4409136231,-2.9811163636
+"KKH","Kirkhill",55.8139079243,-4.1670911014
+"KKM","Kirkham & Wesham",53.7869285701,-2.8829376626
+"KKN","Kirknewton",55.8886849182,-3.4325077075
+"KKS","Kirk Sandall",53.5638967616,-1.074065509
+"KLD","Kildale",54.4777686824,-1.0681580089
+"KLF","Kirkstall Forge",53.8237339338,-1.6224823291
+"KLM","Kilmaurs",55.6372048041,-4.530470324
+"KLN","Kings Lynn",52.7539444878,0.4034623052
+"KLY","Kenley",51.3247744025,-0.1008992757
+"KMH","Kempston Hardwick",52.0922280746,-0.503891956
+"KMK","Kilmarnock",55.6121152355,-4.4986646202
+"KML","Kemsley",51.3624400702,0.7353874775
+"KMP","Kempton Park",51.4209818235,-0.4097301104
+"KMS","Kemsing",51.2971839907,0.2474553811
+"KNA","Knaresborough",54.0090375731,-1.4704220018
+"KND","Kingswood",51.2947217871,-0.2112222297
+"KNE","Kennett",52.2772786496,0.490492211
+"KNF","Knutsford",53.3018050357,-2.3717892715
+"KNG","Kingston",51.412749207,-0.3011440528
+"KNI","Knighton",52.3450836187,-3.0421947541
+"KNL","Kensal Green",51.5305403206,-0.225063468
+"KNN","Kings Norton",52.4143035181,-1.9323192635
+"KNO","Knottingley",53.7065538515,-1.2591815208
+"KNR","Kensal Rise",51.5345542153,-0.2199327512
+"KNS","Kennishead",55.813309436,-4.3252321959
+"KNT","Kenton",51.581801686,-0.3169583454
+"KNU","Knucklas",52.3598728116,-3.0968778892
+"KNW","Kenilworth",52.3427193518,-1.5727265434
+"KPA","Kensington (Olympia)",51.4978982211,-0.2103405047
+"KPT","Kilpatrick",55.9246935335,-4.4533967721
+"KRK","Kirkconnel",55.3883045795,-3.9984909836
+"KSL","Kearsley",53.5441534939,-2.3751177475
+"KSN","Kearsney",51.1493801653,1.2720927524
+"KSW","Kirkby Stephen",54.4548647986,-2.3686012903
+"KTH","Kent House",51.4122125796,-0.0452213855
+"KTL","Kirton Lindsey",53.4848601103,-0.5939161226
+"KTN","Kentish Town",51.550495644,-0.1403392037
+"KTR","Kintore", 57.243611, -2.350278
+"KTW","Kentish Town West",51.546548457,-0.1466298744
+"KVD","Kelvindale",55.8935487999,-4.3095577512
+"KVP","Kiveton Park",53.3367337933,-1.2398447759
+"KWB","Kew Bridge",51.489511729,-0.287085417
+"KWD","Kirkwood",55.8541826133,-4.0483868931
+"KWG","Kew Gardens",51.4770717225,-0.2850311799
+"KWL","Kidwelly",51.7343478013,-4.3170097512
+"KWN","Kilwinning",55.6559470119,-4.7099979638
+"KYL","Kyle of Lochalsh",57.2797467149,-5.7138003131
+"KYN","Keynsham",51.4179728415,-2.495628895
+"LAC","Lancing",50.8270743359,-0.3230828778
+"LAD","Ladywell",51.4562424895,-0.0190151041
+"LAG","Langwith - Whaley Thorns",53.2318581892,-1.2093421054
+"LAI","Laindon",51.5675245473,0.4243193409
+"LAK","Lakenheath",52.4474170039,0.535221579
+"LAM","Lamphey",51.6671952632,-4.8732909776
+"LAN","Lancaster",54.0487386625,-2.8074539872
+"LAP","Lapford",50.8569928871,-3.8106600905
+"LAR","Largs",55.7927371132,-4.8671774606
+"LAS","Llansamlet",51.661506083,-3.8847019198
+"LAU","Laurencekirk",56.8363340087,-2.4659318685
+"LAW","Landywood",52.656554762,-2.0207214262
+"LAY","Layton (Lancs)",53.8352807966,-3.0299856202
+"LBG","London Bridge",51.5050187718,-0.0860663187
+"LBK","Long Buckby",52.2947305797,-1.0864517232
+"LBO","Loughborough (Leics)",52.7789730706,-1.1959223029
+"LBR","Llanbedr",52.8208652563,-4.1102042575
+"LBT","Larbert",56.0226975731,-3.8305736309
+"LBZ","Leighton Buzzard",51.9163138347,-0.6769823167
+"LCC","Lochluichart",57.621737692,-4.8090441141
+"LCG","Lochgelly",56.1353217097,-3.312938865
+"LCK","Lockwood",53.634746673,-1.8007918923
+"LCL","Lochailort",56.8809423369,-5.6633772414
+"LCN","Lincoln Central",53.2261072888,-0.5399222885
+"LCS","Locheilside",56.8553882734,-5.2900225827
+"LDN","Llandanwg",52.8361759873,-4.1238635913
+"LDS","Leeds",53.7956409037,-1.5480300934
+"LDY","Ladybank",56.2737723207,-3.1222761516
+"LEA","Leagrave",51.9051657736,-0.4584767531
+"LEB","Lea Bridge",51.5665477908,-0.0366456064
+"LED","Ledbury",52.0452583249,-2.4258582991
+"LEE","Lee",51.4497532361,0.0135186891
+"LEG","Lea Green",53.4268240445,-2.7249767465
+"LEH","Lea Hall",52.480655776,-1.7860055303
+"LEI","Leicester",52.6314416999,-1.1252675699
+"LEL","Lelant",50.1841132154,-5.4365983681
+"LEM","Leyton Midland Road",51.5697256477,-0.0080229844
+"LEN","Lenham",51.2344839559,0.7077894244
+"LEO","Leominster",52.2256915912,-2.730340766
+"LER","Leytonstone High Road",51.5635545296,0.0084437379
+"LES","Leigh-on-Sea",51.5412752344,0.6404394965
+"LET","Letchworth",51.9799709665,-0.2292371062
+"LEU","Leuchars",56.3750925172,-2.8937163252
+"LEW","Lewisham",51.4656900464,-0.0139988836
+"LEY","Leyland",53.6988690686,-2.6871416367
+"LEV","Leven",56.1923,-3.002
+"LFD","Lingfield",51.1764479512,-0.0071377353
+"LGB","Langbank",55.9245116809,-4.5852569156
+"LGD","Lingwood",52.6221259547,1.4899676829
+"LGE","Long Eaton",52.8850051381,-1.287515035
+"LGF","Longfield",51.3961528278,0.3003927726
+"LGG","Langley Green",52.4938847738,-2.0049580874
+"LGJ","Loughborough Junction",51.4662966456,-0.1021564205
+"LGK","Longbeck",54.5892295098,-1.0304881067
+"LGM","Langley Mill",53.0180775906,-1.3312416884
+"LGN","Longton",52.9899681856,-2.1370099565
+"LGO","Llangynllo",52.3496362697,-3.1613704736
+"LGS","Langside",55.8211269753,-4.2773259977
+"LGW","Langwathby",54.6943634202,-2.6636891905
+"LHA","Loch Awe",56.4020023455,-5.0419541347
+"LHD","Leatherhead",51.2988144436,-0.3332088593
+"LHE","Loch Eil Outward Bound",56.8552494299,-5.1915632271
+"LHM","Lealholm",54.4606042623,-0.8257310498
+"LHO","Langho",53.8048444025,-2.4486582114
+"LHR","Heathrow Terminals 1-3",51.4714046459,-0.4543126778
+"LHS","Limehouse",51.5125361684,-0.0397760782
+"LHW","Lochwinnoch",55.7871497964,-4.6160573245
+"LIC","Lichfield City",52.6801615881,-1.8254127247
+"LID","Lidlington",52.0415453254,-0.5589061726
+"LIF","Lichfield Trent Valley High Level",52.6869091229,-1.8002367619
+"LIH","Leigh (Kent)",51.1938967547,0.2105218236
+"LIN","Linlithgow",55.9764464658,-3.5958472904
+"LIP","Liphook",51.0713092222,-0.8002098038
+"LIS","Liss",51.0435640733,-0.8928497986
+"LIT","Littlehampton",50.8100978499,-0.5459719624
+"LIV","Liverpool Lime Street",53.4073236407,-2.977726082
+"LKE","Lake (Isle of Wight)",50.6464632785,-1.1663386012
+"LLA","Llanaber",52.7415174068,-4.0771833809
+"LLC","Llandecwyn",52.9206985859,-4.0570419611
+"LLD","Llandudno",53.320931375,-3.8270045937
+"LLE","Llanelli",51.6738710202,-4.1613259947
+"LLF","Llanfairfechan",53.2573026611,-3.9832073298
+"LLG","Llangadog",51.9402195807,-3.8931635456
+"LLH","Llangennech",51.6911401855,-4.0789505342
+"LLI","Llandybie",51.8210413519,-4.0036670781
+"LLJ","Llandudno Junction",53.283958434,-3.8091060573
+"LLL","Llandeilo",51.8853508121,-3.9869089385
+"LLM","Llangammarch",52.1143061939,-3.5548258245
+"LLN","Llandaf",51.5084380797,-3.2286220121
+"LLO","Llandrindod",52.2423682996,-3.3791453356
+"LLR","Llanharan",51.5375863272,-3.4407911115
+"LLS","Llanishen",51.532745927,-3.1819878738
+"LLT","Llanbister Road",52.3364359032,-3.2134226095
+"LLV","Llandovery",51.995319454,-3.8028430574
+"LLW","Llwyngwril",52.6667959978,-4.0876869996
+"LLY","Llwynypia",51.6340038599,-3.4535242203
+"LMR","Low Moor",53.7499403782,-1.7534074129
+"LMS","Leamington Spa",52.284503537,-1.5361991242
+"LNB","Llanbradach",51.6032561222,-3.2330580594
+"LND","Longniddry",55.9764783228,-2.8883472596
+"LNG","Longcross",51.3851709311,-0.5945509208
+"LNK","Lanark",55.673604759,-3.7732799051
+"LNR","Llanwrda",51.9625935234,-3.8716896629
+"LNW","Llanwrtyd",52.1047187961,-3.632173997
+"LNY","Langley (Berks)",51.5080622586,-0.5417374982
+"LNZ","Lenzie",55.9213119495,-4.1538778824
+"LOB","Longbridge",52.3964311105,-1.981283672
+"LOC","Lockerbie",55.1230561909,-3.353531624
+"LOF","London Fields",51.5411524205,-0.0577263865
+"LOH","Lostock Hall",53.7242588593,-2.6874800806
+"LOO","Looe",50.3592096258,-4.4561992266
+"LOS","Lostwithiel",50.4071639994,-4.6660056695
+"LOT","Lostock",53.572942054,-2.4942651922
+"LOW","Lowdham",53.0063029264,-0.9984155088
+"LPG","Llanfairpwll",53.2209605021,-4.2092216486
+"LPR","Long Preston",54.0168488895,-2.255595159
+"LPT","Longport",53.0418973325,-2.2164483623
+"LPW","Lapworth",52.3422646161,-1.7256819125
+"LPY","Liverpool South Parkway",53.3577585374,-2.8891427297
+"LRB","London Road (Brighton)",50.8366553421,-0.1364746723
+"LRD","London Road (Guildford)",51.2406441935,-0.565047885
+"LRG","Lairg",58.0018108151,-4.3998916637
+"LRH","Larkhall",55.7385910664,-3.9754997252
+"LSK","Liskeard",50.4468508005,-4.4696103937
+"LSN","Livingston North",55.9013777549,-3.5443460776
+"LST","London Liverpool Street",51.5179909029,-0.0813998966
+"LSW","Leasowe",53.4080616471,-3.0995918732
+"LSY","Lower Sydenham",51.4248284049,-0.0333195275
+"LTG","Lostock Gralam",53.2676790034,-2.4652014465
+"LTH","Llanhilleth",51.7003015567,-3.1351956439
+"LTK","Little Kimble",51.7522355985,-0.8084296111
+"LTL","Littleborough",53.6430095698,-2.0946505145
+"LTM","Lytham",53.7392940824,-2.9640373329
+"LTN","Luton Airport Parkway",51.8724440314,-0.3958564573
+"LTP","Littleport",52.4623961349,0.3165814324
+"LTS","Lelant Saltings",50.1787654627,-5.4409776419
+"LTT","Little Sutton",53.2855291567,-2.9432922123
+"LTV","Lichfield Trent Valley",52.686909098,-1.8002219684
+"LUD","Ludlow",52.3712898598,-2.7162155608
+"LUT","Luton",51.882311449,-0.4140156557
+"LUX","Luxulyan",50.3900215765,-4.7474248225
+"LVC","Liverpool Central",53.4046152032,-2.9791681938
+"LVG","Livingston South",55.8716872521,-3.5015651841
+"LVJ","Liverpool James Street",53.4047793126,-2.9919576763
+"LVL","Liverpool Lime Street Low Level",53.4082223458,-2.9777466846
+"LVM","Levenshulme",53.44417758,-2.1926682497
+"LVN","Littlehaven",51.0797455182,-0.3079538284
+"LVT","Lisvane & Thornhill",51.5445785441,-3.1856117371
+"LWH","Lawrence Hill",51.4580082791,-2.5644309056
+"LWM","Llantwit Major",51.4097453635,-3.4816304262
+"LWR","Llanrwst",53.1388647884,-3.7944055622
+"LWS","Lewes",50.8706247466,0.0113583341
+"LWT","Lowestoft",52.4744616279,1.7497332362
+"LYC","Lympstone Commando",50.6622243505,-3.4408532407
+"LYD","Lydney",51.7141382304,-2.5308648278
+"LYE","Lye (West Midlands)",52.4599348586,-2.1159231742
+"LYM","Lympstone Village",50.6482800194,-3.4310201406
+"LYP","Lymington Pier",50.7582891862,-1.5294384152
+"LYT","Lymington Town",50.7609009488,-1.5371535429
+"LZB","Lazonby & Kirkoswald",54.7504423613,-2.7032136037
+"MAC","Macclesfield",53.2593576131,-2.1219791655
+"MAG","Maghull",53.5064842654,-2.930851711
+"MAI","Maidenhead",51.5186697833,-0.7226423149
+"MAL","Malden Manor",51.3847271859,-0.2612506017
+"MAN","Manchester Piccadilly",53.4773757207,-2.2309078024
+"MAO","Martins Heron",51.4074107796,-0.7243793482
+"MAR","Margate",51.385433445,1.37202976
+"MAS","Manors",54.9727702733,-1.6047541665
+"MAT","Matlock",53.1384242777,-1.5589084294
+"MAU","Mauldeth Road",53.4330757412,-2.2092498987
+"MAX","Maxwell Park",55.8377227182,-4.2886774595
+"MAY","Maybole",55.3547389681,-4.6852666045
+"MBK","Millbrook (Hants)",50.9114857016,-1.433834394
+"MBT","Marsh Barton",50.704,-3.521
+"MBR","Middlesbrough",54.5791171412,-1.2347318713
+"MCB","Moulsecoomb",50.846714382,-0.1188141333
+"MCE","Metrocentre",54.9587542761,-1.6656377117
+"MCH","March",52.5599099766,0.0912162426
+"MCM","Morecambe",54.0703284997,-2.8693058453
+"MCN","Machynlleth",52.5951498424,-3.8545361215
+"MCO","Manchester Oxford Road",53.4740463537,-2.2419934877
+"MCV","Manchester Victoria",53.4874823915,-2.2425968806
+"MDB","Maidstone Barracks",51.27716692,0.5139899352
+"MDE","Maidstone East",51.2778275358,0.5213244253
+"MDG","Midgham",51.3959731964,-1.1776918335
+"MDL","Middlewood",53.3599736747,-2.083352764
+"MDN","Maiden Newton",50.7799951951,-2.5694292738
+"MDS","Morden South",51.3961136271,-0.1994364409
+"MDW","Maidstone West",51.2704636478,0.515803579
+"MEC","Meols Cop",53.6462862013,-2.9758023054
+"MEL","Meldreth",52.0907259969,0.0089697848
+"MEN","Menheniot",50.4262142257,-4.4092572868
+"MEO","Meols",53.3994554549,-3.1542676173
+"MEP","Meopham",51.3864213569,0.3569805515
+"MER","Merthyr Tydfil",51.7446246906,-3.3772616186
+"MES","Melton (Suffolk)",52.1044529456,1.3382667481
+"MEV","Merthyr Vale",51.6866484889,-3.3365879829
+"MEW","Maesteg (Ewenny Road)",51.6053431085,-3.6490064767
+"MEX","Mexborough",53.4910099658,-1.2885625776
+"MEY","Merryton",55.7487021227,-3.9782420669
+"MFA","Morfa Mawddach",52.7071419715,-4.032178053
 "MFD","Minffordd Ffestiniog Railway Station",52.9258888953,-4.0842164454
-"MFF","Minffordd Rail Station",52.926145345,-4.0849726521
-"MFH","Milford Haven Rail Station",51.7149845991,-5.0410051649
-"MFL","Mount Florida Rail Station",55.8265491352,-4.2611173526
-"MFT","Mansfield Rail Station",53.1421177161,-1.1984319382
-"MGM","Metheringham Rail Station",53.1389012206,-0.3914492699
-"MGN","Marston Green Rail Station",52.4672018911,-1.7556002472
-"MHM","Merstham Rail Station",51.2641512942,-0.1502004055
-"MHR","Market Harborough Rail Station",52.4797370398,-0.9093194703
-"MHS","Meadowhall Rail Station",53.4174828257,-1.4128516936
-"MIA","Manchester Airport Rail Station",53.365056148,-2.2729784791
-"MIC","Micheldever Rail Station",51.1823883025,-1.260662184
-"MIH","Mills Hill (Manchester) Rail Station",53.5513245844,-2.1715108069
-"MIJ","Mitcham Junction Rail Station",51.392947391,-0.1577313094
-"MIK","Micklefield Rail Station",53.7888521389,-1.3267968915
-"MIL","Mill Hill Broadway Rail Station",51.6130940209,-0.2492158407
-"MIM","Moreton-in-Marsh Rail Station",51.9922896467,-1.700369111
-"MIN","Milliken Park Rail Station",55.8251055368,-4.5333409179
-"MIR","Mirfield Rail Station",53.6714142168,-1.6925478902
-"MIS","Mistley Rail Station",51.9436415764,1.081430084
-"MKC","Milton Keynes Central Rail Station",52.0342970583,-0.7741256561
-"MKM","Melksham Rail Station",51.3798186441,-2.1444920323
-"MKR","Market Rasen Rail Station",53.3839344671,-0.3369000957
-"MKT","Marks Tey Rail Station",51.8809486375,0.7833551606
-"MLB","Millbrook (Beds) Rail Station",52.0538457297,-0.5326807632
-"MLD","Mouldsworth Rail Station",53.2318188478,-2.7322232144
-"MLF","Milford (Surrey) Rail Station",51.1633133767,-0.6369282874
-"MLG","Mallaig Rail Station",57.005965587,-5.8295792296
-"MLH","Mill Hill (Lancs) Rail Station",53.7354717311,-2.5017331794
-"MLM","Millom Rail Station",54.2108302797,-3.2710839419
-"MLN","Milngavie Rail Station",55.9413575022,-4.3145648876
-"MLT","Malton Rail Station",54.1320917413,-0.7972330574
-"MLW","Marlow Rail Station",51.5709950142,-0.7664123608
-"MLY","Morley Rail Station",53.7499375883,-1.5909802981
-"MMO","Melton Mowbray Rail Station",52.7610494909,-0.8858623625
-"MNC","Markinch Rail Station",56.201006454,-3.1307887208
-"MNE","Manea Rail Station",52.4978548877,0.1777139789
-"MNG","Manningtree Rail Station",51.9490620543,1.0452697914
-"MNN","Menston Rail Station",53.8923520984,-1.7355135499
-"MNP","Manor Park Rail Station",51.5524760236,0.0463682122
-"MNR","Manor Road Rail Station",53.394793603,-3.1714362959
-"MOB","Mobberley Rail Station",53.3291537972,-2.3336642593
-"MOG","Moorgate Rail Station",51.5184914149,-0.0889174169
-"MON","Monifieth Rail Station",56.4801011269,-2.8182514848
-"MOO","Muir of Ord Rail Station",57.5178284795,-4.460230876
-"MOR","Mortimer Rail Station",51.3720775119,-1.0354903866
-"MOS","Moss Side Rail Station",53.764988776,-2.9429318748
-"MOT","Motspur Park Rail Station",51.3951937788,-0.2395071447
-"MPK","Mosspark Rail Station",55.8408228806,-4.3482777791
-"MPL","Marple Rail Station",53.4007069655,-2.0572623816
-"MPT","Morpeth Rail Station",55.1623793108,-1.6830875765
-"MRB","Manorbier Rail Station",51.6601657701,-4.7918631589
-"MRD","Morchard Road Rail Station",50.831888433,-3.7763856573
-"MRF","Moorfields Rail Station",53.408577563,-2.9891877739
-"MRN","Marden Rail Station",51.1751727189,0.4931989357
-"MRP","Moorthorpe Rail Station",53.5950120583,-1.3049494779
-"MRR","Morar Rail Station",56.9696962652,-5.8218995718
-"MRS","Monks Risborough Rail Station",51.7357654911,-0.8293110058
-"MRT","Moreton (Merseyside) Rail Station",53.4072225806,-3.1134999967
-"MRY","Maryport Rail Station",54.71132475,-3.4940750264
-"MSD","Moorside Rail Station",53.516289171,-2.351797693
-"MSH","Mossley Hill Rail Station",53.3790525198,-2.9154430601
-"MSK","Marske Rail Station",54.5874288395,-1.0189249961
-"MSL","Mossley (Manchester) Rail Station",53.5149938702,-2.0412799663
-"MSN","Marsden Rail Station",53.6031989506,-1.9307489058
-"MSO","Moston Rail Station",53.5234344757,-2.1710210757
-"MSR","Minster Rail Station",51.3291791939,1.3172443102
-"MSS","Moses Gate Rail Station",53.5559962598,-2.4011861486
-"MST","Maesteg Rail Station",51.6099392672,-3.6546614792
-"MSW","Mansfield Woodhouse Rail Station",53.1635798405,-1.201846595
-"MTA","Mountain Ash Rail Station",51.6813336784,-3.3763534667
-"MTB","Matlock Bath Rail Station",53.1223708532,-1.5567564386
-"MTC","Mitcham Eastfields Rail Station",51.4077364814,-0.1546204515
-"MTG","Mottingham Rail Station",51.4402167384,0.0500802261
-"MTH","Motherwell Rail Station",55.7916692892,-3.9943169398
-"MTL","Mortlake Rail Station",51.468085138,-0.2670827547
-"MTM","Martin Mill Rail Station",51.1706839505,1.3482479873
-"MTN","Moreton (Dorset) Rail Station",50.7010195625,-2.3134461541
-"MTO","Marton Rail Station",54.5443541756,-1.1984988205
-"MTP","Montpelier Rail Station",51.4683464285,-2.5886872075
-"MTS","Montrose Rail Station",56.7127857624,-2.4720806987
-"MTV","Mount Vernon Rail Station",55.84019612,-4.133656173
-"MUB","Musselburgh Rail Station",55.9335850009,-3.0732054363
-"MUF","Manchester United FC Rail Station",53.4622084856,-2.290652901
-"MUI","Muirend Rail Station",55.8094528886,-4.274377937
-"MVL","Malvern Link Rail Station",52.1254773107,-2.3195074315
-"MYB","London Marylebone Rail Station",51.522523885,-0.1628859644
-"MYH","Maryhill Rail Station",55.8976237197,-4.3007303486
-"MYL","Maryland Rail Station",51.5460813657,0.005842588
-"MYT","Mytholmroyd Rail Station",53.7290162532,-1.9814271564
-"MZH","Maze Hill Rail Station",51.4826233713,0.0029400062
-"NAN","Nantwich Rail Station",53.0635867383,-2.5189592102
-"NAR","Narberth Rail Station",51.7993779002,-4.7272043319
-"NAY","Newton Aycliffe Rail Station",54.6137111141,-1.5896555578
-"NBA","New Barnet Rail Station",51.6485757882,-0.1729714788
-"NBC","New Beckenham Rail Station",51.416767136,-0.0352474454
-"NBE","Newbridge Rail Station",51.665815285,-3.1428939856
-"NBN","New Brighton Rail Station",53.437415844,-3.0479632359
-"NBR","Narborough Rail Station",52.5713097683,-1.2033367857
-"NBT","Norbiton Rail Station",51.4123555216,-0.2840028162
-"NBW","North Berwick Rail Station",56.0570302209,-2.7307472989
-"NBY","Newbury Rail Station",51.397647103,-1.3228424921
-"NCE","New Clee Rail Station",53.5744020885,-0.0608183009
-"NCK","New Cumnock Rail Station",55.4027409338,-4.1843292426
-"NCL","Newcastle Rail Station",54.9684070401,-1.6172925574
-"NCM","North Camp Rail Station",51.2757921453,-0.731181183
-"NCO","Newcourt Rail Station",50.7050286867,-3.4727977721
-"NCT","Newark Castle Rail Station",53.080022402,-0.8131567694
-"NDL","North Dulwich Rail Station",51.4545089621,-0.0878918236
-"NEG","Newtongrange Rail Station",55.8669914004,-3.0693694316
-"NEH","New Eltham Rail Station",51.4380580221,0.0705593927
-"NEI","Neilston Rail Station",55.7830319543,-4.4269370486
-"NEL","Nelson Rail Station",53.8350188567,-2.2137611849
-"NEM","New Malden Rail Station",51.4040722425,-0.2559166562
-"NES","Neston Rail Station",53.2918652932,-3.0630755474
-"NET","Netherfield Rail Station",52.9614294437,-1.0798460669
-"NEW","Newcraighall Rail Station",55.9331154017,-3.0908472906
-"NFA","North Fambridge Rail Station",51.6485874442,0.6816868594
-"NFD","Northfield Rail Station",52.408205022,-1.9658445265
-"NFL","Northfleet Rail Station",51.4458444738,0.3243627291
-"NFN","Nafferton Rail Station",54.0112409619,-0.3860877568
-"NGT","Newington Rail Station",51.3533404814,0.6686002778
-"NHD","Nunhead Rail Station",51.4668266219,-0.0522470725
-"NHE","New Hythe Rail Station",51.3130005132,0.4549583652
-"NHL","New Holland Rail Station",53.7019404883,-0.3602195506
-"NIT","Nitshill Rail Station",55.8119290151,-4.3599440893
-"NLN","New Lane Rail Station",53.611676421,-2.8677150822
-"NLR","North Llanrwst Rail Station",53.1438364668,-3.8027318185
-"NLS","Nailsea & Backwell Rail Station",51.4194043932,-2.750638165
-"NLT","Northolt Park Rail Station",51.5575391716,-0.3594445305
-"NLW","Newton-le-Willows Rail Station",53.4530749987,-2.6135973334
-"NMC","New Mills Central Rail Station",53.3648560934,-2.0056703312
-"NMK","Newmarket Rail Station",52.2379580874,0.4062358785
-"NMN","New Mills Newtown Rail Station",53.3596424903,-2.0085245142
-"NMP","Northampton Rail Station",52.2375139145,-0.906638854
-"NMT","Needham Market Rail Station",52.1526036565,1.0552904861
-"NNG","Newark North Gate Rail Station",53.0817767766,-0.7998511914
-"NNP","Ninian Park Rail Station",51.4766151237,-3.2017026277
-"NNT","Nunthorpe Rail Station",54.5278916561,-1.1694623307
-"NOA","Newton-on-Ayr Rail Station",55.4740529017,-4.6258056575
-"NOR","Normanton Rail Station",53.7005346086,-1.4234040424
-"NOT","Nottingham Rail Station",52.9470929341,-1.1463789462
-"NPD","New Pudsey Rail Station",53.8044975251,-1.6807968849
-"NQU","North Queensferry Rail Station",56.0124941531,-3.394582615
-"NQY","Newquay Rail Station",50.415084133,-5.0756989533
-"NRB","Norbury Rail Station",51.4114439365,-0.1219000953
-"NRC","Newbury Racecourse Rail Station",51.3984581516,-1.3077799439
-"NRD","North Road Rail Station",54.5362092283,-1.5539587211
-"NRN","Nairn Rail Station",57.5802287419,-3.871999953
-"NRT","Nethertown Rail Station",54.4564242911,-3.5658366589
-"NRW","Norwich Rail Station",52.6271764442,1.3068436175
-"NSB","Normans Bay Rail Station",50.8260972868,0.3894907962
-"NSD","Newstead Rail Station",53.0699991881,-1.221784818
-"NSG","New Southgate Rail Station",51.6141146074,-0.1430125641
-"NSH","North Sheen Rail Station",51.4651527407,-0.2878532427
-"NTA","Newton Abbot Rail Station",50.5295709354,-3.5991818536
-"NTB","Norton Bridge Rail Station",52.8667125875,-2.1905418489
-"NTC","Newton St Cyres Rail Station",50.7789165834,-3.589404542
-"NTH","Neath Rail Station",51.6623638663,-3.8072343482
-"NTL","Netley Rail Station",50.8748975168,-1.3418931628
-"NTN","Newton (S Lanarks) Rail Station",55.8187724129,-4.1330414607
-"NTR","Northallerton Rail Station",54.3330824604,-1.4412825015
-"NUF","Nutfield Rail Station",51.2268096258,-0.1325049602
-"NUM","Northumberland Park Rail Station",51.6019688995,-0.0539069251
-"NUN","Nuneaton Rail Station",52.5263860835,-1.4638662754
-"NUT","Nutbourne Rail Station",50.8460585998,-0.8829282409
-"NVH","Newhaven Harbour Rail Station",50.7897843615,0.0550205943
-"NVN","Newhaven Town Rail Station",50.7948486315,0.0549731113
-"NVR","Navigation Road Rail Station",53.3953905024,-2.3434169235
-"NWA","North Walsham Rail Station",52.8169121918,1.3844751173
-"NWB","North Wembley Rail Station",51.5625961704,-0.3039615425
-"NWD","Norwood Junction Rail Station",51.397016964,-0.0751960155
-"NWE","Newport (Essex) Rail Station",51.9798767674,0.2151664222
-"NWI","Northwich Rail Station",53.2614653974,-2.4969157221
-"NWM","New Milton Rail Station",50.7557417759,-1.657805844
-"NWN","Newton for Hyde Rail Station",53.4563946328,-2.0671424184
-"NWP","Newport (S Wales) Rail Station",51.5887891555,-3.0005496511
-"NWR","Newtonmore Rail Station",57.0591301765,-4.1191037522
-"NWT","Newtown (Powys) Rail Station",52.5123270805,-3.3113949158
-"NWX","New Cross ELL Rail Station",51.4763425048,-0.0324150961
-"NXG","New Cross Gate ELL Rail Station",51.4751271677,-0.0403876579
-"OBN","Oban Rail Station",56.4124709629,-5.4739093886
-"OCK","Ockendon Rail Station",51.5219914043,0.290497263
-"OHL","Old Hill Rail Station",52.470947074,-2.0561848613
-"OKE","Okehampton Rail Station",50.7323709771,-3.9962371646
-"OKL","Oakleigh Park Rail Station",51.637679136,-0.1661837043
-"OKM","Oakham Rail Station",52.6722323623,-0.7341607803
-"OKN","Oakengates Rail Station",52.6934109391,-2.4501927064
-"OLD","Old Street Rail Station",51.5258317895,-0.0885090187
-"OLF","Oldfield Park Rail Station",51.3792256566,-2.3805068483
-"OLT","Olton Rail Station",52.438524483,-1.8043032158
-"OLY","Ockley Rail Station",51.1515064148,-0.3359877818
-"OMS","Ormskirk Rail Station",53.56928696,-2.8811915199
-"OPK","Orrell Park Rail Station",53.4619123452,-2.9633147359
-"OPY","Oxford Parkway Rail Station",51.8040758686,-1.2744681129
-"ORE","Ore Rail Station",50.8669427332,0.591596612
-"ORN","Old Roan Rail Station",53.4869093953,-2.9510705094
-"ORP","Orpington Rail Station",51.3732951318,0.0891167615
-"ORR","Orrell Rail Station",53.530325904,-2.7088376683
-"OTF","Otford Rail Station",51.313155145,0.1968058758
-"OUN","Oulton Broad North Rail Station",52.4777844841,1.7157356055
-"OUS","Oulton Broad South Rail Station",52.4696271149,1.7076837204
-"OUT","Outwood Rail Station",53.7153018923,-1.5104034645
-"OVE","Overpool Rail Station",53.2840618342,-2.9240604888
-"OVR","Overton Rail Station",51.2542901889,-1.2592504239
-"OXF","Oxford Rail Station",51.753499533,-1.2701353856
-"OXN","Oxenholme Lake District Rail Station",54.3049347745,-2.7218718643
-"OXS","Oxshott Rail Station",51.3363929984,-0.3623961961
-"OXT","Oxted Rail Station",51.2579045834,-0.0048073736
-"PAD","London Paddington Rail Station",51.515995347,-0.1761493939
-"PAL","Palmers Green Rail Station",51.6183152407,-0.1104116731
-"PAN","Pangbourne Rail Station",51.4854011729,-1.0904500754
-"PAR","Par Rail Station",50.3553115511,-4.7047163536
-"PAT","Patricroft Rail Station",53.4847921621,-2.3582432532
-"PBL","Parbold Rail Station",53.5907686118,-2.7707477548
-"PBO","Peterborough Rail Station",52.5749924034,-0.2498227798
-"PBR","Potters Bar Rail Station",51.6970695641,-0.1925817236
-"PBY","Pembrey & Burry Port Rail Station",51.6835326809,-4.2478649262
-"PCD","Pencoed Rail Station",51.5246083186,-3.5004926045
-"PCN","Paisley Canal Rail Station",55.8400708211,-4.4241022116
-"PDG","Padgate Rail Station",53.4058038948,-2.5568110117
-"PDW","Paddock Wood Rail Station",51.1822633724,0.3891775302
-"PEA","Peartree Rail Station",52.8970116224,-1.4732098615
-"PEB","Pevensey Bay Rail Station",50.8174539615,0.3429353987
-"PEG","Pegswood Rail Station",55.1781320707,-1.6441787746
-"PEM","Pemberton Rail Station",53.5304214463,-2.6703543304
-"PEN","Penarth Rail Station",51.4358873168,-3.1744496863
-"PER","Penrhiwceiber Rail Station",51.6699251561,-3.3599562105
-"PES","Pensarn (Gwynedd) Rail Station",52.8307204357,-4.1121665744
-"PET","Petts Wood Rail Station",51.3886176381,0.0745066346
-"PEV","Pevensey & Westham Rail Station",50.8157924588,0.3248360436
-"PEW","Pewsey Rail Station",51.342188386,-1.7706654384
-"PFL","Purfleet Rail Station",51.4810119817,0.2367953506
-"PFM","Pontefract Monkhill Rail Station",53.6990008028,-1.3036919442
-"PFR","Pontefract Baghill Rail Station",53.6918982987,-1.3033551435
-"PFY","Poulton-le-Fylde Rail Station",53.8484388445,-2.9906188413
-"PGM","Pengam Rail Station",51.6704563039,-3.2301095675
-"PGN","Paignton Rail Station",50.4347023859,-3.5648917612
-"PHG","Penhelig Rail Station",52.5457006306,-4.0350346008
-"PHR","Penshurst Rail Station",51.1973335413,0.1734986012
-"PIL","Pilning Rail Station",51.5566244695,-2.6271165239
-"PIN","Pinhoe Rail Station",50.7377726757,-3.469346888
-"PIT","Pitlochry Rail Station",56.7024883256,-3.7355677144
-"PKG","Penkridge Rail Station",52.723513524,-2.1192894969
-"PKS","Parkstone (Dorset) Rail Station",50.7229662137,-1.9479483493
-"PKT","Park Street Rail Station",51.7254616475,-0.3402531493
-"PLC","Pluckley Rail Station",51.1564699354,0.7474262223
-"PLD","Portslade Rail Station",50.8356743968,-0.2053088577
-"PLE","Pollokshields East Rail Station",55.8410609323,-4.2685885077
-"PLG","Polegate Rail Station",50.8212387544,0.2451683916
-"PLK","Plockton Rail Station",57.333539976,-5.6659881238
-"PLM","Plumley Rail Station",53.2746886444,-2.419660194
-"PLN","Portlethen Rail Station",57.0613593651,-2.1266196251
-"PLS","Pleasington Rail Station",53.7309724834,-2.5441212488
-"PLT","Pontlottyn Rail Station",51.7466343204,-3.2789665322
-"PLU","Plumstead Rail Station",51.4897937032,0.0842834892
-"PLW","Pollokshields West Rail Station",55.8376933127,-4.2757390394
-"PLY","Plymouth Rail Station",50.3778114758,-4.1433494979
-"PMA","Portsmouth Arms Rail Station",50.9569944809,-3.9506012138
-"PMB","Pembroke Rail Station",51.6729545258,-4.9060582576
-"PMD","Pembroke Dock Rail Station",51.693923213,-4.9380817217
+"MFF","Minffordd",52.926145345,-4.0849726521
+"MFH","Milford Haven",51.7149845991,-5.0410051649
+"MFL","Mount Florida",55.8265491352,-4.2611173526
+"MFT","Mansfield",53.1421177161,-1.1984319382
+"MGM","Metheringham",53.1389012206,-0.3914492699
+"MGN","Marston Green",52.4672018911,-1.7556002472
+"MHM","Merstham",51.2641512942,-0.1502004055
+"MHR","Market Harborough",52.4797370398,-0.9093194703
+"MHS","Meadowhall",53.4174828257,-1.4128516936
+"MIA","Manchester Airport",53.365056148,-2.2729784791
+"MIC","Micheldever",51.1823883025,-1.260662184
+"MIH","Mills Hill (Manchester)",53.5513245844,-2.1715108069
+"MIJ","Mitcham Junction",51.392947391,-0.1577313094
+"MIK","Micklefield",53.7888521389,-1.3267968915
+"MIL","Mill Hill Broadway",51.6130940209,-0.2492158407
+"MIM","Moreton-in-Marsh",51.9922896467,-1.700369111
+"MIN","Milliken Park",55.8251055368,-4.5333409179
+"MIR","Mirfield",53.6714142168,-1.6925478902
+"MIS","Mistley",51.9436415764,1.081430084
+"MKC","Milton Keynes Central",52.0342970583,-0.7741256561
+"MKM","Melksham",51.3798186441,-2.1444920323
+"MKR","Market Rasen",53.3839344671,-0.3369000957
+"MKT","Marks Tey",51.8809486375,0.7833551606
+"MLB","Millbrook (Beds)",52.0538457297,-0.5326807632
+"MLD","Mouldsworth",53.2318188478,-2.7322232144
+"MLF","Milford (Surrey)",51.1633133767,-0.6369282874
+"MLG","Mallaig",57.005965587,-5.8295792296
+"MLH","Mill Hill (Lancs)",53.7354717311,-2.5017331794
+"MLM","Millom",54.2108302797,-3.2710839419
+"MLN","Milngavie",55.9413575022,-4.3145648876
+"MLT","Malton",54.1320917413,-0.7972330574
+"MLW","Marlow",51.5709950142,-0.7664123608
+"MLY","Morley",53.7499375883,-1.5909802981
+"MMO","Melton Mowbray",52.7610494909,-0.8858623625
+"MNC","Markinch",56.201006454,-3.1307887208
+"MNE","Manea",52.4978548877,0.1777139789
+"MNG","Manningtree",51.9490620543,1.0452697914
+"MNN","Menston",53.8923520984,-1.7355135499
+"MNP","Manor Park",51.5524760236,0.0463682122
+"MNR","Manor Road",53.394793603,-3.1714362959
+"MNS", "Maghull North", 53.5167, -2.9213
+"MOB","Mobberley",53.3291537972,-2.3336642593
+"MOG","Moorgate",51.5184914149,-0.0889174169
+"MON","Monifieth",56.4801011269,-2.8182514848
+"MOO","Muir of Ord",57.5178284795,-4.460230876
+"MOR","Mortimer",51.3720775119,-1.0354903866
+"MOS","Moss Side",53.764988776,-2.9429318748
+"MOT","Motspur Park",51.3951937788,-0.2395071447
+"MPK","Mosspark",55.8408228806,-4.3482777791
+"MPL","Marple",53.4007069655,-2.0572623816
+"MPT","Morpeth",55.1623793108,-1.6830875765
+"MRB","Manorbier",51.6601657701,-4.7918631589
+"MRD","Morchard Road",50.831888433,-3.7763856573
+"MRF","Moorfields",53.408577563,-2.9891877739
+"MRN","Marden",51.1751727189,0.4931989357
+"MRP","Moorthorpe",53.5950120583,-1.3049494779
+"MRR","Morar",56.9696962652,-5.8218995718
+"MRS","Monks Risborough",51.7357654911,-0.8293110058
+"MRT","Moreton (Merseyside)",53.4072225806,-3.1134999967
+"MRW","Meridian Water", 51.61, -0.0501
+"MRY","Maryport",54.71132475,-3.4940750264
+"MSD","Moorside",53.516289171,-2.351797693
+"MSH","Mossley Hill",53.3790525198,-2.9154430601
+"MSK","Marske",54.5874288395,-1.0189249961
+"MSL","Mossley (Manchester)",53.5149938702,-2.0412799663
+"MSN","Marsden",53.6031989506,-1.9307489058
+"MSO","Moston",53.5234344757,-2.1710210757
+"MSR","Minster",51.3291791939,1.3172443102
+"MSS","Moses Gate",53.5559962598,-2.4011861486
+"MST","Maesteg",51.6099392672,-3.6546614792
+"MSW","Mansfield Woodhouse",53.1635798405,-1.201846595
+"MTA","Mountain Ash",51.6813336784,-3.3763534667
+"MTB","Matlock Bath",53.1223708532,-1.5567564386
+"MTC","Mitcham Eastfields",51.4077364814,-0.1546204515
+"MTG","Mottingham",51.4402167384,0.0500802261
+"MTH","Motherwell",55.7916692892,-3.9943169398
+"MTL","Mortlake",51.468085138,-0.2670827547
+"MTM","Martin Mill",51.1706839505,1.3482479873
+"MTN","Moreton (Dorset)",50.7010195625,-2.3134461541
+"MTO","Marton",54.5443541756,-1.1984988205
+"MTP","Montpelier",51.4683464285,-2.5886872075
+"MTS","Montrose",56.7127857624,-2.4720806987
+"MTV","Mount Vernon",55.84019612,-4.133656173
+"MUB","Musselburgh",55.9335850009,-3.0732054363
+"MUF","Manchester United FC",53.4622084856,-2.290652901
+"MUI","Muirend",55.8094528886,-4.274377937
+"MVL","Malvern Link",52.1254773107,-2.3195074315
+"MYB","London Marylebone",51.522523885,-0.1628859644
+"MYH","Maryhill",55.8976237197,-4.3007303486
+"MYL","Maryland",51.5460813657,0.005842588
+"MYT","Mytholmroyd",53.7290162532,-1.9814271564
+"MZH","Maze Hill",51.4826233713,0.0029400062
+"NAN","Nantwich",53.0635867383,-2.5189592102
+"NAR","Narberth",51.7993779002,-4.7272043319
+"NAY","Newton Aycliffe",54.6137111141,-1.5896555578
+"NBA","New Barnet",51.6485757882,-0.1729714788
+"NBC","New Beckenham",51.416767136,-0.0352474454
+"NBE","Newbridge",51.665815285,-3.1428939856
+"NBN","New Brighton",53.437415844,-3.0479632359
+"NBR","Narborough",52.5713097683,-1.2033367857
+"NBT","Norbiton",51.4123555216,-0.2840028162
+"NBW","North Berwick",56.0570302209,-2.7307472989
+"NBY","Newbury",51.397647103,-1.3228424921
+"NCE","New Clee",53.5744020885,-0.0608183009
+"NCK","New Cumnock",55.4027409338,-4.1843292426
+"NCL","Newcastle",54.9684070401,-1.6172925574
+"NCM","North Camp",51.2757921453,-0.731181183
+"NCO","Newcourt",50.7050286867,-3.4727977721
+"NCT","Newark Castle",53.080022402,-0.8131567694
+"NDL","North Dulwich",51.4545089621,-0.0878918236
+"NEG","Newtongrange",55.8669914004,-3.0693694316
+"NEH","New Eltham",51.4380580221,0.0705593927
+"NEI","Neilston",55.7830319543,-4.4269370486
+"NEL","Nelson",53.8350188567,-2.2137611849
+"NEM","New Malden",51.4040722425,-0.2559166562
+"NES","Neston",53.2918652932,-3.0630755474
+"NET","Netherfield",52.9614294437,-1.0798460669
+"NEW","Newcraighall",55.9331154017,-3.0908472906
+"NFA","North Fambridge",51.6485874442,0.6816868594
+"NFD","Northfield",52.408205022,-1.9658445265
+"NFL","Northfleet",51.4458444738,0.3243627291
+"NFN","Nafferton",54.0112409619,-0.3860877568
+"NGT","Newington",51.3533404814,0.6686002778
+"NHD","Nunhead",51.4668266219,-0.0522470725
+"NHE","New Hythe",51.3130005132,0.4549583652
+"NHL","New Holland",53.7019404883,-0.3602195506
+"NIT","Nitshill",55.8119290151,-4.3599440893
+"NLN","New Lane",53.611676421,-2.8677150822
+"NLR","North Llanrwst",53.1438364668,-3.8027318185
+"NLS","Nailsea & Backwell",51.4194043932,-2.750638165
+"NLT","Northolt Park",51.5575391716,-0.3594445305
+"NLW","Newton-le-Willows",53.4530749987,-2.6135973334
+"NMC","New Mills Central",53.3648560934,-2.0056703312
+"NMK","Newmarket",52.2379580874,0.4062358785
+"NMN","New Mills Newtown",53.3596424903,-2.0085245142
+"NMP","Northampton",52.2375139145,-0.906638854
+"NMT","Needham Market",52.1526036565,1.0552904861
+"NNG","Newark North Gate",53.0817767766,-0.7998511914
+"NNP","Ninian Park",51.4766151237,-3.2017026277
+"NNT","Nunthorpe",54.5278916561,-1.1694623307
+"NOA","Newton-on-Ayr",55.4740529017,-4.6258056575
+"NOR","Normanton",53.7005346086,-1.4234040424
+"NOT","Nottingham",52.9470929341,-1.1463789462
+"NPD","New Pudsey",53.8044975251,-1.6807968849
+"NQU","North Queensferry",56.0124941531,-3.394582615
+"NQY","Newquay",50.415084133,-5.0756989533
+"NRB","Norbury",51.4114439365,-0.1219000953
+"NRC","Newbury Racecourse",51.3984581516,-1.3077799439
+"NRD","North Road",54.5362092283,-1.5539587211
+"NRN","Nairn",57.5802287419,-3.871999953
+"NRT","Nethertown",54.4564242911,-3.5658366589
+"NRW","Norwich",52.6271764442,1.3068436175
+"NSB","Normans Bay",50.8260972868,0.3894907962
+"NSD","Newstead",53.0699991881,-1.221784818
+"NSG","New Southgate",51.6141146074,-0.1430125641
+"NSH","North Sheen",51.4651527407,-0.2878532427
+"NTA","Newton Abbot",50.5295709354,-3.5991818536
+"NTB","Norton Bridge",52.8667125875,-2.1905418489
+"NTC","Newton St Cyres",50.7789165834,-3.589404542
+"NTH","Neath",51.6623638663,-3.8072343482
+"NTL","Netley",50.8748975168,-1.3418931628
+"NTN","Newton (S Lanarks)",55.8187724129,-4.1330414607
+"NTR","Northallerton",54.3330824604,-1.4412825015
+"NUF","Nutfield",51.2268096258,-0.1325049602
+"NUM","Northumberland Park",51.6019688995,-0.0539069251
+"NUN","Nuneaton",52.5263860835,-1.4638662754
+"NUT","Nutbourne",50.8460585998,-0.8829282409
+"NVH","Newhaven Harbour",50.7897843615,0.0550205943
+"NVN","Newhaven Town",50.7948486315,0.0549731113
+"NVR","Navigation Road",53.3953905024,-2.3434169235
+"NWA","North Walsham",52.8169121918,1.3844751173
+"NWB","North Wembley",51.5625961704,-0.3039615425
+"NWD","Norwood Junction",51.397016964,-0.0751960155
+"NWE","Newport (Essex)",51.9798767674,0.2151664222
+"NWI","Northwich",53.2614653974,-2.4969157221
+"NWM","New Milton",50.7557417759,-1.657805844
+"NWN","Newton for Hyde",53.4563946328,-2.0671424184
+"NWP","Newport (S Wales)",51.5887891555,-3.0005496511
+"NWR","Newtonmore",57.0591301765,-4.1191037522
+"NWT","Newtown (Powys)",52.5123270805,-3.3113949158
+"NWX","New Cross ELL",51.4763425048,-0.0324150961
+"NXG","New Cross Gate ELL",51.4751271677,-0.0403876579
+"OBN","Oban",56.4124709629,-5.4739093886
+"OCK","Ockendon",51.5219914043,0.290497263
+"OHL","Old Hill",52.470947074,-2.0561848613
+"OKE","Okehampton",50.7323709771,-3.9962371646
+"OKL","Oakleigh Park",51.637679136,-0.1661837043
+"OKM","Oakham",52.6722323623,-0.7341607803
+"OKN","Oakengates",52.6934109391,-2.4501927064
+"OLD","Old Street",51.5258317895,-0.0885090187
+"OLF","Oldfield Park",51.3792256566,-2.3805068483
+"OLT","Olton",52.438524483,-1.8043032158
+"OLY","Ockley",51.1515064148,-0.3359877818
+"OMS","Ormskirk",53.56928696,-2.8811915199
+"OPK","Orrell Park",53.4619123452,-2.9633147359
+"OPY","Oxford Parkway",51.8040758686,-1.2744681129
+"ORE","Ore",50.8669427332,0.591596612
+"ORN","Old Roan",53.4869093953,-2.9510705094
+"ORP","Orpington",51.3732951318,0.0891167615
+"ORR","Orrell",53.530325904,-2.7088376683
+"OTF","Otford",51.313155145,0.1968058758
+"OUN","Oulton Broad North",52.4777844841,1.7157356055
+"OUS","Oulton Broad South",52.4696271149,1.7076837204
+"OUT","Outwood",53.7153018923,-1.5104034645
+"OVE","Overpool",53.2840618342,-2.9240604888
+"OVR","Overton",51.2542901889,-1.2592504239
+"OXF","Oxford",51.753499533,-1.2701353856
+"OXN","Oxenholme Lake District",54.3049347745,-2.7218718643
+"OXS","Oxshott",51.3363929984,-0.3623961961
+"OXT","Oxted",51.2579045834,-0.0048073736
+"PAD","London Paddington",51.515995347,-0.1761493939
+"PAL","Palmers Green",51.6183152407,-0.1104116731
+"PAN","Pangbourne",51.4854011729,-1.0904500754
+"PAR","Par",50.3553115511,-4.7047163536
+"PAT","Patricroft",53.4847921621,-2.3582432532
+"PBL","Parbold",53.5907686118,-2.7707477548
+"PBO","Peterborough",52.5749924034,-0.2498227798
+"PBR","Potters Bar",51.6970695641,-0.1925817236
+"PBY","Pembrey & Burry Port",51.6835326809,-4.2478649262
+"PCD","Pencoed",51.5246083186,-3.5004926045
+"PCN","Paisley Canal",55.8400708211,-4.4241022116
+"PDG","Padgate",53.4058038948,-2.5568110117
+"PDW","Paddock Wood",51.1822633724,0.3891775302
+"PEA","Peartree",52.8970116224,-1.4732098615
+"PEB","Pevensey Bay",50.8174539615,0.3429353987
+"PEG","Pegswood",55.1781320707,-1.6441787746
+"PEM","Pemberton",53.5304214463,-2.6703543304
+"PEN","Penarth",51.4358873168,-3.1744496863
+"PER","Penrhiwceiber",51.6699251561,-3.3599562105
+"PES","Pensarn (Gwynedd)",52.8307204357,-4.1121665744
+"PET","Petts Wood",51.3886176381,0.0745066346
+"PEV","Pevensey & Westham",50.8157924588,0.3248360436
+"PEW","Pewsey",51.342188386,-1.7706654384
+"PFL","Purfleet",51.4810119817,0.2367953506
+"PFM","Pontefract Monkhill",53.6990008028,-1.3036919442
+"PFR","Pontefract Baghill",53.6918982987,-1.3033551435
+"PFY","Poulton-le-Fylde",53.8484388445,-2.9906188413
+"PGM","Pengam",51.6704563039,-3.2301095675
+"PGN","Paignton",50.4347023859,-3.5648917612
+"PHG","Penhelig",52.5457006306,-4.0350346008
+"PHR","Penshurst",51.1973335413,0.1734986012
+"PIL","Pilning",51.5566244695,-2.6271165239
+"PIN","Pinhoe",50.7377726757,-3.469346888
+"PIT","Pitlochry",56.7024883256,-3.7355677144
+"PKG","Penkridge",52.723513524,-2.1192894969
+"PKS","Parkstone (Dorset)",50.7229662137,-1.9479483493
+"PKT","Park Street",51.7254616475,-0.3402531493
+"PLC","Pluckley",51.1564699354,0.7474262223
+"PLD","Portslade",50.8356743968,-0.2053088577
+"PLE","Pollokshields East",55.8410609323,-4.2685885077
+"PLG","Polegate",50.8212387544,0.2451683916
+"PLK","Plockton",57.333539976,-5.6659881238
+"PLM","Plumley",53.2746886444,-2.419660194
+"PLN","Portlethen",57.0613593651,-2.1266196251
+"PLS","Pleasington",53.7309724834,-2.5441212488
+"PLT","Pontlottyn",51.7466343204,-3.2789665322
+"PLU","Plumstead",51.4897937032,0.0842834892
+"PLW","Pollokshields West",55.8376933127,-4.2757390394
+"PLY","Plymouth",50.3778114758,-4.1433494979
+"PMA","Portsmouth Arms",50.9569944809,-3.9506012138
+"PMB","Pembroke",51.6729545258,-4.9060582576
+"PMD","Pembroke Dock",51.693923213,-4.9380817217
 "PMG","Porthmadog Harbour Ffestiniog Railway Station",52.9240544206,-4.1268252563
-"PMH","Portsmouth Harbour Rail Station",50.7969498727,-1.1078273211
-"PMP","Plumpton Rail Station",50.9286565684,-0.0601544007
-"PMR","Peckham Rye Rail Station",51.470033016,-0.0693887302
-"PMS","Portsmouth & Southsea Rail Station",50.7984827623,-1.0908977098
-"PMT","Polmont Rail Station",55.9847314785,-3.7149654171
-"PMW","Penmaenmawr Rail Station",53.2704805077,-3.9235150995
-"PNA","Penally Rail Station",51.6589262669,-4.7220868534
-"PNE","Penge East Rail Station",51.4193314862,-0.0541945966
-"PNF","Penyffordd Rail Station",53.1431032633,-3.0548384851
-"PNL","Pannal Rail Station",53.9583379183,-1.5334728227
-"PNM","Penmere Rail Station",50.1503163602,-5.0832395818
-"PNR","Penrith North Lakes Rail Station",54.6618111812,-2.7588851525
-"PNS","Penistone Rail Station",53.5255620634,-1.6227817865
-"PNW","Penge West Rail Station",51.4175527378,-0.060813969
-"PNY","Pen-y-Bont Rail Station",52.2739523227,-3.3219364345
-"PNZ","Penzance Rail Station",50.1216622978,-5.5326194274
-"POK","Pokesdown Rail Station",50.7310753298,-1.8250944808
-"POL","Polsloe Bridge Rail Station",50.7312683809,-3.5019615191
-"PON","Ponders End Rail Station",51.642255947,-0.0350543162
-"POO","Poole Rail Station",50.7194165218,-1.9833107381
-"POP","Poppleton Rail Station",53.9759137087,-1.1486052224
-"POR","Porth Rail Station",51.6125376458,-3.4071988908
-"POT","Pontefract Tanshelf Rail Station",53.6941449221,-1.3189173719
-"PPD","Pontypridd Rail Station",51.5993702973,-3.3413865323
-"PPK","Possilpark & Parkhouse Rail Station",55.8901379173,-4.2584986291
-"PPL","Pontypool & New Inn Rail Station",51.6979651222,-3.0142431288
-"PRA","Prestwick Intl Airport Rail Station",55.5090345152,-4.6141499438
-"PRB","Prestbury Rail Station",53.2933984529,-2.1454808763
-"PRE","Preston Rail Station",53.7568736745,-2.7081248286
-"PRH","Penrhyndeudraeth Rail Station",52.9288395107,-4.0645697821
-"PRL","Prittlewell Rail Station",51.5506897273,0.7107053733
-"PRN","Parton Rail Station",54.5703745223,-3.5808010214
-"PRP","Preston Park Rail Station",50.8459365038,-0.1551401939
-"PRR","Princes Risborough Rail Station",51.717862811,-0.8438584339
-"PRS","Prees Rail Station",52.8993178144,-2.6896604773
-"PRT","Prestatyn Rail Station",53.3365131812,-3.4071329997
-"PRU","Prudhoe Rail Station",54.9658336963,-1.8648762701
-"PRW","Perranwell Rail Station",50.2165660708,-5.1121161477
-"PRY","Perry Barr Rail Station",52.5164989542,-1.9019553886
-"PSC","Prescot Rail Station",53.4235727522,-2.7991706418
-"PSE","Pitsea Rail Station",51.5603607427,0.5063210544
-"PSH","Pershore Rail Station",52.1305654583,-2.071529789
-"PSL","Port Sunlight Rail Station",53.3492661166,-2.9980290994
-"PSN","Parson Street Rail Station",51.4333162228,-2.6077452159
-"PST","Prestonpans Rail Station",55.9530925088,-2.9747721637
-"PSW","Polesworth Rail Station",52.6258478025,-1.6105322867
-"PTA","Port Talbot Parkway Rail Station",51.5917198989,-3.7813309651
-"PTB","Pentre-Bach Rail Station",51.7250170652,-3.3623321925
-"PTC","Portchester Rail Station",50.8487383979,-1.1242258208
-"PTD","Pontarddulais Rail Station",51.717625303,-4.0455653141
-"PTF","Pantyffynnon Rail Station",51.7788828692,-3.997449154
-"PTG","Port Glasgow Rail Station",55.9335070293,-4.6898064686
-"PTH","Perth Rail Station",56.3920836665,-3.439696225
-"PTK","Partick Rail Station",55.8698812708,-4.3087915388
-"PTL","Priesthill & Darnley Rail Station",55.8121655063,-4.3428803656
-"PTM","Porthmadog Rail Station",52.9309305535,-4.1344534631
-"PTR","Petersfield Rail Station",51.0067187319,-0.941119933
-"PTT","Patterton Rail Station",55.7906049425,-4.335284571
-"PTW","Prestwick Rail Station",55.5016967612,-4.6151361015
-"PUL","Pulborough Rail Station",50.957350444,-0.5165342741
-"PUO","Purley Oaks Rail Station",51.347043203,-0.0988301854
-"PUR","Purley Rail Station",51.3375762777,-0.1140096477
-"PUT","Putney Rail Station",51.4613011865,-0.2164509784
-"PWE","Pollokshaws East Rail Station",55.8246345854,-4.2868710374
-"PWL","Pwllheli Rail Station",52.8878498612,-4.4167062643
-"PWW","Pollokshaws West Rail Station",55.8238204955,-4.3015915299
-"PWY","Patchway Rail Station",51.5259301005,-2.5626913928
-"PYC","Pontyclun Rail Station",51.523767301,-3.3929297459
-"PYE","Pye Corner Rail Station",51.581475726,-3.0412190166
-"PYG","Paisley Gilmour Street Rail Station",55.8473432284,-4.4244912616
-"PYJ","Paisley St James Rail Station",55.8521114555,-4.4424274654
-"PYL","Pyle Rail Station",51.5257356235,-3.6980690341
-"PYN","Penryn Rail Station",50.1706984329,-5.111654776
-"PYP","Pont-y-Pant Rail Station",53.0651459792,-3.8627254729
-"PYT","Poynton Rail Station",53.350399608,-2.1344099238
-"QBR","Queenborough Rail Station",51.4156380311,0.7496958334
-"QPK","Queens Park (Glasgow) Rail Station",55.8352982505,-4.26673566
-"QPW","Queens Park (London) Rail Station",51.5339663794,-0.2049603036
-"QRB","Queenstown Road (Battersea) Rail Station",51.4749670081,-0.146653366
-"QRP","Queens Road Peckham Rail Station",51.4735650429,-0.057287956
-"QUI","Quintrell Downs Rail Station",50.404043309,-5.0285359493
-"QYD","Quakers Yard Rail Station",51.6607282285,-3.3228133757
-"RAD","Radley Rail Station",51.6862085244,-1.2404640226
-"RAI","Rainham (Kent) Rail Station",51.3663043788,0.6113657109
-"RAM","Ramsgate Rail Station",51.3408101248,1.4064935542
-"RAN","Rannoch Rail Station",56.6860287779,-4.5768596363
-"RAU","Rauceby Rail Station",52.9852250505,-0.4566002495
-"RAV","Ravenglass Rail Station",54.355714451,-3.4088152992
-"RAY","Raynes Park Rail Station",51.4091709872,-0.2301271492
-"RBR","Robertsbridge Rail Station",50.9849282663,0.468811527
-"RBS","British Steel Redcar Rail Station",54.6099002966,-1.1126759256
-"RBU","Reading Rail Station",51.4581455251,-0.9716410129
-"RCA","Risca & Pontymister Rail Station",51.6058480469,-3.0922175896
-"RCC","Redcar Central Rail Station",54.6162371859,-1.0708827236
-"RCD","Rochdale Rail Station",53.6103213876,-2.1535226045
-"RCE","Redcar East Rail Station",54.6092632648,-1.0523074152
-"RDA","Redland Rail Station",51.4683833784,-2.5991255269
-"RDB","Redbridge (Hants) Rail Station",50.919929763,-1.4701514648
-"RDC","Redditch Rail Station",52.3063386466,-1.9452414363
-"RDD","Riddlesdown Rail Station",51.3324835004,-0.0993606073
-"RDF","Radcliffe (Notts) Rail Station",52.948803948,-1.0373248467
-"RDG","Reading Rail Station",51.4587857311,-0.9718425502
-"RDH","Redhill Rail Station",51.2401977624,-0.1658743282
-"RDM","Riding Mill Rail Station",54.9487414454,-1.9715645429
-"RDN","Reddish North Rail Station",53.4494263145,-2.1562533084
-"RDR","Radyr Rail Station",51.5163222796,-3.2483627755
-"RDS","Reddish South Rail Station",53.4359402108,-2.15876271
-"RDT","Radlett Rail Station",51.6851911564,-0.3172197627
-"RDW","Reading West Rail Station",51.4555007173,-0.9901085456
-"REC","Rectory Road Rail Station",51.5585021691,-0.0682408077
-"RED","Redruth Rail Station",50.2332412948,-5.2259636066
-"REE","Reedham (Norfolk) Rail Station",52.5645273067,1.5596750305
-"REI","Reigate Rail Station",51.241955247,-0.2037998793
-"REL","Retford Low Level Rail Station",53.314084796,-0.944772788
-"RET","Retford Rail Station",53.3151729691,-0.9478832051
-"RFD","Rochford Rail Station",51.5817322678,0.7023320206
-"RFY","Rock Ferry Rail Station",53.3726649286,-3.0108263238
-"RGL","Rugeley Trent Valley Rail Station",52.7696708266,-1.9298468285
-"RGT","Rugeley Town Rail Station",52.7543925458,-1.9368345411
-"RGW","Ramsgreave & Wilpshire Rail Station",53.7797887472,-2.4781340362
-"RHD","Ribblehead Rail Station",54.2058547832,-2.3608596376
-"RHI","Rhiwbina Rail Station",51.5211795118,-3.2139748912
-"RHL","Rhyl Rail Station",53.3184382534,-3.4891071986
-"RHM","Reedham (Surrey) Rail Station",51.3311168831,-0.1233901081
-"RHO","Rhosneigr Rail Station",53.234853792,-4.5066484672
-"RHY","Rhymney Rail Station",51.7588400163,-3.2893087685
-"RIA","Rhoose Rail Station",51.3870636406,-3.3493952024
-"RIC","Rickmansworth Rail Station",51.6402484957,-0.4732613263
-"RID","Ridgmont Rail Station",52.0264115351,-0.5945346786
-"RIL","Rice Lane Rail Station",53.4577855134,-2.9623176912
-"RIS","Rishton Rail Station",53.7638280488,-2.4201573255
-"RKT","Ruskington Rail Station",53.0414843853,-0.3807571306
-"RLG","Rayleigh Rail Station",51.5892966358,0.6000099485
-"RLN","Rowlands Castle Rail Station",50.8921618565,-0.9574550113
-"RMB","Roman Bridge Rail Station",53.0444294912,-3.9216535234
-"RMC","Rotherham Central Rail Station",53.4322702249,-1.3604360441
-"RMD","Richmond (London) Rail Station",51.4630586084,-0.3015359438
-"RMF","Romford Rail Station",51.5748295085,0.1832643102
-"RML","Romiley Rail Station",53.4140264045,-2.0893251906
-"RNF","Rainford Rail Station",53.5171200074,-2.7894686817
-"RNH","Rainhill Rail Station",53.4171359422,-2.7663996705
-"RNM","Rainham (London) Rail Station",51.5167228766,0.1906626283
-"RNR","Roughton Road Rail Station",52.9180468243,1.2998131699
-"ROB","Roby Rail Station",53.4100553223,-2.8559333314
-"ROC","Roche Rail Station",50.4185298804,-4.8302395116
-"ROE","Rotherhithe Rail Station",51.5008159021,-0.0520222921
-"ROG","Rogart Rail Station",57.9886951233,-4.1581880614
-"ROL","Rolleston Rail Station",53.0653022003,-0.8996705436
-"ROM","Romsey Rail Station",50.992520078,-1.4931337195
-"ROO","Roose Rail Station",54.115171803,-3.1945656127
-"ROR","Rogerstone Rail Station",51.595617413,-3.0666186229
-"ROS","Rosyth Rail Station",56.0455112188,-3.4273031727
-"ROW","Rowley Regis Rail Station",52.4773392229,-2.0308690726
-"RRB","Ryder Brow Rail Station",53.4565936753,-2.1730866723
-"RSG","Rose Grove Rail Station",53.786206105,-2.2827968156
-"RSH","Rose Hill Marple Rail Station",53.3962378581,-2.0765205539
-"RTN","Renton Rail Station",55.9704230841,-4.5861084015
-"RTR","Rochester Rail Station",51.385547102,0.5103102845
-"RUA","Ruabon Rail Station",52.9871483927,-3.0431380968
-"RUE","Runcorn East Rail Station",53.3275817336,-2.6656977069
-"RUF","Rufford Rail Station",53.6344771165,-2.8078404066
-"RUG","Rugby Rail Station",52.379109602,-1.2504711992
-"RUN","Runcorn Rail Station",53.3387090613,-2.7392524151
-"RUS","Ruswarp Rail Station",54.4702038934,-0.6277880896
-"RUT","Rutherglen Rail Station",55.8305867225,-4.2120903916
-"RVB","Ravensbourne Rail Station",51.4141860649,-0.0075306056
-"RVN","Ravensthorpe Rail Station",53.6755379752,-1.6555824307
-"RWC","Rawcliffe Rail Station",53.689059382,-0.9608672824
-"RYB","Roy Bridge Rail Station",56.8883464006,-4.837231331
-"RYD","Ryde Esplanade Rail Station",50.732855472,-1.1596052649
-"RYE","Rye Rail Station",50.9523651368,0.7307262415
-"RYH","Rye House Rail Station",51.7694168549,0.0056554285
-"RYN","Roydon Rail Station",51.7754907565,0.0362787847
-"RYP","Ryde Pier Head Rail Station",50.7391721946,-1.160115731
-"RYR","Ryde St Johns Road Rail Station",50.7243531538,-1.1565554546
-"RYS","Royston Rail Station",52.0530886425,-0.0268926227
-"SAA","St Albans Abbey Rail Station",51.7447373797,-0.3425457907
-"SAB","Smallbrook Junction Rail Station",50.7110892621,-1.1541879058
-"SAC","St Albans City Rail Station",51.7504771115,-0.3275149609
-"SAD","Sandwell & Dudley Rail Station",52.508672806,-2.0115900516
-"SAE","Saltaire Rail Station",53.8385061525,-1.7904830974
-"SAF","Salfords (Surrey) Rail Station",51.2017437324,-0.1624625843
-"SAH","Salhouse Rail Station",52.6755989185,1.3914382836
-"SAJ","St Johns (London) Rail Station",51.4693892196,-0.0226931111
-"SAL","Salisbury Rail Station",51.0705407298,-1.8063773738
-"SAM","Saltmarshe Rail Station",53.721943052,-0.8094903376
-"SAN","Sandown Rail Station",50.6568577497,-1.1623772447
-"SAR","St Andrews Road Rail Station",51.5127676823,-2.6963176571
-"SAS","St Annes-on-the-Sea Rail Station",53.7530450492,-3.0290965047
-"SAT","South Acton Rail Station",51.4996944038,-0.2701346279
-"SAU","St Austell Rail Station",50.3395021406,-4.7894011447
-"SAV","Stratford-upon-Avon Rail Station",52.1942606452,-1.7162794479
-"SAW","Sawbridgeworth Rail Station",51.8143528887,0.1604379052
-"SAX","Saxmundham Rail Station",52.2149132591,1.4901964806
-"SAY","Swanley Rail Station",51.3933848234,0.1692513064
-"SBE","Starbeck Rail Station",53.9990126023,-1.5011353743
-"SBF","St Budeaux Ferry Road Rail Station",50.4013767558,-4.1868416838
-"SBJ","Stourbridge Junction Rail Station",52.4475544797,-2.1338704963
-"SBK","South Bank Rail Station",54.5838411607,-1.1766809553
-"SBM","South Bermondsey Rail Station",51.4881347391,-0.0546518416
-"SBP","Stonebridge Park Rail Station",51.5441109985,-0.2758051183
-"SBR","Spean Bridge Rail Station",56.889995674,-4.921595255
-"SBS","St Bees Rail Station",54.4925405036,-3.5911492633
-"SBT","Stourbridge Town Rail Station",52.455591256,-2.1418120086
-"SBU","Southbury Rail Station",51.6487058202,-0.0524104286
-"SBV","St Budeaux Victoria Road Rail Station",50.4019952477,-4.1874330909
-"SBY","Selby Rail Station",53.7828026439,-1.063791006
-"SCA","Scarborough Rail Station",54.2798078946,-0.4057198208
-"SCF","Stechford Rail Station",52.4848336609,-1.81101967
-"SCG","Stone Crossing Rail Station",51.4513283183,0.2637992585
-"SCH","Scotstounhill Rail Station",55.88513372,-4.3528726659
-"SCR","St Columb Road Rail Station",50.3986945398,-4.9407987491
-"SCS","Starcross Rail Station",50.6277843819,-3.4477177832
-"SCT","Scotscalder Rail Station",58.4829756671,-3.5520574676
-"SCU","Scunthorpe Rail Station",53.5861949288,-0.6509843133
-"SCY","South Croydon Rail Station",51.3629626314,-0.0934308139
-"SDA","Snodland Rail Station",51.3302285584,0.4482700817
-"SDB","Sandbach Rail Station",53.1501833523,-2.3935053074
-"SDC","Shoreditch High Street Rail Station",51.5233750963,-0.0752198072
-"SDE","Shadwell Rail Station",51.5112835169,-0.0569079056
-"SDF","Saundersfoot Rail Station",51.7220987761,-4.7166131873
-"SDG","Sandling Rail Station",51.09037099,1.0660749872
-"SDH","Sudbury Hill Harrow Rail Station",51.558465264,-0.3357809724
-"SDL","Sandhills Rail Station",53.4299516422,-2.9914899197
-"SDM","Shieldmuir Rail Station",55.7774860976,-3.9569803961
-"SDN","St Denys Rail Station",50.9221787802,-1.3877499436
-"SDP","Sandplace Rail Station",50.3867379699,-4.4645157634
-"SDR","Saunderton Rail Station",51.6759048289,-0.8254472358
-"SDW","Sandwich Rail Station",51.2699092555,1.3425965892
-"SDY","Sandy Rail Station",52.1247435871,-0.281167619
-"SEA","Seaham Rail Station",54.839061911,-1.3463511926
-"SEB","Seaburn Rail Station",54.929542046,-1.3867070759
-"SEC","Seaton Carew Rail Station",54.6583208071,-1.2004437475
-"SED","Shelford (Cambs) Rail Station",52.1488379665,0.1400093409
-"SEE","Southease Rail Station",50.8312579508,0.0306695579
-"SEF","Seaford Rail Station",50.7728366774,0.100161285
-"SEG","Selling Rail Station",51.2773559024,0.9409001439
-"SEH","Shoreham (Kent) Rail Station",51.3322156624,0.1889169828
-"SEL","Sellafield Rail Station",54.4165930704,-3.5104560059
-"SEM","Seamer Rail Station",54.2407682264,-0.4170454656
-"SEN","Shenstone Rail Station",52.6393741914,-1.8441949254
-"SER","St Erth Rail Station",50.1704799545,-5.4443040887
-"SES","South Elmsall Rail Station",53.594624192,-1.2848611415
-"SET","Settle Rail Station",54.0669251994,-2.2807172129
-"SEV","Sevenoaks Rail Station",51.2768624115,0.1816963041
-"SFA","Stratford International Rail Station",51.5448283609,-0.0087499388
-"SFD","Salford Central Rail Station",53.4830977645,-2.2548383451
-"SFI","Shawfair Rail Station",55.9199329881,-3.0787162657
-"SFL","Seaforth & Litherland Rail Station",53.4662829283,-3.0056221352
-"SFN","Shifnal Rail Station",52.6660843703,-2.3718373899
-"SFO","Stanford-le-Hope Rail Station",51.5143632423,0.4230666756
-"SFR","Shalford (Surrey) Rail Station",51.2143177182,-0.5667825878
-"SGB","Smethwick Galton Bridge Rail Station",52.5017945032,-1.9805048854
-"SGL","South Gyle Rail Station",55.9363467134,-3.2994753799
-"SGM","St Germans Rail Station",50.3942591741,-4.3084363092
-"SGN","South Greenford Rail Station",51.5337487794,-0.3366818438
-"SGR","Slade Green Rail Station",51.4677848035,0.19051795
-"SHB","Shirebrook Rail Station",53.20425967,-1.2024390578
-"SHC","Streethouse Rail Station",53.6761699951,-1.4001215054
-"SHD","Shildon Rail Station",54.6261726082,-1.6366159332
-"SHE","Sherborne Rail Station",50.9440137558,-2.5130735512
-"SHF","Sheffield Rail Station",53.3782362148,-1.4621101656
-"SHH","Shirehampton Rail Station",51.4843469177,-2.6792781047
-"SHI","Shiplake Rail Station",51.5114625615,-0.8825832762
-"SHJ","St Helens Junction Rail Station",53.4337400237,-2.7002586912
-"SHL","Shawlands Rail Station",55.8292064055,-4.2923288907
-"SHM","Sheringham Rail Station",52.9414541496,1.2103377731
-"SHN","Shanklin Rail Station",50.633896807,-1.1798245747
-"SHO","Sholing Rail Station",50.896742165,-1.3649055402
-"SHP","Shepperton Rail Station",51.3968021836,-0.4467657574
-"SHR","Shrewsbury Rail Station",52.7119413175,-2.749759506
-"SHS","Shotts Rail Station",55.81864295,-3.7983094064
-"SHT","Shotton Rail Station",53.2125551564,-3.0384238251
-"SHU","Stonehouse Rail Station",51.7458905703,-2.2794958307
+"PMH","Portsmouth Harbour",50.7969498727,-1.1078273211
+"PMP","Plumpton",50.9286565684,-0.0601544007
+"PMR","Peckham Rye",51.470033016,-0.0693887302
+"PMS","Portsmouth & Southsea",50.7984827623,-1.0908977098
+"PMT","Polmont",55.9847314785,-3.7149654171
+"PMW","Penmaenmawr",53.2704805077,-3.9235150995
+"PNA","Penally",51.6589262669,-4.7220868534
+"PNE","Penge East",51.4193314862,-0.0541945966
+"PNF","Penyffordd",53.1431032633,-3.0548384851
+"PNL","Pannal",53.9583379183,-1.5334728227
+"PNM","Penmere",50.1503163602,-5.0832395818
+"PNR","Penrith North Lakes",54.6618111812,-2.7588851525
+"PNS","Penistone",53.5255620634,-1.6227817865
+"PNW","Penge West",51.4175527378,-0.060813969
+"PNY","Pen-y-Bont",52.2739523227,-3.3219364345
+"PNZ","Penzance",50.1216622978,-5.5326194274
+"POK","Pokesdown",50.7310753298,-1.8250944808
+"POL","Polsloe Bridge",50.7312683809,-3.5019615191
+"PON","Ponders End",51.642255947,-0.0350543162
+"POO","Poole",50.7194165218,-1.9833107381
+"POP","Poppleton",53.9759137087,-1.1486052224
+"POR","Porth",51.6125376458,-3.4071988908
+"POT","Pontefract Tanshelf",53.6941449221,-1.3189173719
+"PPD","Pontypridd",51.5993702973,-3.3413865323
+"PPK","Possilpark & Parkhouse",55.8901379173,-4.2584986291
+"PPL","Pontypool & New Inn",51.6979651222,-3.0142431288
+"PRA","Prestwick Intl Airport",55.5090345152,-4.6141499438
+"PRB","Prestbury",53.2933984529,-2.1454808763
+"PRE","Preston",53.7568736745,-2.7081248286
+"PRI","Portway Park and Ride",51.488611,-2.688056
+"PRH","Penrhyndeudraeth",52.9288395107,-4.0645697821
+"PRL","Prittlewell",51.5506897273,0.7107053733
+"PRN","Parton",54.5703745223,-3.5808010214
+"PRP","Preston Park",50.8459365038,-0.1551401939
+"PRR","Princes Risborough",51.717862811,-0.8438584339
+"PRS","Prees",52.8993178144,-2.6896604773
+"PRT","Prestatyn",53.3365131812,-3.4071329997
+"PRU","Prudhoe",54.9658336963,-1.8648762701
+"PRW","Perranwell",50.2165660708,-5.1121161477
+"PRY","Perry Barr",52.5164989542,-1.9019553886
+"PSC","Prescot",53.4235727522,-2.7991706418
+"PSE","Pitsea",51.5603607427,0.5063210544
+"PSH","Pershore",52.1305654583,-2.071529789
+"PSL","Port Sunlight",53.3492661166,-2.9980290994
+"PSN","Parson Street",51.4333162228,-2.6077452159
+"PST","Prestonpans",55.9530925088,-2.9747721637
+"PSW","Polesworth",52.6258478025,-1.6105322867
+"PTA","Port Talbot Parkway",51.5917198989,-3.7813309651
+"PTB","Pentre-Bach",51.7250170652,-3.3623321925
+"PTC","Portchester",50.8487383979,-1.1242258208
+"PTD","Pontarddulais",51.717625303,-4.0455653141
+"PTF","Pantyffynnon",51.7788828692,-3.997449154
+"PTG","Port Glasgow",55.9335070293,-4.6898064686
+"PTH","Perth",56.3920836665,-3.439696225
+"PTK","Partick",55.8698812708,-4.3087915388
+"PTL","Priesthill & Darnley",55.8121655063,-4.3428803656
+"PTM","Porthmadog",52.9309305535,-4.1344534631
+"PTR","Petersfield",51.0067187319,-0.941119933
+"PTT","Patterton",55.7906049425,-4.335284571
+"PTW","Prestwick",55.5016967612,-4.6151361015
+"PUL","Pulborough",50.957350444,-0.5165342741
+"PUO","Purley Oaks",51.347043203,-0.0988301854
+"PUR","Purley",51.3375762777,-0.1140096477
+"PUT","Putney",51.4613011865,-0.2164509784
+"PWE","Pollokshaws East",55.8246345854,-4.2868710374
+"PWL","Pwllheli",52.8878498612,-4.4167062643
+"PWW","Pollokshaws West",55.8238204955,-4.3015915299
+"PWY","Patchway",51.5259301005,-2.5626913928
+"PYC","Pontyclun",51.523767301,-3.3929297459
+"PYE","Pye Corner",51.581475726,-3.0412190166
+"PYG","Paisley Gilmour Street",55.8473432284,-4.4244912616
+"PYJ","Paisley St James",55.8521114555,-4.4424274654
+"PYL","Pyle",51.5257356235,-3.6980690341
+"PYN","Penryn",50.1706984329,-5.111654776
+"PYP","Pont-y-Pant",53.0651459792,-3.8627254729
+"PYT","Poynton",53.350399608,-2.1344099238
+"QBR","Queenborough",51.4156380311,0.7496958334
+"QPK","Queens Park (Glasgow)",55.8352982505,-4.26673566
+"QPW","Queens Park (London)",51.5339663794,-0.2049603036
+"QRB","Queenstown Road (Battersea)",51.4749670081,-0.146653366
+"QRP","Queens Road Peckham",51.4735650429,-0.057287956
+"QUI","Quintrell Downs",50.404043309,-5.0285359493
+"QYD","Quakers Yard",51.6607282285,-3.3228133757
+"RAD","Radley",51.6862085244,-1.2404640226
+"RAI","Rainham (Kent)",51.3663043788,0.6113657109
+"RAM","Ramsgate",51.3408101248,1.4064935542
+"RAN","Rannoch",56.6860287779,-4.5768596363
+"RAU","Rauceby",52.9852250505,-0.4566002495
+"RAV","Ravenglass",54.355714451,-3.4088152992
+"RAY","Raynes Park",51.4091709872,-0.2301271492
+"RBR","Robertsbridge",50.9849282663,0.468811527
+"RBS","British Steel Redcar",54.6099002966,-1.1126759256
+"RBU","Reading",51.4581455251,-0.9716410129
+"RCA","Risca & Pontymister",51.6058480469,-3.0922175896
+"RCC","Redcar Central",54.6162371859,-1.0708827236
+"RCD","Rochdale",53.6103213876,-2.1535226045
+"RCE","Redcar East",54.6092632648,-1.0523074152
+"RDA","Redland",51.4683833784,-2.5991255269
+"RDB","Redbridge (Hants)",50.919929763,-1.4701514648
+"RDC","Redditch",52.3063386466,-1.9452414363
+"RDD","Riddlesdown",51.3324835004,-0.0993606073
+"RDF","Radcliffe (Notts)",52.948803948,-1.0373248467
+"RDG","Reading",51.4587857311,-0.9718425502
+"RDH","Redhill",51.2401977624,-0.1658743282
+"RDM","Riding Mill",54.9487414454,-1.9715645429
+"RDN","Reddish North",53.4494263145,-2.1562533084
+"RDR","Radyr",51.5163222796,-3.2483627755
+"RDS","Reddish South",53.4359402108,-2.15876271
+"RDT","Radlett",51.6851911564,-0.3172197627
+"RDW","Reading West",51.4555007173,-0.9901085456
+"REC","Rectory Road",51.5585021691,-0.0682408077
+"RED","Redruth",50.2332412948,-5.2259636066
+"REE","Reedham (Norfolk)",52.5645273067,1.5596750305
+"REI","Reigate",51.241955247,-0.2037998793
+"REL","Retford Low Level",53.314084796,-0.944772788
+"RET","Retford",53.3151729691,-0.9478832051
+"RFD","Rochford",51.5817322678,0.7023320206
+"RFY","Rock Ferry",53.3726649286,-3.0108263238
+"RGL","Rugeley Trent Valley",52.7696708266,-1.9298468285
+"RGP","Reading Green Park",51.426667,-1.001389
+"RGT","Rugeley Town",52.7543925458,-1.9368345411
+"RGW","Ramsgreave & Wilpshire",53.7797887472,-2.4781340362
+"RHD","Ribblehead",54.2058547832,-2.3608596376
+"RHI","Rhiwbina",51.5211795118,-3.2139748912
+"RHL","Rhyl",53.3184382534,-3.4891071986
+"RHM","Reedham (Surrey)",51.3311168831,-0.1233901081
+"RHO","Rhosneigr",53.234853792,-4.5066484672
+"RHY","Rhymney",51.7588400163,-3.2893087685
+"RIA","Rhoose",51.3870636406,-3.3493952024
+"RIC","Rickmansworth",51.6402484957,-0.4732613263
+"RID","Ridgmont",52.0264115351,-0.5945346786
+"RIL","Rice Lane",53.4577855134,-2.9623176912
+"RIS","Rishton",53.7638280488,-2.4201573255
+"RKT","Ruskington",53.0414843853,-0.3807571306
+"RLG","Rayleigh",51.5892966358,0.6000099485
+"RLN","Rowlands Castle",50.8921618565,-0.9574550113
+"RMB","Roman Bridge",53.0444294912,-3.9216535234
+"RMC","Rotherham Central",53.4322702249,-1.3604360441
+"RMD","Richmond (London)",51.4630586084,-0.3015359438
+"RMF","Romford",51.5748295085,0.1832643102
+"RML","Romiley",53.4140264045,-2.0893251906
+"RNF","Rainford",53.5171200074,-2.7894686817
+"RNH","Rainhill",53.4171359422,-2.7663996705
+"RNM","Rainham (London)",51.5167228766,0.1906626283
+"RNR","Roughton Road",52.9180468243,1.2998131699
+"ROB","Roby",53.4100553223,-2.8559333314
+"ROC","Roche",50.4185298804,-4.8302395116
+"ROE","Rotherhithe",51.5008159021,-0.0520222921
+"ROG","Rogart",57.9886951233,-4.1581880614
+"ROL","Rolleston",53.0653022003,-0.8996705436
+"ROM","Romsey",50.992520078,-1.4931337195
+"ROO","Roose",54.115171803,-3.1945656127
+"ROR","Rogerstone",51.595617413,-3.0666186229
+"ROS","Rosyth",56.0455112188,-3.4273031727
+"ROW","Rowley Regis",52.4773392229,-2.0308690726
+"RRB","Ryder Brow",53.4565936753,-2.1730866723,
+"RRN","Robroyston", 55.887581, -4.172291
+"RSG","Rose Grove",53.786206105,-2.2827968156
+"RSN","Reston",55.8506,-2.1972
+"RSH","Rose Hill Marple",53.3962378581,-2.0765205539
+"RTN","Renton",55.9704230841,-4.5861084015
+"RTR","Rochester",51.385547102,0.5103102845
+"RUA","Ruabon",52.9871483927,-3.0431380968
+"RUE","Runcorn East",53.3275817336,-2.6656977069
+"RUF","Rufford",53.6344771165,-2.8078404066
+"RUG","Rugby",52.379109602,-1.2504711992
+"RUN","Runcorn",53.3387090613,-2.7392524151
+"RUS","Ruswarp",54.4702038934,-0.6277880896
+"RUT","Rutherglen",55.8305867225,-4.2120903916
+"RVB","Ravensbourne",51.4141860649,-0.0075306056
+"RVN","Ravensthorpe",53.6755379752,-1.6555824307
+"RWC","Rawcliffe",53.689059382,-0.9608672824
+"RYB","Roy Bridge",56.8883464006,-4.837231331
+"RYD","Ryde Esplanade",50.732855472,-1.1596052649
+"RYE","Rye",50.9523651368,0.7307262415
+"RYH","Rye House",51.7694168549,0.0056554285
+"RYN","Roydon",51.7754907565,0.0362787847
+"RYP","Ryde Pier Head",50.7391721946,-1.160115731
+"RYR","Ryde St Johns Road",50.7243531538,-1.1565554546
+"RYS","Royston",52.0530886425,-0.0268926227
+"SAA","St Albans Abbey",51.7447373797,-0.3425457907
+"SAB","Smallbrook Junction",50.7110892621,-1.1541879058
+"SAC","St Albans City",51.7504771115,-0.3275149609
+"SAD","Sandwell & Dudley",52.508672806,-2.0115900516
+"SAE","Saltaire",53.8385061525,-1.7904830974
+"SAF","Salfords (Surrey)",51.2017437324,-0.1624625843
+"SAH","Salhouse",52.6755989185,1.3914382836
+"SAJ","St Johns (London)",51.4693892196,-0.0226931111
+"SAL","Salisbury",51.0705407298,-1.8063773738
+"SAM","Saltmarshe",53.721943052,-0.8094903376
+"SAN","Sandown",50.6568577497,-1.1623772447
+"SAR","St Andrews Road",51.5127676823,-2.6963176571
+"SAS","St Annes-on-the-Sea",53.7530450492,-3.0290965047
+"SAT","South Acton",51.4996944038,-0.2701346279
+"SAU","St Austell",50.3395021406,-4.7894011447
+"SAV","Stratford-upon-Avon",52.1942606452,-1.7162794479
+"SAW","Sawbridgeworth",51.8143528887,0.1604379052
+"SAX","Saxmundham",52.2149132591,1.4901964806
+"SAY","Swanley",51.3933848234,0.1692513064
+"SBE","Starbeck",53.9990126023,-1.5011353743
+"SBF","St Budeaux Ferry Road",50.4013767558,-4.1868416838
+"SBJ","Stourbridge Junction",52.4475544797,-2.1338704963
+"SBK","South Bank",54.5838411607,-1.1766809553
+"SBM","South Bermondsey",51.4881347391,-0.0546518416
+"SBP","Stonebridge Park",51.5441109985,-0.2758051183
+"SBR","Spean Bridge",56.889995674,-4.921595255
+"SBS","St Bees",54.4925405036,-3.5911492633
+"SBT","Stourbridge Town",52.455591256,-2.1418120086
+"SBU","Southbury",51.6487058202,-0.0524104286
+"SBV","St Budeaux Victoria Road",50.4019952477,-4.1874330909
+"SBY","Selby",53.7828026439,-1.063791006
+"SCA","Scarborough",54.2798078946,-0.4057198208
+"SCF","Stechford",52.4848336609,-1.81101967
+"SCG","Stone Crossing",51.4513283183,0.2637992585
+"SCH","Scotstounhill",55.88513372,-4.3528726659
+"SCR","St Columb Road",50.3986945398,-4.9407987491
+"SCS","Starcross",50.6277843819,-3.4477177832
+"SCT","Scotscalder",58.4829756671,-3.5520574676
+"SCU","Scunthorpe",53.5861949288,-0.6509843133
+"SCY","South Croydon",51.3629626314,-0.0934308139
+"SDA","Snodland",51.3302285584,0.4482700817
+"SDB","Sandbach",53.1501833523,-2.3935053074
+"SDC","Shoreditch High Street",51.5233750963,-0.0752198072
+"SDE","Shadwell",51.5112835169,-0.0569079056
+"SDF","Saundersfoot",51.7220987761,-4.7166131873
+"SDG","Sandling",51.09037099,1.0660749872
+"SDH","Sudbury Hill Harrow",51.558465264,-0.3357809724
+"SDL","Sandhills",53.4299516422,-2.9914899197
+"SDM","Shieldmuir",55.7774860976,-3.9569803961
+"SDN","St Denys",50.9221787802,-1.3877499436
+"SDP","Sandplace",50.3867379699,-4.4645157634
+"SDR","Saunderton",51.6759048289,-0.8254472358
+"SDW","Sandwich",51.2699092555,1.3425965892
+"SDY","Sandy",52.1247435871,-0.281167619
+"SEA","Seaham",54.839061911,-1.3463511926
+"SEB","Seaburn",54.929542046,-1.3867070759
+"SEC","Seaton Carew",54.6583208071,-1.2004437475
+"SED","Shelford (Cambs)",52.1488379665,0.1400093409
+"SEE","Southease",50.8312579508,0.0306695579
+"SEF","Seaford",50.7728366774,0.100161285
+"SEG","Selling",51.2773559024,0.9409001439
+"SEH","Shoreham (Kent)",51.3322156624,0.1889169828
+"SEL","Sellafield",54.4165930704,-3.5104560059
+"SEM","Seamer",54.2407682264,-0.4170454656
+"SEN","Shenstone",52.6393741914,-1.8441949254
+"SER","St Erth",50.1704799545,-5.4443040887
+"SES","South Elmsall",53.594624192,-1.2848611415
+"SET","Settle",54.0669251994,-2.2807172129
+"SEV","Sevenoaks",51.2768624115,0.1816963041
+"SFA","Stratford International",51.5448283609,-0.0087499388
+"SFD","Salford Central",53.4830977645,-2.2548383451
+"SFI","Shawfair",55.9199329881,-3.0787162657
+"SFL","Seaforth & Litherland",53.4662829283,-3.0056221352
+"SFN","Shifnal",52.6660843703,-2.3718373899
+"SFO","Stanford-le-Hope",51.5143632423,0.4230666756
+"SFR","Shalford (Surrey)",51.2143177182,-0.5667825878
+"SGB","Smethwick Galton Bridge",52.5017945032,-1.9805048854
+"SGL","South Gyle",55.9363467134,-3.2994753799
+"SGM","St Germans",50.3942591741,-4.3084363092
+"SGN","South Greenford",51.5337487794,-0.3366818438
+"SGR","Slade Green",51.4677848035,0.19051795
+"SHB","Shirebrook",53.20425967,-1.2024390578
+"SHC","Streethouse",53.6761699951,-1.4001215054
+"SHD","Shildon",54.6261726082,-1.6366159332
+"SHE","Sherborne",50.9440137558,-2.5130735512
+"SHF","Sheffield",53.3782362148,-1.4621101656
+"SHH","Shirehampton",51.4843469177,-2.6792781047
+"SHI","Shiplake",51.5114625615,-0.8825832762
+"SHJ","St Helens Junction",53.4337400237,-2.7002586912
+"SHL","Shawlands",55.8292064055,-4.2923288907
+"SHM","Sheringham",52.9414541496,1.2103377731
+"SHN","Shanklin",50.633896807,-1.1798245747
+"SHO","Sholing",50.896742165,-1.3649055402
+"SHP","Shepperton",51.3968021836,-0.4467657574
+"SHR","Shrewsbury",52.7119413175,-2.749759506
+"SHS","Shotts",55.81864295,-3.7983094064
+"SHT","Shotton",53.2125551564,-3.0384238251
+"SHU","Stonehouse",51.7458905703,-2.2794958307
 "SHV","Southsea Hoverport",50.7853157325,-1.0999768593
-"SHW","Shawford Rail Station",51.0221166807,-1.3277625973
-"SHY","Shipley Rail Station",53.8330646823,-1.7734929691
-"SIA","Southend Airport Rail Station",51.5686727167,0.7050788997
-"SIC","Silecroft Rail Station",54.2259646268,-3.3344411623
-"SID","Sidcup Rail Station",51.4338684504,0.103820707
-"SIE","Sherburn-in-Elmet Rail Station",53.797168439,-1.2326887081
-"SIH","St Helier (London) Rail Station",51.3898980858,-0.1987461399
-"SIL","Sileby Rail Station",52.7316119497,-1.1099817344
-"SIN","Singer Rail Station",55.9076643414,-4.4054709223
-"SIP","Shipton Rail Station",51.8656602235,-1.5926793251
-"SIT","Sittingbourne Rail Station",51.3419765756,0.734715016
-"SIV","St Ives (Cornwall) Rail Station",50.2090340797,-5.4779638071
-"SJP","St James Park (Devon) Rail Station",50.7311433327,-3.522008373
-"SJS","St James Street (London) Rail Station",51.5809810952,-0.0328918555
-"SKE","Skewen Rail Station",51.6613929554,-3.8465246377
-"SKG","Skegness Rail Station",53.1432054155,0.3343478313
-"SKI","Skipton Rail Station",53.9586993556,-2.0258762003
-"SKM","Stoke Mandeville Rail Station",51.7878005079,-0.7840627602
+"SHW","Shawford",51.0221166807,-1.3277625973
+"SHY","Shipley",53.8330646823,-1.7734929691
+"SIA","Southend Airport",51.5686727167,0.7050788997
+"SIC","Silecroft",54.2259646268,-3.3344411623
+"SID","Sidcup",51.4338684504,0.103820707
+"SIE","Sherburn-in-Elmet",53.797168439,-1.2326887081
+"SIH","St Helier (London)",51.3898980858,-0.1987461399
+"SIL","Sileby",52.7316119497,-1.1099817344
+"SIN","Singer",55.9076643414,-4.4054709223
+"SIP","Shipton",51.8656602235,-1.5926793251
+"SIT","Sittingbourne",51.3419765756,0.734715016
+"SIV","St Ives (Cornwall)",50.2090340797,-5.4779638071
+"SJP","St James Park (Devon)",50.7311433327,-3.522008373
+"SJS","St James Street (London)",51.5809810952,-0.0328918555
+"SKE","Skewen",51.6613929554,-3.8465246377
+"SKG","Skegness",53.1432054155,0.3343478313
+"SKI","Skipton",53.9586993556,-2.0258762003
+"SKM","Stoke Mandeville",51.7878005079,-0.7840627602
 "SKN","St Keyne Wishing Well Halt (Rail Station)",50.4230258748,-4.4635552009
-"SKS","Stocksfield Rail Station",54.9470541409,-1.9167691115
-"SKW","Stoke Newington Rail Station",51.5652328179,-0.0728615603
-"SLA","Slateford Rail Station",55.9266820904,-3.2434555997
-"SLB","Saltburn Rail Station",54.5834629003,-0.9741485323
-"SLD","Salford Crescent Rail Station",53.4866023466,-2.2757478149
-"SLH","Sleights Rail Station",54.4610657105,-0.6624968789
-"SLK","Silkstone Common Rail Station",53.5349327521,-1.5634802419
-"SLL","Stallingborough Rail Station",53.5871163761,-0.1836712695
-"SLO","Slough Rail Station",51.5118802466,-0.5914931274
-"SLQ","St Leonards Warrior Square Rail Station",50.8556892437,0.5603085614
-"SLR","Sleaford Rail Station",52.9954938802,-0.4103411047
-"SLS","Shettleston Rail Station",55.8535309533,-4.1600304592
-"SLT","Saltcoats Rail Station",55.6338785668,-4.7842684101
-"SLV","Silver Street Rail Station",51.614688688,-0.0672151307
-"SLW","Salwick Rail Station",53.781554319,-2.8170354918
-"SLY","Selly Oak Rail Station",52.4419948393,-1.9358085367
-"SMA","Small Heath Rail Station",52.4637743964,-1.8593875424
-"SMB","Smithy Bridge Rail Station",53.6332679916,-2.1135014139
-"SMC","Sampford Courtenay Rail Station",50.7700908969,-3.9489125512
-"SMD","Stamford Rail Station",52.6478489455,-0.4801041079
-"SMG","St Margarets (London) Rail Station",51.4552338666,-0.3201782408
-"SMH","Stamford Hill Rail Station",51.5744676612,-0.0766565162
-"SMK","Stowmarket Rail Station",52.189727647,1.0000367465
-"SML","Sea Mills Rail Station",51.4799904425,-2.6499531782
-"SMN","Southminster Rail Station",51.6606288734,0.8352211602
-"SMO","South Merton Rail Station",51.4029904753,-0.2051331043
-"SMR","Smethwick Rolfe Street Rail Station",52.4963984863,-1.9706383988
-"SMT","St Margarets (Herts) Rail Station",51.7878447991,0.0012964611
-"SMY","St Mary Cray Rail Station",51.3947475934,0.1064098734
-"SNA","Sandal & Agbrigg Rail Station",53.663093616,-1.4814212432
-"SND","Sandhurst Rail Station",51.3469294691,-0.8045742694
-"SNE","Stone Rail Station",52.9083405003,-2.1550394406
-"SNF","Shenfield Rail Station",51.6308782728,0.3298784447
-"SNG","Sunningdale Rail Station",51.3919389035,-0.6330228307
-"SNH","St Helens Central Rail Station",53.4531374207,-2.7303039117
-"SNI","Snaith Rail Station",53.6931319312,-1.0284631537
-"SNK","Sankey for Penketh Rail Station",53.392475627,-2.6504695097
-"SNL","Stoneleigh Rail Station",51.3633975389,-0.248640927
-"SNN","Swinton (Manchester) Rail Station",53.5148477623,-2.3374594966
-"SNO","St Neots Rail Station",52.2315789405,-0.2473922859
-"SNP","Stanhope Rail Station",54.7433166118,-2.003270368
-"SNR","Sanderstead Rail Station",51.3482809474,-0.0936522427
-"SNS","Staines Rail Station",51.4324535002,-0.5031448916
-"SNT","Stanlow & Thornton Rail Station",53.2783765388,-2.8420514589
-"SNW","Swanwick Rail Station",50.8756583726,-1.2658406523
-"SNY","Sunnymeads Rail Station",51.4702876016,-0.5593563895
-"SOA","Southampton Airport Parkway Rail Station",50.9508051335,-1.3630864575
-"SOB","Southbourne Rail Station",50.8482655747,-0.9080912718
-"SOC","Southend Central Rail Station",51.537066598,0.7117558649
-"SOE","Southend East Rail Station",51.5389747276,0.7318442913
-"SOF","South Woodham Ferrers Rail Station",51.6494615164,0.6065323444
-"SOG","Stonegate Rail Station",51.0199626384,0.3638955581
-"SOH","South Hampstead Rail Station",51.5414325626,-0.1788526652
-"SOI","Stow Rail Station",55.6924175451,-2.8659523944
-"SOK","South Kenton Rail Station",51.5702144388,-0.3084401599
-"SOL","Solihull Rail Station",52.4144038973,-1.7883836849
-"SOM","South Milford Rail Station",53.782342555,-1.2505333925
-"SON","Steeton & Silsden Rail Station",53.9000444561,-1.9447229013
-"SOO","Strood Rail Station",51.3965463718,0.5002161998
-"SOP","Southport Rail Station",53.6465333176,-3.0024325138
-"SOR","Sole Street Rail Station",51.3831433215,0.3781256752
-"SOT","Stoke-on-Trent Rail Station",53.0079958214,-2.1809866656
-"SOU","Southampton Central Rail Station",50.9074381105,-1.4135875626
-"SOV","Southend Victoria Rail Station",51.5415147415,0.7115300293
-"SOW","Sowerby Bridge Rail Station",53.7078597734,-1.9070230861
-"SPA","Spalding Rail Station",52.7888256516,-0.1568731307
-"SPB","Shepherds Bush Rail Station",51.505284273,-0.2176304274
-"SPF","Springfield Rail Station",56.2949608449,-3.0524499272
-"SPH","Shepherds Well Rail Station",51.1884029231,1.229940616
-"SPI","Spital Rail Station",53.3399518307,-2.9939065057
-"SPK","Sutton Parkway Rail Station",53.1141094224,-1.2455659505
-"SPL","London St Pancras International LL Rail Station",51.5321682332,-0.1273170838
-"SPN","Spooner Row Rail Station",52.535018036,1.0864987701
-"SPO","Spondon Rail Station",52.9122360781,-1.4110901354
-"SPP","Shippea Hill Rail Station",52.4302290785,0.4133683213
-"SPR","Springburn Rail Station",55.8819306661,-4.2305204867
-"SPS","Stepps Rail Station",55.8901303522,-4.1407948936
-"SPT","Stockport Rail Station",53.4055533886,-2.1630118236
-"SPU","Staplehurst Rail Station",51.1714644595,0.5504684545
-"SPY","Shepley Rail Station",53.5887544999,-1.7049300824
-"SQE","Surrey Quays Rail Station",51.493195576,-0.0474925165
-"SQH","Sanquhar Rail Station",55.3701688129,-3.9245103507
-"SQU","Squires Gate Rail Station",53.7773453923,-3.0502988204
-"SRA","Stratford (London) Rail Station",51.541895146,-0.0033691271
-"SRC","Streatham Common Rail Station",51.4187280874,-0.1359839628
-"SRD","Stapleton Road Rail Station",51.4675039991,-2.5662177437
-"SRG","Seer Green Rail Station",51.6098457593,-0.6077986309
-"SRH","Streatham Hill Rail Station",51.4381912428,-0.1271343887
-"SRI","Spring Road Rail Station",52.4434290378,-1.8373837238
-"SRL","Shirley Rail Station",52.4034335801,-1.8451727358
-"SRN","Strines Rail Station",53.375053434,-2.03391498
-"SRO","Shireoaks Rail Station",53.324793696,-1.1679906243
-"SRR","Sarn Rail Station",51.538716062,-3.5899278153
-"SRS","Selhurst Rail Station",51.3919256691,-0.0882746656
-"SRT","Shortlands Rail Station",51.4057983982,0.0018099278
-"SRU","South Ruislip Rail Station",51.5569197794,-0.3992385186
-"SRY","Shoeburyness Rail Station",51.5309751312,0.7953748853
-"SSC","Seascale Rail Station",54.3958826629,-3.4845106158
-"SSD","Stansted Airport Rail Station",51.8885969065,0.2608429847
-"SSE","Shoreham-by-Sea (Sussex) Rail Station",50.8344187806,-0.2716932437
-"SSM","Stocksmoor Rail Station",53.5941012185,-1.723249622
-"SSS","Sheerness-on-Sea Rail Station",51.4410626729,0.7585627159
-"SST","Stansted Mountfitchet Rail Station",51.9014446092,0.1998076437
-"STA","Stafford Rail Station",52.8039040388,-2.122032317
-"STC","Strathcarron Rail Station",57.4227106139,-5.4286056714
-"STD","Stroud (Glos) Rail Station",51.7446251691,-2.2193787757
-"STE","Streatham Rail Station",51.425806399,-0.1315244629
-"STF","Stromeferry Rail Station",57.3522743311,-5.5511508974
-"STG","Stirling Rail Station",56.1198084255,-3.9356129186
-"STH","Shepreth Rail Station",52.1141714275,0.0313474706
-"STJ","Severn Tunnel Junction Rail Station",51.5846753669,-2.777896695
-"STK","Stockton Rail Station",54.5696329596,-1.3185563444
-"STL","Southall Rail Station",51.5059555535,-0.3785893432
-"STM","St Michaels Rail Station",53.3756143466,-2.9527983882
-"STN","Stonehaven Rail Station",56.9668074474,-2.2253042533
-"STO","South Tottenham Rail Station",51.580372482,-0.0720773948
-"STP","London St Pancras International Rail Station",51.5323906044,-0.1271637715
+"SKS","Stocksfield",54.9470541409,-1.9167691115
+"SKW","Stoke Newington",51.5652328179,-0.0728615603
+"SLA","Slateford",55.9266820904,-3.2434555997
+"SLB","Saltburn",54.5834629003,-0.9741485323
+"SLD","Salford Crescent",53.4866023466,-2.2757478149
+"SLH","Sleights",54.4610657105,-0.6624968789
+"SLK","Silkstone Common",53.5349327521,-1.5634802419
+"SLL","Stallingborough",53.5871163761,-0.1836712695
+"SLO","Slough",51.5118802466,-0.5914931274
+"SLQ","St Leonards Warrior Square",50.8556892437,0.5603085614
+"SLR","Sleaford",52.9954938802,-0.4103411047
+"SLS","Shettleston",55.8535309533,-4.1600304592
+"SLT","Saltcoats",55.6338785668,-4.7842684101
+"SLV","Silver Street",51.614688688,-0.0672151307
+"SLW","Salwick",53.781554319,-2.8170354918
+"SLY","Selly Oak",52.4419948393,-1.9358085367
+"SMA","Small Heath",52.4637743964,-1.8593875424
+"SMB","Smithy Bridge",53.6332679916,-2.1135014139
+"SMC","Sampford Courtenay",50.7700908969,-3.9489125512
+"SMD","Stamford",52.6478489455,-0.4801041079
+"SMG","St Margarets (London)",51.4552338666,-0.3201782408
+"SMH","Stamford Hill",51.5744676612,-0.0766565162
+"SMK","Stowmarket",52.189727647,1.0000367465
+"SML","Sea Mills",51.4799904425,-2.6499531782
+"SMN","Southminster",51.6606288734,0.8352211602
+"SMO","South Merton",51.4029904753,-0.2051331043
+"SMR","Smethwick Rolfe Street",52.4963984863,-1.9706383988
+"SMT","St Margarets (Herts)",51.7878447991,0.0012964611
+"SMY","St Mary Cray",51.3947475934,0.1064098734
+"SNA","Sandal & Agbrigg",53.663093616,-1.4814212432
+"SND","Sandhurst",51.3469294691,-0.8045742694
+"SNE","Stone",52.9083405003,-2.1550394406
+"SNF","Shenfield",51.6308782728,0.3298784447
+"SNG","Sunningdale",51.3919389035,-0.6330228307
+"SNH","St Helens Central",53.4531374207,-2.7303039117
+"SNI","Snaith",53.6931319312,-1.0284631537
+"SNK","Sankey for Penketh",53.392475627,-2.6504695097
+"SNL","Stoneleigh",51.3633975389,-0.248640927
+"SNN","Swinton (Manchester)",53.5148477623,-2.3374594966
+"SNO","St Neots",52.2315789405,-0.2473922859
+"SNP","Stanhope",54.7433166118,-2.003270368
+"SNR","Sanderstead",51.3482809474,-0.0936522427
+"SNS","Staines",51.4324535002,-0.5031448916
+"SNT","Stanlow & Thornton",53.2783765388,-2.8420514589
+"SNW","Swanwick",50.8756583726,-1.2658406523
+"SNY","Sunnymeads",51.4702876016,-0.5593563895
+"SOA","Southampton Airport Parkway",50.9508051335,-1.3630864575
+"SOB","Southbourne",50.8482655747,-0.9080912718
+"SOC","Southend Central",51.537066598,0.7117558649
+"SOE","Southend East",51.5389747276,0.7318442913
+"SOF","South Woodham Ferrers",51.6494615164,0.6065323444
+"SOG","Stonegate",51.0199626384,0.3638955581
+"SOH","South Hampstead",51.5414325626,-0.1788526652
+"SOI","Stow",55.6924175451,-2.8659523944
+"SOJ","Soham",52.331,-0.337
+"SOK","South Kenton",51.5702144388,-0.3084401599
+"SOL","Solihull",52.4144038973,-1.7883836849
+"SOM","South Milford",53.782342555,-1.2505333925
+"SON","Steeton & Silsden",53.9000444561,-1.9447229013
+"SOO","Strood",51.3965463718,0.5002161998
+"SOP","Southport",53.6465333176,-3.0024325138
+"SOR","Sole Street",51.3831433215,0.3781256752
+"SOT","Stoke-on-Trent",53.0079958214,-2.1809866656
+"SOU","Southampton Central",50.9074381105,-1.4135875626
+"SOV","Southend Victoria",51.5415147415,0.7115300293
+"SOW","Sowerby Bridge",53.7078597734,-1.9070230861
+"SPA","Spalding",52.7888256516,-0.1568731307
+"SPB","Shepherds Bush",51.505284273,-0.2176304274
+"SPF","Springfield",56.2949608449,-3.0524499272
+"SPH","Shepherds Well",51.1884029231,1.229940616
+"SPI","Spital",53.3399518307,-2.9939065057
+"SPK","Sutton Parkway",53.1141094224,-1.2455659505
+"SPL","London St Pancras International LL",51.5321682332,-0.1273170838
+"SPN","Spooner Row",52.535018036,1.0864987701
+"SPO","Spondon",52.9122360781,-1.4110901354
+"SPP","Shippea Hill",52.4302290785,0.4133683213
+"SPR","Springburn",55.8819306661,-4.2305204867
+"SPS","Stepps",55.8901303522,-4.1407948936
+"SPT","Stockport",53.4055533886,-2.1630118236
+"SPU","Staplehurst",51.1714644595,0.5504684545
+"SPY","Shepley",53.5887544999,-1.7049300824
+"SQE","Surrey Quays",51.493195576,-0.0474925165
+"SQH","Sanquhar",55.3701688129,-3.9245103507
+"SQU","Squires Gate",53.7773453923,-3.0502988204
+"SRA","Stratford (London)",51.541895146,-0.0033691271
+"SRC","Streatham Common",51.4187280874,-0.1359839628
+"SRD","Stapleton Road",51.4675039991,-2.5662177437
+"SRG","Seer Green",51.6098457593,-0.6077986309
+"SRH","Streatham Hill",51.4381912428,-0.1271343887
+"SRI","Spring Road",52.4434290378,-1.8373837238
+"SRL","Shirley",52.4034335801,-1.8451727358
+"SRN","Strines",53.375053434,-2.03391498
+"SRO","Shireoaks",53.324793696,-1.1679906243
+"SRR","Sarn",51.538716062,-3.5899278153
+"SRS","Selhurst",51.3919256691,-0.0882746656
+"SRT","Shortlands",51.4057983982,0.0018099278
+"SRU","South Ruislip",51.5569197794,-0.3992385186
+"SRY","Shoeburyness",51.5309751312,0.7953748853
+"SSC","Seascale",54.3958826629,-3.4845106158
+"SSD","Stansted Airport",51.8885969065,0.2608429847
+"SSE","Shoreham-by-Sea (Sussex)",50.8344187806,-0.2716932437
+"SSM","Stocksmoor",53.5941012185,-1.723249622
+"SSS","Sheerness-on-Sea",51.4410626729,0.7585627159
+"SST","Stansted Mountfitchet",51.9014446092,0.1998076437
+"STA","Stafford",52.8039040388,-2.122032317
+"STC","Strathcarron",57.4227106139,-5.4286056714
+"STD","Stroud (Glos)",51.7446251691,-2.2193787757
+"STE","Streatham",51.425806399,-0.1315244629
+"STF","Stromeferry",57.3522743311,-5.5511508974
+"STG","Stirling",56.1198084255,-3.9356129186
+"STH","Shepreth",52.1141714275,0.0313474706
+"STJ","Severn Tunnel Junction",51.5846753669,-2.777896695
+"STK","Stockton",54.5696329596,-1.3185563444
+"STL","Southall",51.5059555535,-0.3785893432
+"STM","St Michaels",53.3756143466,-2.9527983882
+"STN","Stonehaven",56.9668074474,-2.2253042533
+"STO","South Tottenham",51.580372482,-0.0720773948
+"STP","London St Pancras International",51.5323906044,-0.1271637715
 "STQ","Southampton Town Quay",50.8951417965,-1.4058217125
-"STR","Stranraer Rail Station",54.9096119416,-5.0247136457
-"STS","Saltash Rail Station",50.407341292,-4.2091429608
-"STT","Stewarton Rail Station",55.6821494442,-4.5180405975
-"STU","Sturry Rail Station",51.301071637,1.1222846311
-"STV","Stevenston Rail Station",55.6342752646,-4.7507681765
-"STW","Strawberry Hill Rail Station",51.4389610182,-0.3393370866
-"STY","Stratford-upon-Avon Parkway Rail Station",52.20679123,-1.7308347436
-"STZ","St Peters Rail Station",54.9114465319,-1.3838157241
-"SUC","Sutton Common Rail Station",51.374887892,-0.1963176971
-"SUD","Sudbury & Harrow Road Rail Station",51.5543983927,-0.3154454426
-"SUG","Sugar Loaf Rail Station",52.082277733,-3.6869603427
-"SUM","Summerston Rail Station",55.8988291055,-4.2915239477
-"SUN","Sunderland Rail Station",54.9053460619,-1.382318101
-"SUO","Sutton (London) Rail Station",51.359530184,-0.1911898264
-"SUP","Sundridge Park Rail Station",51.4137794712,0.0214722343
-"SUR","Surbiton Rail Station",51.392457041,-0.3039362021
-"SUT","Sutton Coldfield Rail Station",52.5649558162,-1.824837271
-"SUU","Sunbury Rail Station",51.4183118212,-0.4177615601
-"SUY","Sudbury (Suffolk) Rail Station",52.0362894221,0.7354756664
-"SVB","Severn Beach Rail Station",51.560023655,-2.6644812454
-"SVG","Stevenage Rail Station",51.9016927995,-0.2070860807
-"SVK","Seven Kings Rail Station",51.5640254913,0.0971266259
-"SVL","Staveley Rail Station",54.3755397414,-2.8188650127
-"SVR","Silverdale Rail Station",54.1699177481,-2.8038415221
-"SVS","Seven Sisters Rail Station",51.5822680092,-0.0752448572
-"SWA","Swansea Rail Station",51.6251487596,-3.9415644468
-"SWD","Swinderby Rail Station",53.1695752058,-0.7026776123
-"SWE","Swineshead Rail Station",52.9698246032,-0.1871603301
-"SWG","Swaythling Rail Station",50.9411378896,-1.3763987158
-"SWI","Swindon Rail Station",51.5654717291,-1.7854997597
-"SWK","Southwick Rail Station",50.8325078755,-0.2359343912
-"SWL","Swale Rail Station",51.3892367714,0.7471634594
-"SWM","Swanscombe Rail Station",51.4490684493,0.3095719354
-"SWN","Swinton (South Yorks) Rail Station",53.4862573953,-1.3058228385
-"SWO","Snowdown Rail Station",51.2153033313,1.2137349076
-"SWR","Stewartby Rail Station",52.0690889946,-0.5206700583
-"SWS","South Wigston Rail Station",52.5822411091,-1.1340686433
-"SWT","Slaithwaite Rail Station",53.6238425513,-1.8815786683
-"SWY","Sway Rail Station",50.7846919652,-1.6099880732
-"SXY","Saxilby Rail Station",53.2672239409,-0.664039544
-"SYA","Styal Rail Station",53.3483444707,-2.2404551552
-"SYB","Stalybridge Rail Station",53.4845940592,-2.0627406537
-"SYD","Sydenham Rail Station",51.4272456275,-0.0542181492
-"SYH","Sydenham Hill Rail Station",51.4327121996,-0.0803137756
-"SYL","Syon Lane Rail Station",51.4817833206,-0.3248202577
-"SYS","Syston Rail Station",52.6942282549,-1.0823921267
-"SYT","Somerleyton Rail Station",52.510254523,1.65228441
-"TAB","Tame Bridge Parkway Rail Station",52.5529462534,-1.9762062325
-"TAC","Tackley Rail Station",51.8812440038,-1.2975180267
-"TAD","Tadworth Rail Station",51.2916337745,-0.2359396303
-"TAF","Taffs Well Rail Station",51.5408038104,-3.2629475716
-"TAH","Tamworth High Level Rail Station",52.6374896703,-1.6864429533
-"TAI","Tain Rail Station",57.814403344,-4.052050677
-"TAL","Talsarnau Rail Station",52.9043217775,-4.0681617526
-"TAM","Tamworth Rail Station",52.6374897095,-1.6864577321
-"TAP","Taplow Rail Station",51.5235630262,-0.6813523989
-"TAT","Tattenham Corner Rail Station",51.3091795736,-0.242584206
-"TAU","Taunton Rail Station",51.0232957201,-3.1027501001
-"TAY","Taynuilt Rail Station",56.4307929324,-5.2395897581
-"TBD","Three Bridges Rail Station",51.1169179407,-0.1611569978
-"TBW","Tunbridge Wells Rail Station",51.1302300678,0.2628373001
-"TBY","Thornaby Rail Station",54.5592813582,-1.3014251552
-"TDU","Tondu Rail Station",51.547362229,-3.5955651626
-"TEA","Tees-side Airport Rail Station",54.5181424575,-1.4253223693
-"TED","Teddington Rail Station",51.4244788122,-0.3326846191
-"TEN","Tenby Rail Station",51.672951966,-4.7067273929
-"TEO","Theobalds Grove Rail Station",51.692457758,-0.0348052112
-"TEY","Teynham Rail Station",51.3333932934,0.8074562729
-"TFC","Telford Central Rail Station",52.6811206446,-2.4409698489
-"TGM","Teignmouth Rail Station",50.5480477205,-3.4946764735
-"TGS","Ty Glas Rail Station",51.5215383785,-3.1965433402
-"THA","Thatcham Rail Station",51.3938422697,-1.2431703674
-"THB","Thornliebank Rail Station",55.8110931929,-4.3116934017
-"THC","Thurnscoe Rail Station",53.5450596404,-1.3087865327
-"THD","Thames Ditton Rail Station",51.389094233,-0.3391301451
-"THE","Theale Rail Station",51.4334510541,-1.074953188
-"THH","Thatto Heath Rail Station",53.4365966678,-2.7593735619
-"THI","Thirsk Rail Station",54.2282229773,-1.3725964904
-"THL","Tile Hill Rail Station",52.3951180004,-1.5968388563
-"THO","Thornford Rail Station",50.9105671531,-2.5789881669
-"THS","Thurso Rail Station",58.5901618735,-3.5275560192
-"THT","Thorntonhall Rail Station",55.7686725545,-4.251148703
-"THU","Thurgarton Rail Station",53.0289614147,-0.9622529876
-"THW","The Hawthorns Rail Station",52.5053866205,-1.9640028874
-"TIL","Tilbury Town Rail Station",51.4623579727,0.3540684253
-"TIP","Tipton Rail Station",52.5304554489,-2.0656957349
-"TIR","Tir-phil Rail Station",51.720908438,-3.2463907704
-"TIS","Tisbury Rail Station",51.0608447298,-2.078996052
-"TLB","Talybont Rail Station",52.7726445507,-4.0966036401
-"TLC","Tal-y-Cafn Rail Station",53.2283776011,-3.8182676092
-"TLH","Tilehurst Rail Station",51.4715086374,-1.0297956661
-"TLK","The Lakes Rail Station",52.3591567803,-1.8446654141
-"TLS","Thorpe-le-Soken Rail Station",51.847646828,1.1614320188
-"TMC","Templecombe Rail Station",51.0014953975,-2.4177222648
-"TNA","Thornton Abbey Rail Station",53.6543223993,-0.3230275398
-"TNF","Tonfanau Rail Station",52.6135565545,-4.1237062703
-"TNN","Thorne North Rail Station",53.6160814226,-0.9723356959
-"TNP","Tonypandy Rail Station",51.6197644665,-3.4488804142
-"TNS","Thorne South Rail Station",53.6033482935,-0.9551144553
-"TOD","Todmorden Rail Station",53.7138309013,-2.0996605197
-"TOK","Three Oaks Rail Station",50.9011098188,0.6130803485
-"TOL","Tolworth Rail Station",51.376857174,-0.279438167
-"TOM","Tottenham Hale Rail Station",51.5883098971,-0.0599041132
-"TON","Tonbridge Rail Station",51.1914072217,0.27100092
-"TOO","Tooting Rail Station",51.4198462078,-0.1612523385
-"TOP","Topsham Rail Station",50.6862032067,-3.4644362802
-"TOT","Totnes Rail Station",50.4358486966,-3.6887120337
-"TPB","Thorpe Bay Rail Station",51.5375725855,0.761757978
-"TPC","Thorpe Culvert Rail Station",53.1231171411,0.199418712
-"TPN","Ton Pentre Rail Station",51.6478022913,-3.4861984834
-"TQY","Torquay Rail Station",50.4611182406,-3.5432904492
-"TRA","Trafford Park Rail Station",53.4548323413,-2.310631341
-"TRB","Treherbert Rail Station",51.6722450222,-3.5363140662
-"TRD","Troed-y-Rhiw Rail Station",51.7124284343,-3.3467559182
-"TRE","Trefforest Estate Rail Station",51.5682913986,-3.2902588749
-"TRF","Trefforest Rail Station",51.5914619743,-3.3251300368
-"TRH","Trehafod Rail Station",51.6101512603,-3.3809848496
-"TRI","Tring Rail Station",51.8007474169,-0.6224150693
-"TRM","Trimley Rail Station",51.9765411505,1.3195660189
-"TRN","Troon Rail Station",55.5428092479,-4.6552789194
-"TRO","Trowbridge Rail Station",51.3198258981,-2.2143311551
-"TRR","Torre Rail Station",50.4731733437,-3.546431156
-"TRS","Thurston Rail Station",52.250018318,0.80868287
-"TRU","Truro Rail Station",50.2638281307,-5.0648592797
-"TRY","Treorchy Rail Station",51.6575345216,-3.5057452076
-"TTF","Thetford Rail Station",52.4191425696,0.7450983124
-"TTH","Thornton Heath Rail Station",51.3987754716,-0.100280296
-"TTN","Totton Rail Station",50.917871726,-1.4824091536
-"TUH","Tulse Hill Rail Station",51.439859554,-0.1050510178
-"TUL","Tulloch Rail Station",56.8842613618,-4.7013115681
-"TUR","Turkey Street Rail Station",51.6726289265,-0.047190258
-"TUT","Tutbury & Hatton Rail Station",52.8641515138,-1.6822308376
-"TVP","Tiverton Parkway Rail Station",50.917168904,-3.3596569642
-"TWB","Tweedbank Rail Station",55.6057393628,-2.7595353637
-"TWI","Twickenham Rail Station",51.4500290431,-0.3303719704
-"TWN","Town Green Rail Station",53.5428211891,-2.9044849794
-"TWY","Twyford Rail Station",51.4755339055,-0.8632740226
+"STR","Stranraer",54.9096119416,-5.0247136457
+"STS","Saltash",50.407341292,-4.2091429608
+"STT","Stewarton",55.6821494442,-4.5180405975
+"STU","Sturry",51.301071637,1.1222846311
+"STV","Stevenston",55.6342752646,-4.7507681765
+"STW","Strawberry Hill",51.4389610182,-0.3393370866
+"STY","Stratford-upon-Avon Parkway",52.20679123,-1.7308347436
+"STZ","St Peters",54.9114465319,-1.3838157241
+"SUC","Sutton Common",51.374887892,-0.1963176971
+"SUD","Sudbury & Harrow Road",51.5543983927,-0.3154454426
+"SUG","Sugar Loaf",52.082277733,-3.6869603427
+"SUM","Summerston",55.8988291055,-4.2915239477
+"SUN","Sunderland",54.9053460619,-1.382318101
+"SUO","Sutton (London)",51.359530184,-0.1911898264
+"SUP","Sundridge Park",51.4137794712,0.0214722343
+"SUR","Surbiton",51.392457041,-0.3039362021
+"SUT","Sutton Coldfield",52.5649558162,-1.824837271
+"SUU","Sunbury",51.4183118212,-0.4177615601
+"SUY","Sudbury (Suffolk)",52.0362894221,0.7354756664
+"SVB","Severn Beach",51.560023655,-2.6644812454
+"SVG","Stevenage",51.9016927995,-0.2070860807
+"SVK","Seven Kings",51.5640254913,0.0971266259
+"SVL","Staveley",54.3755397414,-2.8188650127
+"SVR","Silverdale",54.1699177481,-2.8038415221
+"SVS","Seven Sisters",51.5822680092,-0.0752448572
+"SWA","Swansea",51.6251487596,-3.9415644468
+"SWD","Swinderby",53.1695752058,-0.7026776123
+"SWE","Swineshead",52.9698246032,-0.1871603301
+"SWG","Swaythling",50.9411378896,-1.3763987158
+"SWI","Swindon",51.5654717291,-1.7854997597
+"SWK","Southwick",50.8325078755,-0.2359343912
+"SWL","Swale",51.3892367714,0.7471634594
+"SWM","Swanscombe",51.4490684493,0.3095719354
+"SWN","Swinton (South Yorks)",53.4862573953,-1.3058228385
+"SWO","Snowdown",51.2153033313,1.2137349076
+"SWR","Stewartby",52.0690889946,-0.5206700583
+"SWS","South Wigston",52.5822411091,-1.1340686433
+"SWT","Slaithwaite",53.6238425513,-1.8815786683
+"SWY","Sway",50.7846919652,-1.6099880732
+"SXY","Saxilby",53.2672239409,-0.664039544
+"SYA","Styal",53.3483444707,-2.2404551552
+"SYB","Stalybridge",53.4845940592,-2.0627406537
+"SYD","Sydenham",51.4272456275,-0.0542181492
+"SYH","Sydenham Hill",51.4327121996,-0.0803137756
+"SYL","Syon Lane",51.4817833206,-0.3248202577
+"SYS","Syston",52.6942282549,-1.0823921267
+"SYT","Somerleyton",52.510254523,1.65228441
+"TAB","Tame Bridge Parkway",52.5529462534,-1.9762062325
+"TAC","Tackley",51.8812440038,-1.2975180267
+"TAD","Tadworth",51.2916337745,-0.2359396303
+"TAF","Taffs Well",51.5408038104,-3.2629475716
+"TAH","Tamworth High Level",52.6374896703,-1.6864429533
+"TAI","Tain",57.814403344,-4.052050677
+"TAL","Talsarnau",52.9043217775,-4.0681617526
+"TAM","Tamworth",52.6374897095,-1.6864577321
+"TAP","Taplow",51.5235630262,-0.6813523989
+"TAT","Tattenham Corner",51.3091795736,-0.242584206
+"TAU","Taunton",51.0232957201,-3.1027501001
+"TAY","Taynuilt",56.4307929324,-5.2395897581
+"TBD","Three Bridges",51.1169179407,-0.1611569978
+"TBW","Tunbridge Wells",51.1302300678,0.2628373001
+"TBY","Thornaby",54.5592813582,-1.3014251552
+"TDU","Tondu",51.547362229,-3.5955651626
+"TEA","Tees-side Airport",54.5181424575,-1.4253223693
+"TED","Teddington",51.4244788122,-0.3326846191
+"TEN","Tenby",51.672951966,-4.7067273929
+"TEO","Theobalds Grove",51.692457758,-0.0348052112
+"TEY","Teynham",51.3333932934,0.8074562729
+"TFC","Telford Central",52.6811206446,-2.4409698489
+"TGM","Teignmouth",50.5480477205,-3.4946764735
+"TGS","Ty Glas",51.5215383785,-3.1965433402
+"THA","Thatcham",51.3938422697,-1.2431703674
+"THB","Thornliebank",55.8110931929,-4.3116934017
+"THC","Thurnscoe",53.5450596404,-1.3087865327
+"THD","Thames Ditton",51.389094233,-0.3391301451
+"THE","Theale",51.4334510541,-1.074953188
+"THH","Thatto Heath",53.4365966678,-2.7593735619
+"THI","Thirsk",54.2282229773,-1.3725964904
+"THL","Tile Hill",52.3951180004,-1.5968388563
+"THO","Thornford",50.9105671531,-2.5789881669
+"THP","Thanet Parkway",51.330843,1.361777
+"THS","Thurso",58.5901618735,-3.5275560192
+"THT","Thorntonhall",55.7686725545,-4.251148703
+"THU","Thurgarton",53.0289614147,-0.9622529876
+"THW","The Hawthorns",52.5053866205,-1.9640028874
+"TIL","Tilbury Town",51.4623579727,0.3540684253
+"TIP","Tipton",52.5304554489,-2.0656957349
+"TIR","Tir-phil",51.720908438,-3.2463907704
+"TIS","Tisbury",51.0608447298,-2.078996052
+"TLB","Talybont",52.7726445507,-4.0966036401
+"TLC","Tal-y-Cafn",53.2283776011,-3.8182676092
+"TLH","Tilehurst",51.4715086374,-1.0297956661
+"TLK","The Lakes",52.3591567803,-1.8446654141
+"TLS","Thorpe-le-Soken",51.847646828,1.1614320188
+"TMC","Templecombe",51.0014953975,-2.4177222648
+"TNA","Thornton Abbey",53.6543223993,-0.3230275398
+"TNF","Tonfanau",52.6135565545,-4.1237062703
+"TNN","Thorne North",53.6160814226,-0.9723356959
+"TNP","Tonypandy",51.6197644665,-3.4488804142
+"TNS","Thorne South",53.6033482935,-0.9551144553
+"TOD","Todmorden",53.7138309013,-2.0996605197
+"TOK","Three Oaks",50.9011098188,0.6130803485
+"TOL","Tolworth",51.376857174,-0.279438167
+"TOM","Tottenham Hale",51.5883098971,-0.0599041132
+"TON","Tonbridge",51.1914072217,0.27100092
+"TOO","Tooting",51.4198462078,-0.1612523385
+"TOP","Topsham",50.6862032067,-3.4644362802
+"TOT","Totnes",50.4358486966,-3.6887120337
+"TPB","Thorpe Bay",51.5375725855,0.761757978
+"TPC","Thorpe Culvert",53.1231171411,0.199418712
+"TPN","Ton Pentre",51.6478022913,-3.4861984834
+"TQY","Torquay",50.4611182406,-3.5432904492
+"TRA","Trafford Park",53.4548323413,-2.310631341
+"TRB","Treherbert",51.6722450222,-3.5363140662
+"TRD","Troed-y-Rhiw",51.7124284343,-3.3467559182
+"TRE","Trefforest Estate",51.5682913986,-3.2902588749
+"TRF","Trefforest",51.5914619743,-3.3251300368
+"TRH","Trehafod",51.6101512603,-3.3809848496
+"TRI","Tring",51.8007474169,-0.6224150693
+"TRM","Trimley",51.9765411505,1.3195660189
+"TRN","Troon",55.5428092479,-4.6552789194
+"TRO","Trowbridge",51.3198258981,-2.2143311551
+"TRR","Torre",50.4731733437,-3.546431156
+"TRS","Thurston",52.250018318,0.80868287
+"TRU","Truro",50.2638281307,-5.0648592797
+"TRY","Treorchy",51.6575345216,-3.5057452076
+"TTF","Thetford",52.4191425696,0.7450983124
+"TTH","Thornton Heath",51.3987754716,-0.100280296
+"TTN","Totton",50.917871726,-1.4824091536
+"TUH","Tulse Hill",51.439859554,-0.1050510178
+"TUL","Tulloch",56.8842613618,-4.7013115681
+"TUR","Turkey Street",51.6726289265,-0.047190258
+"TUT","Tutbury & Hatton",52.8641515138,-1.6822308376
+"TVP","Tiverton Parkway",50.917168904,-3.3596569642
+"TWB","Tweedbank",55.6057393628,-2.7595353637
+"TWI","Twickenham",51.4500290431,-0.3303719704
+"TWN","Town Green",53.5428211891,-2.9044849794
+"TWY","Twyford",51.4755339055,-0.8632740226
 "TYB","Tan-y-Bwlch Ffestiniog Railway Station",52.9543847212,-4.0115223964
-"TYC","Ty Croes Rail Station",53.2225738882,-4.4747394282
-"TYG","Tygwyn Rail Station",52.8937988543,-4.0786617087
-"TYL","Tyndrum Lower Rail Station",56.4333287654,-4.7148053177
-"TYS","Tyseley Rail Station",52.4541295073,-1.839110539
-"TYW","Tywyn Rail Station",52.5855906404,-4.0935677848
-"UCK","Uckfield Rail Station",50.9687336094,0.0964070853
-"UDD","Uddingston Rail Station",55.8235220757,-4.0866850065
-"UHA","Uphall Rail Station",55.9190364207,-3.5021160921
-"UHL","Upper Holloway Rail Station",51.5636322354,-0.1294870843
-"ULC","Ulceby Rail Station",53.619221029,-0.3008319145
-"ULL","Ulleskelf Rail Station",53.8536281296,-1.2139769916
-"ULV","Ulverston Rail Station",54.1915918364,-3.0979152379
-"UMB","Umberleigh Rail Station",50.996741205,-3.9829094548
-"UNI","University Rail Station",52.4512550606,-1.9366781951
-"UPH","Upper Halliford Rail Station",51.4130654507,-0.4308849859
-"UPL","Upholland Rail Station",53.5283938559,-2.7414050505
-"UPM","Upminster Rail Station",51.5591080891,0.2509114423
-"UPT","Upton Rail Station",53.3865027098,-3.0841516558
-"UPW","Upwey Rail Station",50.6482597109,-2.4661355254
-"URM","Urmston Rail Station",53.4482848621,-2.353796027
-"UTT","Uttoxeter Rail Station",52.896806652,-1.8572519121
-"UTY","Upper Tyndrum Rail Station",56.4346498324,-4.7037058912
-"UWL","Upper Warlingham Rail Station",51.3085086648,-0.0779244127
-"VAL","Valley Rail Station",53.2813003565,-4.5633754695
-"VIC","London Victoria Rail Station",51.4952569307,-0.144534171
-"VIR","Virginia Water Rail Station",51.4018001404,-0.5621549173
-"VXH","Vauxhall Rail Station",51.4861891618,-0.1228646018
-"WAC","Warrington Central Rail Station",53.3918305175,-2.5931678177
-"WAD","Wadhurst Rail Station",51.0734564722,0.3132008907
-"WAE","London Waterloo East Rail Station",51.504075761,-0.108872757
-"WAF","Wallyford Rail Station",55.9402786267,-3.0149549323
-"WAL","Walton-on-Thames Rail Station",51.3729282422,-0.4146141512
-"WAM","Walmer Rail Station",51.2033289364,1.3829045251
-"WAN","Wanborough Rail Station",51.2445185634,-0.6675689513
-"WAO","Walton (Merseyside) Rail Station",53.4562297489,-2.9657463744
-"WAR","Ware Rail Station",51.8079649403,-0.0287536426
-"WAS","Watton-at-Stone Rail Station",51.8564430342,-0.1194009287
-"WAT","London Waterloo Rail Station",51.5032982602,-0.1130836248
-"WAV","Wavertree Technology Park Rail Station",53.405206521,-2.9229088929
-"WBC","Waterbeach Rail Station",52.2623177182,0.1968191721
-"WBD","Whitley Bridge Rail Station",53.6991474904,-1.1582841752
-"WBL","Warblington Rail Station",50.8534343877,-0.9671408737
-"WBO","Wimbledon Chase Rail Station",51.4095558211,-0.214007061
-"WBP","West Brompton Rail Station",51.4870605518,-0.1955689841
-"WBQ","Warrington Bank Quay Rail Station",53.3860225082,-2.6023634292
-"WBR","Whaley Bridge Rail Station",53.3302489394,-1.9846443668
-"WBY","West Byfleet Rail Station",51.3392223062,-0.5054647648
-"WCB","Westcombe Park Rail Station",51.484201535,0.0184203333
-"WCF","Westcliff-on-Sea Rail Station",51.5373355032,0.6914948438
-"WCH","Whitchurch (Hants) Rail Station",51.2375390314,-1.3377316326
-"WCK","Wick Rail Station",58.441552763,-3.0968646871
-"WCL","West Calder Rail Station",55.8537981997,-3.5670119586
-"WCM","Wickham Market Rail Station",52.151115559,1.3987106267
-"WCP","Worcester Park Rail Station",51.3812496853,-0.2451435039
-"WCR","Whitecraigs Rail Station",55.7903161404,-4.310143285
-"WCX","Wembley Stadium Rail Station",51.5544157634,-0.2855850739
-"WCY","West Croydon Rail Station",51.3784258204,-0.1025603616
-"WDB","Woodbridge Rail Station",52.0904601291,1.317801029
-"WDD","Widdrington Rail Station",55.2413084934,-1.6164875215
-"WDE","Wood End Rail Station",52.3436934001,-1.8442057013
-"WDH","Woodhouse Rail Station",53.363760625,-1.357553357
-"WDL","Woodhall Rail Station",55.9311983025,-4.6553823064
-"WDM","Windermere Rail Station",54.3796096377,-2.9033943659
-"WDN","Walsden Rail Station",53.6962732634,-2.104464907
-"WDO","Waddon Rail Station",51.3673957219,-0.1173106836
-"WDS","Woodlesford Rail Station",53.7568021778,-1.4428831514
-"WDT","West Drayton Rail Station",51.5100546283,-0.4722138153
-"WDU","West Dulwich Rail Station",51.4407162507,-0.0913457383
-"WEA","West Ealing Rail Station",51.5135045768,-0.3201109918
-"WED","Wedgwood Rail Station",52.951063264,-2.1708212356
-"WEE","Weeley Rail Station",51.8531089886,1.115513113
-"WEH","West Ham Rail Station",51.5284892546,0.0054585883
-"WEL","Wellingborough Rail Station",52.3037949376,-0.6766340582
-"WEM","Wem Rail Station",52.8564224306,-2.7180138594
-"WES","Westerton Rail Station",55.9047998365,-4.3348647949
-"WET","Weeton Rail Station",53.9231914641,-1.5812210981
-"WEY","Weymouth Rail Station",50.6153023761,-2.4542188409
-"WFF","Whifflet Rail Station",55.8536860909,-4.0186440499
-"WFH","Watford High Street Rail Station",51.6526581832,-0.3916880939
-"WFI","Westerfield Rail Station",52.0809953585,1.1659358409
-"WFJ","Watford Junction Rail Station",51.6635326348,-0.3964938369
-"WFL","Wainfleet Rail Station",53.1051521478,0.2347308866
-"WFN","Watford North Rail Station",51.6757075829,-0.3899023411
-"WGA","Westgate-on-Sea Rail Station",51.3814500239,1.3383886434
-"WGC","Welwyn Garden City Rail Station",51.8010528857,-0.2040464223
-"WGN","Wigan North Western Rail Station",53.5436746706,-2.6332734056
-"WGR","Woodgrange Park Rail Station",51.5492631072,0.0444499653
-"WGT","Wigton Rail Station",54.8291221455,-3.1643456818
-"WGV","Wargrave Rail Station",51.4981592025,-0.8764978044
-"WGW","Wigan Wallgate Rail Station",53.5448346342,-2.633185063
-"WHA","Westenhanger Rail Station",51.0949607041,1.0380815591
-"WHC","Walthamstow Central Rail Station",51.5829189505,-0.0197878799
-"WHD","West Hampstead Rail Station",51.5474681384,-0.1911595369
-"WHE","Whalley Rail Station",53.8240295678,-2.412253049
-"WHG","Westhoughton Rail Station",53.5556848068,-2.5237269574
-"WHI","Whitstable Rail Station",51.3575849431,1.0333248141
-"WHL","White Hart Lane Rail Station",51.6050372456,-0.0708886785
-"WHM","Whimple Rail Station",50.7680161469,-3.3543350506
-"WHN","Whiston Rail Station",53.4138830477,-2.7964313384
-"WHP","West Hampstead Thameslink Rail Station",51.5484763715,-0.1918118442
-"WHR","West Horndon Rail Station",51.5679455135,0.3406719119
-"WHS","Whyteleafe South Rail Station",51.3033836423,-0.076890083
-"WHT","Whitchurch (Cardiff) Rail Station",51.5207503854,-3.2232604275
-"WHY","Whyteleafe Rail Station",51.3099550362,-0.0811212248
-"WIC","Wickford Rail Station",51.6150252316,0.5192126597
-"WID","Widnes Rail Station",53.3785111245,-2.7335372039
-"WIH","Winchmore Hill Rail Station",51.6339428901,-0.1008743449
-"WIJ","Willesden Junction Rail Station",51.5324966867,-0.2445240688
-"WIL","Willington Rail Station",52.8536609081,-1.5633566039
-"WIM","Wimbledon Rail Station",51.4212733693,-0.2063586485
-"WIN","Winchester Rail Station",51.0672031347,-1.3196880282
-"WIV","Wivenhoe Rail Station",51.8565396555,0.9561671919
-"WKB","West Kilbride Rail Station",55.6961504044,-4.8517231169
-"WKD","Walkden Rail Station",53.5197896484,-2.3963191924
-"WKF","Wakefield Westgate Rail Station",53.6830884864,-1.5061128915
-"WKG","Workington Rail Station",54.6451016394,-3.5585006973
-"WKI","West Kirby Rail Station",53.3731876944,-3.1837707177
-"WKK","Wakefield Kirkgate Rail Station",53.6786734429,-1.4885726643
-"WKM","Wokingham Rail Station",51.4112171669,-0.8425250632
-"WLC","Waltham Cross Rail Station",51.6850619631,-0.0265322372
-"WLD","West St Leonards Rail Station",50.8531478652,0.539964669
-"WLE","Whittlesea Rail Station",52.5495457817,-0.1189720533
-"WLF","Whittlesford Parkway Rail Station",52.1035981209,0.1656457011
-"WLG","Wallasey Grove Road Rail Station",53.4280187313,-3.069705311
-"WLH","Wolsingham Rail Station",54.7263219512,-1.8835277375
-"WLI","Welling Rail Station",51.4647970094,0.1017165383
-"WLM","Williamwood Rail Station",55.7936801397,-4.2903211229
-"WLN","Wellington (Shropshire) Rail Station",52.7013189006,-2.5171628549
-"WLO","Waterloo (Merseyside) Rail Station",53.4749677015,-3.0255345128
-"WLP","Welshpool Rail Station",52.6575072859,-3.1398692323
-"WLS","Woolston Rail Station",50.898912011,-1.3770486087
-"WLT","Wallington Rail Station",51.3603838072,-0.1508078249
-"WLV","Wallasey Village Rail Station",53.4229003142,-3.0691254064
-"WLW","Welwyn North Rail Station",51.8235025409,-0.1920673777
-"WLY","Woodley Rail Station",53.4292679007,-2.0932702851
-"WMA","West Malling Rail Station",51.2920176581,0.4186819525
-"WMB","Wembley Central Rail Station",51.552325148,-0.2964096325
-"WMC","Wilmcote Rail Station",52.2230107026,-1.7560030891
-"WMD","Wymondham Rail Station",52.5654338739,1.1180480575
-"WME","Woodmansterne Rail Station",51.3190162934,-0.1542365305
-"WMG","Welham Green Rail Station",51.736355041,-0.210669375
-"WMI","Wildmill Rail Station",51.5208701744,-3.5796491532
-"WML","Wilmslow Rail Station",53.3268623597,-2.226326187
-"WMN","Warminster Rail Station",51.2067697704,-2.1767285454
-"WMR","Widney Manor Rail Station",52.3959484322,-1.7743630129
-"WMS","Wemyss Bay Rail Station",55.8761375469,-4.8890595221
-"WMW","Walthamstow Queens Road Rail Station",51.5815031634,-0.0238187685
-"WNC","Windsor & Eton Central Rail Station",51.4832677885,-0.6103634231
-"WND","Wendover Rail Station",51.7617617158,-0.7473477525
-"WNE","Wilnecote (Staffs) Rail Station",52.6107271717,-1.6797075751
-"WNF","Winchfield Rail Station",51.2849477502,-0.9069607416
-"WNG","Waun-gron Park Rail Station",51.4881949213,-3.2296615036
-"WNH","Warnham Rail Station",51.0928963956,-0.3294372471
-"WNL","Whinhill Rail Station",55.9383637813,-4.7466746978
-"WNM","Weston Milton Rail Station",51.348465771,-2.9423917485
-"WNN","Wennington Rail Station",54.1237145615,-2.5875119193
-"WNP","Wanstead Park Rail Station",51.5516926945,0.0262400164
-"WNR","Windsor & Eton Riverside Rail Station",51.4856499617,-0.6065175067
-"WNS","Winnersh Rail Station",51.4302818498,-0.87683995
-"WNT","Wandsworth Town Rail Station",51.4610465985,-0.1881010831
-"WNW","West Norwood Rail Station",51.4317458109,-0.1038042183
-"WNY","White Notley Rail Station",51.8389190888,0.5958911326
-"WOB","Woburn Sands Rail Station",52.0181602116,-0.6540621907
-"WOF","Worcester Foregate Street Rail Station",52.1951552361,-2.2215923384
-"WOH","Woldingham Rail Station",51.2901548311,-0.0518430517
-"WOK","Woking Rail Station",51.3184663679,-0.5569403769
-"WOL","Wolverton Rail Station",52.0658873901,-0.8042463611
-"WOM","Wombwell Rail Station",53.517362766,-1.4161637925
-"WON","Walton-on-the-Naze Rail Station",51.8461792474,1.2676990657
-"WOO","Wool Rail Station",50.681626061,-2.2214563212
-"WOR","Worle Rail Station",51.3580317777,-2.9096264535
-"WOS","Worcester Shrub Hill Rail Station",52.194736867,-2.2094036358
-"WPE","Wapping Rail Station",51.5043874917,-0.0559045836
-"WPL","Worplesdon Rail Station",51.289013057,-0.5825586496
-"WRB","Wrabness Rail Station",51.9395205813,1.1715280173
-"WRE","Wrenbury Rail Station",53.0194020901,-2.5959470421
-"WRH","Worthing Rail Station",50.8184892196,-0.3761461656
-"WRK","Worksop Rail Station",53.3115252628,-1.1227713307
-"WRL","Wetheral Rail Station",54.8838456329,-2.8317175358
-"WRM","Wareham Rail Station",50.6928762389,-2.1152411345
-"WRN","West Runton Rail Station",52.9355527634,1.2454754855
-"WRP","Warwick Parkway Rail Station",52.2861162934,-1.6120460343
-"WRS","Wressle Rail Station",53.7729422572,-0.9243539655
-"WRT","Worstead Rail Station",52.7774520547,1.4041024484
-"WRU","West Ruislip Rail Station",51.5697585389,-0.4377469365
-"WRW","Warwick Rail Station",52.2865527555,-1.5818426042
-"WRX","Wrexham General Rail Station",53.0502463948,-3.0024435025
-"WRY","Wraysbury Rail Station",51.4577071718,-0.5419033065
-"WSA","West Allerton Rail Station",53.3691394493,-2.9069642345
-"WSB","Westbury (Wilts) Rail Station",51.2669801221,-2.1991779411
-"WSE","Winchelsea Rail Station",50.933760407,0.7022917517
-"WSF","Winsford Rail Station",53.190525188,-2.4945975727
-"WSH","Wishaw Rail Station",55.7720379365,-3.9264142917
-"WSL","Walsall Rail Station",52.5844123362,-1.9847496237
-"WSM","Weston-super-Mare Rail Station",51.3443145157,-2.9716684624
-"WSR","Woodsmoor Rail Station",53.3864885313,-2.1420856045
-"WST","Wood Street Rail Station",51.5865803321,-0.0023784573
-"WSU","West Sutton Rail Station",51.3658510426,-0.2051484336
-"WSW","Wandsworth Common Rail Station",51.4461834495,-0.1633607829
-"WTA","Wester Hailes Rail Station",55.9143114673,-3.2843381703
-"WTB","Whitby Rail Station",54.4846228934,-0.6154196587
-"WTC","Whitchurch (Shrops) Rail Station",52.9680723073,-2.6716975313
-"WTE","Whitlocks End Rail Station",52.3918444057,-1.8515316565
-"WTG","Watlington Rail Station",52.6731905958,0.383333413
-"WTH","Whitehaven Rail Station",54.5530370984,-3.5869341489
-"WTI","Winnersh Triangle Rail Station",51.436740952,-0.891312814
-"WTL","Whitland Rail Station",51.8180389016,-4.6144179575
-"WTM","Witham (Essex) Rail Station",51.8059754077,0.6391569064
-"WTN","Whitton Rail Station",51.4496053939,-0.3576601374
-"WTO","Water Orton Rail Station",52.5185987323,-1.743083154
-"WTR","Wateringbury Rail Station",51.2497316844,0.4224946816
-"WTS","Whatstandwell Rail Station",53.0833304944,-1.5040836241
-"WTT","Witton (West Midlands) Rail Station",52.512392581,-1.88442989
-"WTY","Witley Rail Station",51.1331560769,-0.6457625387
-"WVF","Wivelsfield Rail Station",50.9642899705,-0.1207633726
-"WVH","Wolverhampton Rail Station",52.5878584294,-2.1195080884
-"WWA","Woolwich Arsenal Rail Station",51.4899075996,0.0692207097
-"WWD","Woolwich Dockyard Rail Station",51.4911257712,0.0546684641
-"WWI","West Wickham Rail Station",51.381299435,-0.01440507
-"WWL","Whitwell (Derbys) Rail Station",53.2799805667,-1.2002056127
-"WWO","West Worthing Rail Station",50.8183442209,-0.3929601185
-"WWR","Wandsworth Road Rail Station",51.4702155479,-0.1384945236
-"WWW","Wootton Wawen Rail Station",52.2669127478,-1.7846878163
-"WXC","Wrexham Central Rail Station",53.0462026991,-2.9990529112
-"WYB","Weybridge Rail Station",51.3617683693,-0.4577187292
-"WYE","Wye Rail Station",51.1850110281,0.9293337289
-"WYL","Wylde Green Rail Station",52.545726518,-1.8314010655
-"WYM","Wylam Rail Station",54.9749775863,-1.8140737353
-"WYT","Wythall Rail Station",52.3799491076,-1.8655274464
-"YAE","Yate Rail Station",51.5405996642,-2.4325201347
-"YAL","Yalding Rail Station",51.2264801343,0.4121922549
-"YAT","Yatton Rail Station",51.3910100893,-2.8277833431
-"YEO","Yeoford Rail Station",50.7769135717,-3.7271368279
-"YET","Yetminster Rail Station",50.8957550733,-2.5737566578
-"YNW","Ynyswen Rail Station",51.6649733413,-3.5216084057
-"YOK","Yoker Rail Station",55.8925792728,-4.3862714831
-"YRD","Yardley Wood Rail Station",52.4215152176,-1.8543739528
-"YRK","York Rail Station",53.9579821958,-1.0931909318
-"YRM","Yarm Rail Station",54.493908683,-1.3515575298
-"YRT","Yorton Rail Station",52.8089705446,-2.736458295
-"YSM","Ystrad Mynach Rail Station",51.6409356979,-3.2413052794
-"YSR","Ystrad Rhondda Rail Station",51.6436413608,-3.4666955023
-"YVJ","Yeovil Junction Rail Station",50.9247392604,-2.6124572985
-"YVP","Yeovil Pen Mill Rail Station",50.9445178485,-2.6134285854
+"TYC","Ty Croes",53.2225738882,-4.4747394282
+"TYG","Tygwyn",52.8937988543,-4.0786617087
+"TYL","Tyndrum Lower",56.4333287654,-4.7148053177
+"TYS","Tyseley",52.4541295073,-1.839110539
+"TYW","Tywyn",52.5855906404,-4.0935677848
+"UCK","Uckfield",50.9687336094,0.0964070853
+"UDD","Uddingston",55.8235220757,-4.0866850065
+"UHA","Uphall",55.9190364207,-3.5021160921
+"UHL","Upper Holloway",51.5636322354,-0.1294870843
+"ULC","Ulceby",53.619221029,-0.3008319145
+"ULL","Ulleskelf",53.8536281296,-1.2139769916
+"ULV","Ulverston",54.1915918364,-3.0979152379
+"UMB","Umberleigh",50.996741205,-3.9829094548
+"UNI","University",52.4512550606,-1.9366781951
+"UPH","Upper Halliford",51.4130654507,-0.4308849859
+"UPL","Upholland",53.5283938559,-2.7414050505
+"UPM","Upminster",51.5591080891,0.2509114423
+"UPT","Upton",53.3865027098,-3.0841516558
+"UPW","Upwey",50.6482597109,-2.4661355254
+"URM","Urmston",53.4482848621,-2.353796027
+"UTT","Uttoxeter",52.896806652,-1.8572519121
+"UTY","Upper Tyndrum",56.4346498324,-4.7037058912
+"UWL","Upper Warlingham",51.3085086648,-0.0779244127
+"VAL","Valley",53.2813003565,-4.5633754695
+"VIC","London Victoria",51.4952569307,-0.144534171
+"VIR","Virginia Water",51.4018001404,-0.5621549173
+"VXH","Vauxhall",51.4861891618,-0.1228646018
+"WAC","Warrington Central",53.3918305175,-2.5931678177
+"WAD","Wadhurst",51.0734564722,0.3132008907
+"WAE","London Waterloo East",51.504075761,-0.108872757
+"WAF","Wallyford",55.9402786267,-3.0149549323
+"WAL","Walton-on-Thames",51.3729282422,-0.4146141512
+"WAM","Walmer",51.2033289364,1.3829045251
+"WAN","Wanborough",51.2445185634,-0.6675689513
+"WAO","Walton (Merseyside)",53.4562297489,-2.9657463744
+"WAR","Ware",51.8079649403,-0.0287536426
+"WAS","Watton-at-Stone",51.8564430342,-0.1194009287
+"WAT","London Waterloo",51.5032982602,-0.1130836248
+"WAW","Warrington West", 53.393744, -2.636929
+"WAV","Wavertree Technology Park",53.405206521,-2.9229088929
+"WBC","Waterbeach",52.2623177182,0.1968191721
+"WBD","Whitley Bridge",53.6991474904,-1.1582841752
+"WBL","Warblington",50.8534343877,-0.9671408737
+"WBO","Wimbledon Chase",51.4095558211,-0.214007061
+"WBP","West Brompton",51.4870605518,-0.1955689841
+"WBQ","Warrington Bank Quay",53.3860225082,-2.6023634292
+"WBR","Whaley Bridge",53.3302489394,-1.9846443668
+"WBY","West Byfleet",51.3392223062,-0.5054647648
+"WCB","Westcombe Park",51.484201535,0.0184203333
+"WCF","Westcliff-on-Sea",51.5373355032,0.6914948438
+"WCH","Whitchurch (Hants)",51.2375390314,-1.3377316326
+"WCK","Wick",58.441552763,-3.0968646871
+"WCL","West Calder",55.8537981997,-3.5670119586
+"WCM","Wickham Market",52.151115559,1.3987106267
+"WCP","Worcester Park",51.3812496853,-0.2451435039
+"WCR","Whitecraigs",55.7903161404,-4.310143285
+"WCX","Wembley Stadium",51.5544157634,-0.2855850739
+"WCY","West Croydon",51.3784258204,-0.1025603616
+"WDB","Woodbridge",52.0904601291,1.317801029
+"WDD","Widdrington",55.2413084934,-1.6164875215
+"WDE","Wood End",52.3436934001,-1.8442057013
+"WDH","Woodhouse",53.363760625,-1.357553357
+"WDL","Woodhall",55.9311983025,-4.6553823064
+"WDM","Windermere",54.3796096377,-2.9033943659
+"WDN","Walsden",53.6962732634,-2.104464907
+"WDO","Waddon",51.3673957219,-0.1173106836
+"WDS","Woodlesford",53.7568021778,-1.4428831514
+"WDT","West Drayton",51.5100546283,-0.4722138153
+"WDU","West Dulwich",51.4407162507,-0.0913457383
+"WEA","West Ealing",51.5135045768,-0.3201109918
+"WED","Wedgwood",52.951063264,-2.1708212356
+"WEE","Weeley",51.8531089886,1.115513113
+"WEH","West Ham",51.5284892546,0.0054585883
+"WEL","Wellingborough",52.3037949376,-0.6766340582
+"WEM","Wem",52.8564224306,-2.7180138594
+"WES","Westerton",55.9047998365,-4.3348647949
+"WET","Weeton",53.9231914641,-1.5812210981
+"WEY","Weymouth",50.6153023761,-2.4542188409
+"WFF","Whifflet",55.8536860909,-4.0186440499
+"WFH","Watford High Street",51.6526581832,-0.3916880939
+"WFI","Westerfield",52.0809953585,1.1659358409
+"WFJ","Watford Junction",51.6635326348,-0.3964938369
+"WFL","Wainfleet",53.1051521478,0.2347308866
+"WFN","Watford North",51.6757075829,-0.3899023411
+"WGA","Westgate-on-Sea",51.3814500239,1.3383886434
+"WGC","Welwyn Garden City",51.8010528857,-0.2040464223
+"WGN","Wigan North Western",53.5436746706,-2.6332734056
+"WGR","Woodgrange Park",51.5492631072,0.0444499653
+"WGT","Wigton",54.8291221455,-3.1643456818
+"WGV","Wargrave",51.4981592025,-0.8764978044
+"WGW","Wigan Wallgate",53.5448346342,-2.633185063
+"WHA","Westenhanger",51.0949607041,1.0380815591
+"WHC","Walthamstow Central",51.5829189505,-0.0197878799
+"WHD","West Hampstead",51.5474681384,-0.1911595369
+"WHE","Whalley",53.8240295678,-2.412253049
+"WHG","Westhoughton",53.5556848068,-2.5237269574
+"WHI","Whitstable",51.3575849431,1.0333248141
+"WHL","White Hart Lane",51.6050372456,-0.0708886785
+"WHM","Whimple",50.7680161469,-3.3543350506
+"WHN","Whiston",53.4138830477,-2.7964313384
+"WHP","West Hampstead Thameslink",51.5484763715,-0.1918118442
+"WHR","West Horndon",51.5679455135,0.3406719119
+"WHS","Whyteleafe South",51.3033836423,-0.076890083
+"WHT","Whitchurch (Cardiff)",51.5207503854,-3.2232604275
+"WHY","Whyteleafe",51.3099550362,-0.0811212248
+"WIC","Wickford",51.6150252316,0.5192126597
+"WID","Widnes",53.3785111245,-2.7335372039
+"WIH","Winchmore Hill",51.6339428901,-0.1008743449
+"WIJ","Willesden Junction",51.5324966867,-0.2445240688
+"WIL","Willington",52.8536609081,-1.5633566039
+"WIM","Wimbledon",51.4212733693,-0.2063586485
+"WIN","Winchester",51.0672031347,-1.3196880282
+"WIV","Wivenhoe",51.8565396555,0.9561671919
+"WKB","West Kilbride",55.6961504044,-4.8517231169
+"WKD","Walkden",53.5197896484,-2.3963191924
+"WKF","Wakefield Westgate",53.6830884864,-1.5061128915
+"WKG","Workington",54.6451016394,-3.5585006973
+"WKI","West Kirby",53.3731876944,-3.1837707177
+"WKK","Wakefield Kirkgate",53.6786734429,-1.4885726643
+"WKM","Wokingham",51.4112171669,-0.8425250632
+"WLC","Waltham Cross",51.6850619631,-0.0265322372
+"WLD","West St Leonards",50.8531478652,0.539964669
+"WLE","Whittlesea",52.5495457817,-0.1189720533
+"WLF","Whittlesford Parkway",52.1035981209,0.1656457011
+"WLG","Wallasey Grove Road",53.4280187313,-3.069705311
+"WLH","Wolsingham",54.7263219512,-1.8835277375
+"WLI","Welling",51.4647970094,0.1017165383
+"WLM","Williamwood",55.7936801397,-4.2903211229
+"WLN","Wellington (Shropshire)",52.7013189006,-2.5171628549
+"WLO","Waterloo (Merseyside)",53.4749677015,-3.0255345128
+"WLP","Welshpool",52.6575072859,-3.1398692323
+"WLS","Woolston",50.898912011,-1.3770486087
+"WLT","Wallington",51.3603838072,-0.1508078249
+"WLV","Wallasey Village",53.4229003142,-3.0691254064
+"WLW","Welwyn North",51.8235025409,-0.1920673777
+"WLY","Woodley",53.4292679007,-2.0932702851
+"WMA","West Malling",51.2920176581,0.4186819525
+"WMB","Wembley Central",51.552325148,-0.2964096325
+"WMC","Wilmcote",52.2230107026,-1.7560030891
+"WMD","Wymondham",52.5654338739,1.1180480575
+"WME","Woodmansterne",51.3190162934,-0.1542365305
+"WMG","Welham Green",51.736355041,-0.210669375
+"WMI","Wildmill",51.5208701744,-3.5796491532
+"WML","Wilmslow",53.3268623597,-2.226326187
+"WMN","Warminster",51.2067697704,-2.1767285454
+"WMR","Widney Manor",52.3959484322,-1.7743630129
+"WMS","Wemyss Bay",55.8761375469,-4.8890595221
+"WMW","Walthamstow Queens Road",51.5815031634,-0.0238187685
+"WNC","Windsor & Eton Central",51.4832677885,-0.6103634231
+"WND","Wendover",51.7617617158,-0.7473477525
+"WNE","Wilnecote (Staffs)",52.6107271717,-1.6797075751
+"WNF","Winchfield",51.2849477502,-0.9069607416
+"WNG","Waun-gron Park",51.4881949213,-3.2296615036
+"WNH","Warnham",51.0928963956,-0.3294372471
+"WNL","Whinhill",55.9383637813,-4.7466746978
+"WNM","Weston Milton",51.348465771,-2.9423917485
+"WNN","Wennington",54.1237145615,-2.5875119193
+"WNP","Wanstead Park",51.5516926945,0.0262400164
+"WNR","Windsor & Eton Riverside",51.4856499617,-0.6065175067
+"WNS","Winnersh",51.4302818498,-0.87683995
+"WNT","Wandsworth Town",51.4610465985,-0.1881010831
+"WNW","West Norwood",51.4317458109,-0.1038042183
+"WNY","White Notley",51.8389190888,0.5958911326
+"WOB","Woburn Sands",52.0181602116,-0.6540621907
+"WOF","Worcester Foregate Street",52.1951552361,-2.2215923384
+"WOH","Woldingham",51.2901548311,-0.0518430517
+"WOK","Woking",51.3184663679,-0.5569403769
+"WOL","Wolverton",52.0658873901,-0.8042463611
+"WOM","Wombwell",53.517362766,-1.4161637925
+"WON","Walton-on-the-Naze",51.8461792474,1.2676990657
+"WOO","Wool",50.681626061,-2.2214563212
+"WOP","Worcestershire Parkway", 52.1556, -2.1609
+"WOR","Worle",51.3580317777,-2.9096264535
+"WOS","Worcester Shrub Hill",52.194736867,-2.2094036358
+"WPE","Wapping",51.5043874917,-0.0559045836
+"WPL","Worplesdon",51.289013057,-0.5825586496
+"WRB","Wrabness",51.9395205813,1.1715280173
+"WRE","Wrenbury",53.0194020901,-2.5959470421
+"WRH","Worthing",50.8184892196,-0.3761461656
+"WRK","Worksop",53.3115252628,-1.1227713307
+"WRL","Wetheral",54.8838456329,-2.8317175358
+"WRM","Wareham",50.6928762389,-2.1152411345
+"WRN","West Runton",52.9355527634,1.2454754855
+"WRP","Warwick Parkway",52.2861162934,-1.6120460343
+"WRS","Wressle",53.7729422572,-0.9243539655
+"WRT","Worstead",52.7774520547,1.4041024484
+"WRU","West Ruislip",51.5697585389,-0.4377469365
+"WRW","Warwick",52.2865527555,-1.5818426042
+"WRX","Wrexham General",53.0502463948,-3.0024435025
+"WRY","Wraysbury",51.4577071718,-0.5419033065
+"WSA","West Allerton",53.3691394493,-2.9069642345
+"WSB","Westbury (Wilts)",51.2669801221,-2.1991779411
+"WSE","Winchelsea",50.933760407,0.7022917517
+"WSF","Winsford",53.190525188,-2.4945975727
+"WSH","Wishaw",55.7720379365,-3.9264142917
+"WSL","Walsall",52.5844123362,-1.9847496237
+"WSM","Weston-super-Mare",51.3443145157,-2.9716684624
+"WSR","Woodsmoor",53.3864885313,-2.1420856045
+"WST","Wood Street",51.5865803321,-0.0023784573
+"WSU","West Sutton",51.3658510426,-0.2051484336
+"WSW","Wandsworth Common",51.4461834495,-0.1633607829
+"WTA","Wester Hailes",55.9143114673,-3.2843381703
+"WTB","Whitby",54.4846228934,-0.6154196587
+"WTC","Whitchurch (Shrops)",52.9680723073,-2.6716975313
+"WTE","Whitlocks End",52.3918444057,-1.8515316565
+"WTG","Watlington",52.6731905958,0.383333413
+"WTH","Whitehaven",54.5530370984,-3.5869341489
+"WTI","Winnersh Triangle",51.436740952,-0.891312814
+"WTL","Whitland",51.8180389016,-4.6144179575
+"WTM","Witham (Essex)",51.8059754077,0.6391569064
+"WTN","Whitton",51.4496053939,-0.3576601374
+"WTO","Water Orton",52.5185987323,-1.743083154
+"WTR","Wateringbury",51.2497316844,0.4224946816
+"WTS","Whatstandwell",53.0833304944,-1.5040836241
+"WTT","Witton (West Midlands)",52.512392581,-1.88442989
+"WTY","Witley",51.1331560769,-0.6457625387
+"WVF","Wivelsfield",50.9642899705,-0.1207633726
+"WVH","Wolverhampton",52.5878584294,-2.1195080884
+"WWA","Woolwich Arsenal",51.4899075996,0.0692207097
+"WWC","Woolwich",51.491578,0.071819
+"WWD","Woolwich Dockyard",51.4911257712,0.0546684641
+"WWI","West Wickham",51.381299435,-0.01440507
+"WWL","Whitwell (Derbys)",53.2799805667,-1.2002056127
+"WWO","West Worthing",50.8183442209,-0.3929601185
+"WWR","Wandsworth Road",51.4702155479,-0.1384945236
+"WWW","Wootton Wawen",52.2669127478,-1.7846878163
+"WXC","Wrexham Central",53.0462026991,-2.9990529112
+"WYB","Weybridge",51.3617683693,-0.4577187292
+"WYE","Wye",51.1850110281,0.9293337289
+"WYL","Wylde Green",52.545726518,-1.8314010655
+"WYM","Wylam",54.9749775863,-1.8140737353
+"WYT","Wythall",52.3799491076,-1.8655274464
+"YAE","Yate",51.5405996642,-2.4325201347
+"YAL","Yalding",51.2264801343,0.4121922549
+"YAT","Yatton",51.3910100893,-2.8277833431
+"YEO","Yeoford",50.7769135717,-3.7271368279
+"YET","Yetminster",50.8957550733,-2.5737566578
+"YNW","Ynyswen",51.6649733413,-3.5216084057
+"YOK","Yoker",55.8925792728,-4.3862714831
+"YRD","Yardley Wood",52.4215152176,-1.8543739528
+"YRK","York",53.9579821958,-1.0931909318
+"YRM","Yarm",54.493908683,-1.3515575298
+"YRT","Yorton",52.8089705446,-2.736458295
+"YSM","Ystrad Mynach",51.6409356979,-3.2413052794
+"YSR","Ystrad Rhondda",51.6436413608,-3.4666955023
+"YVJ","Yeovil Junction",50.9247392604,-2.6124572985
+"YVP","Yeovil Pen Mill",50.9445178485,-2.6134285854
 "ZBU","Southease - Piddinghoe Road",50.8296187442,0.0178462867
-"ZCW","Canada Water Rail Station",51.4979894212,-0.0496935895
-"ZFD","Farringdon (London) Rail Station",51.5201671742,-0.1051789136
-"ZWL","Whitechapel Rail Station",51.5194686455,-0.0597305213
-"ZZT","Lintley Rail Station",54.853558347,-2.4883171256
+"ZCW","Canada Water",51.4979894212,-0.0496935895
+"ZFD","Farringdon (London)",51.5201671742,-0.1051789136
+"ZWL","Whitechapel",51.5194686455,-0.0597305213
+"ZZT","Lintley",54.853558347,-2.4883171256

--- a/uk-train-stations.json
+++ b/uk-train-stations.json
@@ -552,6 +552,12 @@
     "longitude": -2.1087526816
   },
   {
+    "3alpha": "ASD",
+    "station_name": "Ashley Down",
+    "latitude": 51.4788,
+    "longitude": -2.5767
+  },
+  {
     "3alpha": "ASF",
     "station_name": "Ashfield",
     "latitude": 55.8889152278,
@@ -574,6 +580,12 @@
     "station_name": "Askam",
     "latitude": 54.1889365481,
     "longitude": -3.2045108901
+  },
+  {
+    "3alpha": "ASL",
+    "station_name": "Ashington",
+    "latitude": 55.1820,
+    "longitude": -1.5731
   },
   {
     "3alpha": "ASN",
@@ -2674,6 +2686,12 @@
     "station_name": "Canterbury West",
     "latitude": 51.284271981,
     "longitude": 1.0753330452
+  },
+  {
+    "3alpha": "CBX",
+    "station_name": "Cameron Bridge",
+    "latitude": 56.189693,
+    "longitude": -3.046855
   },
   {
     "3alpha": "CBY",
@@ -8334,6 +8352,12 @@
     "longitude": -2.6871416367
   },
   {
+    "3alpha": "LEV",
+    "station_name": "Leven",
+    "latitude": 56.1923,
+    "longitude": -3.002
+  },
+  {
     "3alpha": "LFD",
     "station_name": "Lingfield",
     "latitude": 51.1764479512,
@@ -11022,6 +11046,12 @@
     "longitude": -2.7081248286
   },
   {
+    "3alpha": "PRI",
+    "station_name": "Portway Park and Ride",
+    "latitude": 51.488611,
+    "longitude": -2.688056
+  },
+  {
     "3alpha": "PRH",
     "station_name": "Penrhyndeudraeth",
     "latitude": 52.9288395107,
@@ -11554,6 +11584,12 @@
     "station_name": "Rugeley Trent Valley",
     "latitude": 52.7696708266,
     "longitude": -1.9298468285
+  },
+  {
+    "3alpha": "RGP",
+    "station_name": "Reading Green Park",
+    "latitude": 51.426667,
+    "longitude": -1.001389
   },
   {
     "3alpha": "RGT",
@@ -13816,6 +13852,12 @@
     "station_name": "Thornford",
     "latitude": 50.9105671531,
     "longitude": -2.5789881669
+  },
+  {
+    "3alpha": "THP",
+    "station_name": "Thanet Parkway",
+    "latitude": 51.330843,
+    "longitude": 1.361777
   },
   {
     "3alpha": "THS",

--- a/uk-train-stations.json
+++ b/uk-train-stations.json
@@ -1,463 +1,463 @@
 [
   {
     "3alpha": "AAP",
-    "station_name": "Alexandra Palace Rail Station",
+    "station_name": "Alexandra Palace",
     "latitude": 51.5979250073,
     "longitude": -0.1202099313
   },
   {
     "3alpha": "AAT",
-    "station_name": "Achanalt Rail Station",
+    "station_name": "Achanalt",
     "latitude": 57.6095763828,
     "longitude": -4.913846165
   },
   {
     "3alpha": "ABA",
-    "station_name": "Aberdare Rail Station",
+    "station_name": "Aberdare",
     "latitude": 51.7150603368,
     "longitude": -3.4430947912
   },
   {
     "3alpha": "ABC",
-    "station_name": "Altnabreac Rail Station",
+    "station_name": "Altnabreac",
     "latitude": 58.3881329239,
     "longitude": -3.7062873902
   },
-  {
+  { 
     "3alpha": "ABD",
-    "station_name": "Aberdeen Rail Station",
+    "station_name": "Aberdeen",
     "latitude": 57.1436867734,
     "longitude": -2.0986925585
   },
   {
     "3alpha": "ABE",
-    "station_name": "Aber Rail Station",
+    "station_name": "Aber",
     "latitude": 51.5749656756,
     "longitude": -3.2298391052
   },
   {
     "3alpha": "ABH",
-    "station_name": "Abererch Rail Station",
+    "station_name": "Abererch",
     "latitude": 52.8985982311,
     "longitude": -4.3741839689
   },
   {
     "3alpha": "ABW",
-    "station_name": "Abbey Wood (London) Rail Station",
+    "station_name": "Abbey Wood (London)",
     "latitude": 51.4910611665,
     "longitude": 0.1214217457
   },
   {
     "3alpha": "ABY",
-    "station_name": "Ashburys Rail Station",
+    "station_name": "Ashburys",
     "latitude": 53.4716521884,
     "longitude": -2.194434998
   },
   {
     "3alpha": "ACB",
-    "station_name": "Acton Bridge Rail Station",
+    "station_name": "Acton Bridge",
     "latitude": 53.2665207003,
     "longitude": -2.6031255204
   },
   {
     "3alpha": "ACC",
-    "station_name": "Acton Central Rail Station",
+    "station_name": "Acton Central",
     "latitude": 51.5087156784,
     "longitude": -0.2629477949
   },
   {
     "3alpha": "ACG",
-    "station_name": "Acocks Green Rail Station",
+    "station_name": "Acocks Green",
     "latitude": 52.4493357815,
     "longitude": -1.8189696484
   },
   {
     "3alpha": "ACH",
-    "station_name": "Achnashellach Rail Station",
+    "station_name": "Achnashellach",
     "latitude": 57.4820517208,
     "longitude": -5.3330497284
   },
   {
     "3alpha": "ACK",
-    "station_name": "Acklington Rail Station",
+    "station_name": "Acklington",
     "latitude": 55.3070995797,
     "longitude": -1.6518483985
   },
   {
     "3alpha": "ACL",
-    "station_name": "Acle Rail Station",
+    "station_name": "Acle",
     "latitude": 52.6347061444,
     "longitude": 1.5439384675
   },
   {
     "3alpha": "ACN",
-    "station_name": "Achnasheen Rail Station",
+    "station_name": "Achnasheen",
     "latitude": 57.5792680938,
     "longitude": -5.0723280881
   },
   {
     "3alpha": "ACR",
-    "station_name": "Accrington Rail Station",
+    "station_name": "Accrington",
     "latitude": 53.7529844843,
     "longitude": -2.3695474455
   },
   {
     "3alpha": "ACT",
-    "station_name": "Ascot Rail Station",
+    "station_name": "Ascot",
     "latitude": 51.4062421592,
     "longitude": -0.6758156963
   },
   {
     "3alpha": "ACY",
-    "station_name": "Abercynon Rail Station",
+    "station_name": "Abercynon",
     "latitude": 51.6447111646,
     "longitude": -3.3270008927
   },
   {
     "3alpha": "ADC",
-    "station_name": "Adlington (Cheshire) Rail Station",
+    "station_name": "Adlington (Cheshire)",
     "latitude": 53.3195695329,
     "longitude": -2.1335617879
   },
   {
     "3alpha": "ADD",
-    "station_name": "Adderley Park Rail Station",
+    "station_name": "Adderley Park",
     "latitude": 52.4830987434,
     "longitude": -1.8559397876
   },
   {
     "3alpha": "ADK",
-    "station_name": "Ardwick Rail Station",
+    "station_name": "Ardwick",
     "latitude": 53.471358298,
     "longitude": -2.213882234
   },
   {
     "3alpha": "ADL",
-    "station_name": "Adlington (Lancs) Rail Station",
+    "station_name": "Adlington (Lancs)",
     "latitude": 53.6132582182,
     "longitude": -2.603069152
   },
   {
     "3alpha": "ADM",
-    "station_name": "Adisham Rail Station",
+    "station_name": "Adisham",
     "latitude": 51.2412043148,
     "longitude": 1.1991182098
   },
   {
     "3alpha": "ADN",
-    "station_name": "Ardrossan Town Rail Station",
+    "station_name": "Ardrossan Town",
     "latitude": 55.6397026924,
     "longitude": -4.8126528377
   },
   {
     "3alpha": "ADR",
-    "station_name": "Airdrie Rail Station",
+    "station_name": "Airdrie",
     "latitude": 55.8639734432,
     "longitude": -3.9829014475
   },
   {
     "3alpha": "ADS",
-    "station_name": "Ardrossan Harbour Rail Station",
+    "station_name": "Ardrossan Harbour",
     "latitude": 55.6398684301,
     "longitude": -4.8210878622
   },
   {
     "3alpha": "ADV",
-    "station_name": "Andover Rail Station",
+    "station_name": "Andover",
     "latitude": 51.2115409141,
     "longitude": -1.4922208179
   },
   {
     "3alpha": "ADW",
-    "station_name": "Addiewell Rail Station",
+    "station_name": "Addiewell",
     "latitude": 55.8434039199,
     "longitude": -3.6065211407
   },
   {
     "3alpha": "AFK",
-    "station_name": "Ashford International Rail Station",
+    "station_name": "Ashford International",
     "latitude": 51.143703647,
     "longitude": 0.8762282027
   },
   {
     "3alpha": "AFS",
-    "station_name": "Ashford (Surrey) Rail Station",
+    "station_name": "Ashford (Surrey)",
     "latitude": 51.4365050918,
     "longitude": -0.4680505426
   },
   {
     "3alpha": "AFV",
-    "station_name": "Ansdell & Fairhaven Rail Station",
+    "station_name": "Ansdell & Fairhaven",
     "latitude": 53.7414755302,
     "longitude": -2.9930315929
   },
   {
     "3alpha": "AGL",
-    "station_name": "Abergele & Pensarn Rail Station",
+    "station_name": "Abergele & Pensarn",
     "latitude": 53.2945885877,
     "longitude": -3.5826252049
   },
   {
     "3alpha": "AGR",
-    "station_name": "Angel Road Rail Station",
+    "station_name": "Angel Road",
     "latitude": 51.612404791,
     "longitude": -0.0487664558
   },
   {
     "3alpha": "AGS",
-    "station_name": "Argyle Street Rail Station",
+    "station_name": "Argyle Street",
     "latitude": 55.8572976321,
     "longitude": -4.2506797284
   },
   {
     "3alpha": "AGT",
-    "station_name": "Aldrington Rail Station",
+    "station_name": "Aldrington",
     "latitude": 50.8363759964,
     "longitude": -0.1837938786
   },
   {
     "3alpha": "AGV",
-    "station_name": "Abergavenny Rail Station",
+    "station_name": "Abergavenny",
     "latitude": 51.8166929204,
     "longitude": -3.0096529786
   },
   {
     "3alpha": "AHD",
-    "station_name": "Ashtead Rail Station",
+    "station_name": "Ashtead",
     "latitude": 51.3178707762,
     "longitude": -0.3075480044
   },
   {
     "3alpha": "AHN",
-    "station_name": "Ashton-under-Lyne Rail Station",
+    "station_name": "Ashton-under-Lyne",
     "latitude": 53.4912877289,
     "longitude": -2.0943117675
   },
   {
     "3alpha": "AHS",
-    "station_name": "Ashurst (Kent) Rail Station",
+    "station_name": "Ashurst (Kent)",
     "latitude": 51.1286581521,
     "longitude": 0.1526783965
   },
   {
     "3alpha": "AHT",
-    "station_name": "Aldershot Rail Station",
+    "station_name": "Aldershot",
     "latitude": 51.2464146675,
     "longitude": -0.7598418662
   },
   {
     "3alpha": "AHV",
-    "station_name": "Ash Vale Rail Station",
+    "station_name": "Ash Vale",
     "latitude": 51.2722439454,
     "longitude": -0.721630982
   },
   {
     "3alpha": "AIG",
-    "station_name": "Aigburth Rail Station",
+    "station_name": "Aigburth",
     "latitude": 53.364579864,
     "longitude": -2.9271549702
   },
   {
     "3alpha": "AIN",
-    "station_name": "Aintree Rail Station",
+    "station_name": "Aintree",
     "latitude": 53.4739239739,
     "longitude": -2.9562794487
   },
   {
     "3alpha": "AIR",
-    "station_name": "Airbles Rail Station",
+    "station_name": "Airbles",
     "latitude": 55.7828281606,
     "longitude": -3.9941848819
   },
   {
     "3alpha": "ALB",
-    "station_name": "Albrighton Rail Station",
+    "station_name": "Albrighton",
     "latitude": 52.637955578,
     "longitude": -2.2688961662
   },
   {
     "3alpha": "ALD",
-    "station_name": "Alderley Edge Rail Station",
+    "station_name": "Alderley Edge",
     "latitude": 53.3037949434,
     "longitude": -2.2367975748
   },
   {
     "3alpha": "ALF",
-    "station_name": "Alfreton Rail Station",
+    "station_name": "Alfreton",
     "latitude": 53.1004491479,
     "longitude": -1.3696938892
   },
   {
     "3alpha": "ALK",
-    "station_name": "Aslockton Rail Station",
+    "station_name": "Aslockton",
     "latitude": 52.9515688778,
     "longitude": -0.8980931448
   },
   {
     "3alpha": "ALM",
-    "station_name": "Alnmouth Rail Station",
+    "station_name": "Alnmouth",
     "latitude": 55.3927781339,
     "longitude": -1.6366531856
   },
   {
     "3alpha": "ALN",
-    "station_name": "Althorne Rail Station",
+    "station_name": "Althorne",
     "latitude": 51.647874589,
     "longitude": 0.7525126479
   },
   {
     "3alpha": "ALO",
-    "station_name": "Alloa Rail Station",
+    "station_name": "Alloa",
     "latitude": 56.1177816937,
     "longitude": -3.7900478514
   },
   {
     "3alpha": "ALP",
-    "station_name": "Althorpe Rail Station",
+    "station_name": "Althorpe",
     "latitude": 53.5855202235,
     "longitude": -0.7331858491
   },
   {
     "3alpha": "ALR",
-    "station_name": "Alresford (Essex) Rail Station",
+    "station_name": "Alresford (Essex)",
     "latitude": 51.8540099196,
     "longitude": 0.9974663385
   },
   {
     "3alpha": "ALT",
-    "station_name": "Altrincham Rail Station",
+    "station_name": "Altrincham",
     "latitude": 53.3877312834,
     "longitude": -2.3468882352
   },
   {
     "3alpha": "ALV",
-    "station_name": "Alvechurch Rail Station",
+    "station_name": "Alvechurch",
     "latitude": 52.3460841489,
     "longitude": -1.96765319
   },
   {
     "3alpha": "ALW",
-    "station_name": "Allens West Rail Station",
+    "station_name": "Allens West",
     "latitude": 54.5246329186,
     "longitude": -1.361128823
   },
   {
     "3alpha": "ALX",
-    "station_name": "Alexandria Rail Station",
+    "station_name": "Alexandria",
     "latitude": 55.9850750252,
     "longitude": -4.5774669847
   },
   {
     "3alpha": "AMB",
-    "station_name": "Ambergate Rail Station",
+    "station_name": "Ambergate",
     "latitude": 53.0605332632,
     "longitude": -1.4806950473
   },
   {
     "3alpha": "AMF",
-    "station_name": "Ammanford Rail Station",
+    "station_name": "Ammanford",
     "latitude": 51.7959802661,
     "longitude": -3.9967546569
   },
   {
     "3alpha": "AML",
-    "station_name": "Acton Main Line Rail Station",
+    "station_name": "Acton Main Line",
     "latitude": 51.5171796932,
     "longitude": -0.2667334712
   },
   {
     "3alpha": "AMR",
-    "station_name": "Amersham Rail Station",
+    "station_name": "Amersham",
     "latitude": 51.6742082152,
     "longitude": -0.6075738184
   },
   {
     "3alpha": "AMT",
-    "station_name": "Aldermaston Rail Station",
+    "station_name": "Aldermaston",
     "latitude": 51.4019601992,
     "longitude": -1.1374044609
   },
   {
     "3alpha": "AMY",
-    "station_name": "Amberley Rail Station",
+    "station_name": "Amberley",
     "latitude": 50.8966706624,
     "longitude": -0.5419699859
   },
   {
     "3alpha": "ANC",
-    "station_name": "Ancaster Rail Station",
+    "station_name": "Ancaster",
     "latitude": 52.9877078434,
     "longitude": -0.5356177511
   },
   {
     "3alpha": "AND",
-    "station_name": "Anderston Rail Station",
+    "station_name": "Anderston",
     "latitude": 55.8598905332,
     "longitude": -4.2709646678
   },
   {
     "3alpha": "ANF",
-    "station_name": "Ashurst New Forest Rail Station",
+    "station_name": "Ashurst New Forest",
     "latitude": 50.8898407705,
     "longitude": -1.5266232035
   },
   {
     "3alpha": "ANG",
-    "station_name": "Angmering Rail Station",
+    "station_name": "Angmering",
     "latitude": 50.8165649857,
     "longitude": -0.4893702151
   },
   {
     "3alpha": "ANL",
-    "station_name": "Anniesland Rail Station",
+    "station_name": "Anniesland",
     "latitude": 55.8893432336,
     "longitude": -4.3219418416
   },
   {
     "3alpha": "ANN",
-    "station_name": "Annan Rail Station",
+    "station_name": "Annan",
     "latitude": 54.9838392542,
     "longitude": -3.2625828964
   },
   {
     "3alpha": "ANS",
-    "station_name": "Ainsdale Rail Station",
+    "station_name": "Ainsdale",
     "latitude": 53.6020465522,
     "longitude": -3.0426494721
   },
   {
     "3alpha": "ANZ",
-    "station_name": "Anerley Rail Station",
+    "station_name": "Anerley",
     "latitude": 51.4121504955,
     "longitude": -0.0658599305
   },
   {
     "3alpha": "AON",
-    "station_name": "Alton Rail Station",
+    "station_name": "Alton",
     "latitude": 51.151964195,
     "longitude": -0.9668980606
   },
   {
     "3alpha": "APB",
-    "station_name": "Appley Bridge Rail Station",
+    "station_name": "Appley Bridge",
     "latitude": 53.5786855814,
     "longitude": -2.7192513076
   },
   {
     "3alpha": "APD",
-    "station_name": "Appledore (Kent) Rail Station",
+    "station_name": "Appledore (Kent)",
     "latitude": 51.0332339326,
     "longitude": 0.8163754751
   },
   {
     "3alpha": "APF",
-    "station_name": "Appleford Rail Station",
+    "station_name": "Appleford",
     "latitude": 51.6396427695,
     "longitude": -1.2421230581
   },
   {
     "3alpha": "APG",
-    "station_name": "Aspley Guise Rail Station",
+    "station_name": "Aspley Guise",
     "latitude": 52.0212455205,
     "longitude": -0.6323124906
   },
@@ -469,865 +469,877 @@
   },
   {
     "3alpha": "APP",
-    "station_name": "Appleby Rail Station",
+    "station_name": "Appleby",
     "latitude": 54.5803531214,
     "longitude": -2.4866970812
   },
   {
     "3alpha": "APS",
-    "station_name": "Apsley Rail Station",
+    "station_name": "Apsley",
     "latitude": 51.7325265818,
     "longitude": -0.462913617
   },
   {
     "3alpha": "APY",
-    "station_name": "Apperley Bridge Rail Station",
+    "station_name": "Apperley Bridge",
     "latitude": 53.8417623189,
     "longitude": -1.7058332
   },
   {
     "3alpha": "ARB",
-    "station_name": "Arbroath Rail Station",
+    "station_name": "Arbroath",
     "latitude": 56.5595623759,
     "longitude": -2.58893669
   },
   {
     "3alpha": "ARD",
-    "station_name": "Ardgay Rail Station",
+    "station_name": "Ardgay",
     "latitude": 57.8814343743,
     "longitude": -4.3620902545
   },
   {
     "3alpha": "ARG",
-    "station_name": "Arisaig Rail Station",
+    "station_name": "Arisaig",
     "latitude": 56.9125239651,
     "longitude": -5.8390581876
   },
   {
     "3alpha": "ARL",
-    "station_name": "Arlesey Rail Station",
+    "station_name": "Arlesey",
     "latitude": 52.0260393622,
     "longitude": -0.2662942214
   },
   {
     "3alpha": "ARM",
-    "station_name": "Armadale (W Lothian) Rail Station",
+    "station_name": "Armadale (W Lothian)",
     "latitude": 55.8857041796,
     "longitude": -3.6954045698
   },
   {
     "3alpha": "ARN",
-    "station_name": "Arnside Rail Station",
+    "station_name": "Arnside",
     "latitude": 54.2027369524,
     "longitude": -2.8282411629
   },
   {
     "3alpha": "ARR",
-    "station_name": "Arram Rail Station",
+    "station_name": "Arram",
     "latitude": 53.8843617225,
     "longitude": -0.4265787094
   },
   {
     "3alpha": "ART",
-    "station_name": "Arrochar & Tarbet Rail Station",
+    "station_name": "Arrochar & Tarbet",
     "latitude": 56.2039604882,
     "longitude": -4.7227536136
   },
   {
     "3alpha": "ARU",
-    "station_name": "Arundel Rail Station",
+    "station_name": "Arundel",
     "latitude": 50.848204225,
     "longitude": -0.5461513877
   },
   {
     "3alpha": "ASB",
-    "station_name": "Ardrossan South Beach Rail Station",
+    "station_name": "Ardrossan South Beach",
     "latitude": 55.6414123987,
     "longitude": -4.8011892639
   },
   {
     "3alpha": "ASC",
-    "station_name": "Ashchurch for Tewkesbury Rail Station",
+    "station_name": "Ashchurch for Tewkesbury",
     "latitude": 51.9989119042,
     "longitude": -2.1087526816
   },
   {
     "3alpha": "ASF",
-    "station_name": "Ashfield Rail Station",
+    "station_name": "Ashfield",
     "latitude": 55.8889152278,
     "longitude": -4.2492001758
   },
   {
     "3alpha": "ASG",
-    "station_name": "Alsager Rail Station",
+    "station_name": "Alsager",
     "latitude": 53.0930183471,
     "longitude": -2.2990577384
   },
   {
     "3alpha": "ASH",
-    "station_name": "Ash Rail Station",
+    "station_name": "Ash",
     "latitude": 51.2495930968,
     "longitude": -0.7127872134
   },
   {
     "3alpha": "ASK",
-    "station_name": "Askam Rail Station",
+    "station_name": "Askam",
     "latitude": 54.1889365481,
     "longitude": -3.2045108901
   },
   {
     "3alpha": "ASN",
-    "station_name": "Addlestone Rail Station",
+    "station_name": "Addlestone",
     "latitude": 51.3730427936,
     "longitude": -0.4844377608
   },
   {
     "3alpha": "ASP",
-    "station_name": "Aspatria Rail Station",
+    "station_name": "Aspatria",
     "latitude": 54.7589613565,
     "longitude": -3.3318751754
   },
   {
     "3alpha": "ASS",
-    "station_name": "Alness Rail Station",
+    "station_name": "Alness",
     "latitude": 57.6943767246,
     "longitude": -4.2497156226
   },
   {
     "3alpha": "AST",
-    "station_name": "Aston Rail Station",
+    "station_name": "Aston",
     "latitude": 52.5042436334,
     "longitude": -1.8719289166
   },
   {
     "3alpha": "ASY",
-    "station_name": "Ashley Rail Station",
+    "station_name": "Ashley",
     "latitude": 53.3557384507,
     "longitude": -2.3414591344
   },
   {
     "3alpha": "ATB",
-    "station_name": "Attenborough Rail Station",
+    "station_name": "Attenborough",
     "latitude": 52.9062307659,
     "longitude": -1.2314110309
   },
   {
     "3alpha": "ATH",
-    "station_name": "Atherstone Rail Station",
+    "station_name": "Atherstone",
     "latitude": 52.5789873633,
     "longitude": -1.5528024825
   },
   {
     "3alpha": "ATL",
-    "station_name": "Attleborough Rail Station",
+    "station_name": "Attleborough",
     "latitude": 52.5145682909,
     "longitude": 1.0223710881
   },
   {
     "3alpha": "ATN",
-    "station_name": "Atherton Rail Station",
+    "station_name": "Atherton",
     "latitude": 53.5291592416,
     "longitude": -2.4789715129
   },
   {
     "3alpha": "ATT",
-    "station_name": "Attadale Rail Station",
+    "station_name": "Attadale",
     "latitude": 57.395013788,
     "longitude": -5.4555693529
   },
   {
     "3alpha": "AUD",
-    "station_name": "Audley End Rail Station",
+    "station_name": "Audley End",
     "latitude": 52.0044503988,
     "longitude": 0.2071861287
   },
   {
     "3alpha": "AUG",
-    "station_name": "Aughton Park Rail Station",
+    "station_name": "Aughton Park",
     "latitude": 53.5542616334,
     "longitude": -2.8952192106
   },
   {
     "3alpha": "AUI",
-    "station_name": "Ardlui Rail Station",
+    "station_name": "Ardlui",
     "latitude": 56.3019554792,
     "longitude": -4.7216411129
   },
   {
     "3alpha": "AUK",
-    "station_name": "Auchinleck Rail Station",
+    "station_name": "Auchinleck",
     "latitude": 55.4702735607,
     "longitude": -4.2953352235
   },
   {
     "3alpha": "AUR",
-    "station_name": "Aberdour Rail Station",
+    "station_name": "Aberdour",
     "latitude": 56.0545845646,
     "longitude": -3.3005596025
   },
   {
     "3alpha": "AUW",
-    "station_name": "Ascott-under-Wychwood Rail Station",
+    "station_name": "Ascott-under-Wychwood",
     "latitude": 51.8673469281,
     "longitude": -1.5640381523
   },
   {
     "3alpha": "AVF",
-    "station_name": "Avoncliff Rail Station",
+    "station_name": "Avoncliff",
     "latitude": 51.3396455319,
     "longitude": -2.2813231272
   },
   {
     "3alpha": "AVM",
-    "station_name": "Aviemore Rail Station",
+    "station_name": "Aviemore",
     "latitude": 57.1884955899,
     "longitude": -3.8288664748
   },
   {
     "3alpha": "AVN",
-    "station_name": "Avonmouth Rail Station",
+    "station_name": "Avonmouth",
     "latitude": 51.5003586482,
     "longitude": -2.6994701634
   },
   {
     "3alpha": "AVP",
-    "station_name": "Aylesbury Vale Parkway Rail Station",
+    "station_name": "Aylesbury Vale Parkway",
     "latitude": 51.8311641936,
     "longitude": -0.860160203
   },
   {
     "3alpha": "AVY",
-    "station_name": "Aberdovey Rail Station",
+    "station_name": "Aberdovey",
     "latitude": 52.5439709134,
     "longitude": -4.0570763906
   },
   {
     "3alpha": "AWK",
-    "station_name": "Adwick Rail Station",
+    "station_name": "Adwick",
     "latitude": 53.5723385016,
     "longitude": -1.1803591649
   },
   {
     "3alpha": "AWM",
-    "station_name": "Ashwell & Morden Rail Station",
+    "station_name": "Ashwell & Morden",
     "latitude": 52.0307801801,
     "longitude": -0.1097609643
   },
   {
     "3alpha": "AWT",
-    "station_name": "Armathwaite Rail Station",
+    "station_name": "Armathwaite",
     "latitude": 54.8094705871,
     "longitude": -2.7720762415
   },
   {
     "3alpha": "AXM",
-    "station_name": "Axminster Rail Station",
+    "station_name": "Axminster",
     "latitude": 50.7792590196,
     "longitude": -3.0047301649
   },
   {
     "3alpha": "AXP",
-    "station_name": "Alexandra Parade Rail Station",
+    "station_name": "Alexandra Parade",
     "latitude": 55.8631647206,
     "longitude": -4.2106343183
   },
   {
     "3alpha": "AYH",
-    "station_name": "Aylesham Rail Station",
+    "station_name": "Aylesham",
     "latitude": 51.2272573443,
     "longitude": 1.2094822749
   },
   {
     "3alpha": "AYL",
-    "station_name": "Aylesford Rail Station",
+    "station_name": "Aylesford",
     "latitude": 51.3013150665,
     "longitude": 0.4661994822
   },
   {
     "3alpha": "AYP",
-    "station_name": "Albany Park Rail Station",
+    "station_name": "Albany Park",
     "latitude": 51.4354510748,
     "longitude": 0.1257631402
   },
   {
     "3alpha": "AYR",
-    "station_name": "Ayr Rail Station",
+    "station_name": "Ayr",
     "latitude": 55.4581420821,
     "longitude": -4.6258547017
   },
   {
     "3alpha": "AYS",
-    "station_name": "Aylesbury Rail Station",
+    "station_name": "Aylesbury",
     "latitude": 51.8138958856,
     "longitude": -0.8150732917
   },
   {
     "3alpha": "AYW",
-    "station_name": "Aberystwyth Rail Station",
+    "station_name": "Aberystwyth",
     "latitude": 52.4140589056,
     "longitude": -4.081904916
   },
   {
     "3alpha": "BAA",
-    "station_name": "Barnham Rail Station",
+    "station_name": "Barnham",
     "latitude": 50.8308955044,
     "longitude": -0.6396586529
   },
   {
     "3alpha": "BAB",
-    "station_name": "Balcombe Rail Station",
+    "station_name": "Balcombe",
     "latitude": 51.0555161298,
     "longitude": -0.1369064512
   },
   {
     "3alpha": "BAC",
-    "station_name": "Bache Rail Station",
+    "station_name": "Bache",
     "latitude": 53.2087996005,
     "longitude": -2.8916714556
   },
   {
     "3alpha": "BAD",
-    "station_name": "Banstead Rail Station",
+    "station_name": "Banstead",
     "latitude": 51.3293456873,
     "longitude": -0.2131338747
   },
   {
     "3alpha": "BAG",
-    "station_name": "Bagshot Rail Station",
+    "station_name": "Bagshot",
     "latitude": 51.3643658384,
     "longitude": -0.688644212
   },
   {
     "3alpha": "BAH",
-    "station_name": "Bank Hall Rail Station",
+    "station_name": "Bank Hall",
     "latitude": 53.4375081504,
     "longitude": -2.9875109807
   },
   {
     "3alpha": "BAI",
-    "station_name": "Blairhill Rail Station",
+    "station_name": "Blairhill",
     "latitude": 55.866445195,
     "longitude": -4.0432793703
   },
   {
     "3alpha": "BAJ",
-    "station_name": "Baglan Rail Station",
+    "station_name": "Baglan",
     "latitude": 51.6155428964,
     "longitude": -3.8111528304
   },
   {
     "3alpha": "BAK",
-    "station_name": "Battersea Park Rail Station",
+    "station_name": "Battersea Park",
     "latitude": 51.4769589055,
     "longitude": -0.1475087424
   },
   {
     "3alpha": "BAL",
-    "station_name": "Balham Rail Station",
+    "station_name": "Balham",
     "latitude": 51.4432235254,
     "longitude": -0.1523989843
   },
   {
     "3alpha": "BAM",
-    "station_name": "Bamford Rail Station",
+    "station_name": "Bamford",
     "latitude": 53.3390149874,
     "longitude": -1.6890804845
   },
   {
     "3alpha": "BAN",
-    "station_name": "Banbury Rail Station",
+    "station_name": "Banbury",
     "latitude": 52.0603171415,
     "longitude": -1.3281174658
   },
   {
     "3alpha": "BAR",
-    "station_name": "Bare Lane Rail Station",
+    "station_name": "Bare Lane",
     "latitude": 54.0745502872,
     "longitude": -2.8353285199
   },
   {
     "3alpha": "BAS",
-    "station_name": "Bere Alston Rail Station",
+    "station_name": "Bere Alston",
     "latitude": 50.4855801051,
     "longitude": -4.2003841017
   },
   {
     "3alpha": "BAT",
-    "station_name": "Battle Rail Station",
+    "station_name": "Battle",
     "latitude": 50.9129099302,
     "longitude": 0.494731748
   },
   {
     "3alpha": "BAU",
-    "station_name": "Barton-on-Humber Rail Station",
+    "station_name": "Barton-on-Humber",
     "latitude": 53.6889361427,
     "longitude": -0.443441463
   },
   {
     "3alpha": "BAV",
-    "station_name": "Barrow Haven Rail Station",
+    "station_name": "Barrow Haven",
     "latitude": 53.6974399715,
     "longitude": -0.3929610176
   },
   {
     "3alpha": "BAW",
-    "station_name": "Blackwater Rail Station",
+    "station_name": "Blackwater",
     "latitude": 51.3315799276,
     "longitude": -0.7767238015
   },
   {
     "3alpha": "BAY",
-    "station_name": "Bayford Rail Station",
+    "station_name": "Bayford",
     "latitude": 51.7577191097,
     "longitude": -0.0955835363
   },
   {
     "3alpha": "BBG",
-    "station_name": "Bishopbriggs Rail Station",
+    "station_name": "Bishopbriggs",
     "latitude": 55.9038715243,
     "longitude": -4.2249012111
   },
   {
     "3alpha": "BBK",
-    "station_name": "Bilbrook Rail Station",
+    "station_name": "Bilbrook",
     "latitude": 52.6237315662,
     "longitude": -2.1860832074
   },
   {
     "3alpha": "BBL",
-    "station_name": "Bat & Ball Rail Station",
+    "station_name": "Bat & Ball",
     "latitude": 51.28975765,
     "longitude": 0.1942546658
   },
   {
     "3alpha": "BBN",
-    "station_name": "Blackburn Rail Station",
+    "station_name": "Blackburn",
     "latitude": 53.7465295919,
     "longitude": -2.4791202443
   },
   {
     "3alpha": "BBS",
-    "station_name": "Bordesley Rail Station",
+    "station_name": "Bordesley",
     "latitude": 52.4718857429,
     "longitude": -1.877763734
   },
   {
     "3alpha": "BBW",
-    "station_name": "Berry Brow Rail Station",
+    "station_name": "Berry Brow",
     "latitude": 53.6210542572,
     "longitude": -1.793433127
   },
   {
     "3alpha": "BCB",
-    "station_name": "Burscough Bridge Rail Station",
+    "station_name": "Burscough Bridge",
     "latitude": 53.6052706223,
     "longitude": -2.8408791461
   },
   {
     "3alpha": "BCC",
-    "station_name": "Beccles Rail Station",
+    "station_name": "Beccles",
     "latitude": 52.4585445204,
     "longitude": 1.5695203477
   },
   {
     "3alpha": "BCE",
-    "station_name": "Bracknell Rail Station",
+    "station_name": "Bracknell",
     "latitude": 51.4130905636,
     "longitude": -0.7516868278
   },
   {
     "3alpha": "BCF",
-    "station_name": "Beaconsfield Rail Station",
+    "station_name": "Beaconsfield",
     "latitude": 51.6112923305,
     "longitude": -0.6438028303
   },
   {
     "3alpha": "BCG",
-    "station_name": "Birchgrove Rail Station",
+    "station_name": "Birchgrove",
     "latitude": 51.5215559616,
     "longitude": -3.2018626211
   },
   {
     "3alpha": "BCH",
-    "station_name": "Birchington-on-Sea Rail Station",
+    "station_name": "Birchington-on-Sea",
     "latitude": 51.37749655,
     "longitude": 1.3014357084
   },
   {
     "3alpha": "BCJ",
-    "station_name": "Burscough Junction Rail Station",
+    "station_name": "Burscough Junction",
     "latitude": 53.5975334888,
     "longitude": -2.8406044888
   },
   {
     "3alpha": "BCK",
-    "station_name": "Buckley Rail Station",
+    "station_name": "Buckley",
     "latitude": 53.1630498684,
     "longitude": -3.0559258882
   },
   {
     "3alpha": "BCN",
-    "station_name": "Branchton Rail Station",
+    "station_name": "Branchton",
     "latitude": 55.9405880748,
     "longitude": -4.8035281728
   },
   {
     "3alpha": "BCS",
-    "station_name": "Bicester North Rail Station",
+    "station_name": "Bicester North",
     "latitude": 51.9034889722,
     "longitude": -1.1503639712
   },
   {
     "3alpha": "BCU",
-    "station_name": "Brockenhurst Rail Station",
+    "station_name": "Brockenhurst",
     "latitude": 50.8168300371,
     "longitude": -1.5735227393
   },
   {
     "3alpha": "BCV",
-    "station_name": "Bruce Grove Rail Station",
+    "station_name": "Bruce Grove",
     "latitude": 51.5939593358,
     "longitude": -0.0698420983
   },
   {
     "3alpha": "BCY",
-    "station_name": "Brockley Rail Station",
+    "station_name": "Brockley",
     "latitude": 51.4646472415,
     "longitude": -0.0375111039
   },
   {
+    "3alpha": "BCZ",
+    "station_name": "Brent Cross West",
+    "latitude": 51.5687,
+    "longitude": -0.2269
+  },
+  {
     "3alpha": "BDA",
-    "station_name": "Brundall Rail Station",
+    "station_name": "Brundall",
     "latitude": 52.6195070541,
     "longitude": 1.4393221465
   },
   {
     "3alpha": "BDB",
-    "station_name": "Broadbottom Rail Station",
+    "station_name": "Broadbottom",
     "latitude": 53.4409884275,
     "longitude": -2.0165194714
   },
   {
     "3alpha": "BDG",
-    "station_name": "Bridgeton Rail Station",
+    "station_name": "Bridgeton",
     "latitude": 55.8489565185,
     "longitude": -4.2260423916
   },
   {
     "3alpha": "BDH",
-    "station_name": "Bedhampton Rail Station",
+    "station_name": "Bedhampton",
     "latitude": 50.8539453593,
     "longitude": -0.9958127279
   },
   {
     "3alpha": "BDI",
-    "station_name": "Bradford Interchange Rail Station",
+    "station_name": "Bradford Interchange",
     "latitude": 53.7910884508,
     "longitude": -1.7495992021
   },
   {
     "3alpha": "BDK",
-    "station_name": "Baldock Rail Station",
+    "station_name": "Baldock",
     "latitude": 51.9928784919,
     "longitude": -0.1875367625
   },
   {
     "3alpha": "BDL",
-    "station_name": "Birkdale Rail Station",
+    "station_name": "Birkdale",
     "latitude": 53.6340637332,
     "longitude": -3.0144470298
   },
   {
     "3alpha": "BDM",
-    "station_name": "Bedford Rail Station",
+    "station_name": "Bedford",
     "latitude": 52.1361978063,
     "longitude": -0.4794210009
   },
   {
     "3alpha": "BDN",
-    "station_name": "Brading Rail Station",
+    "station_name": "Brading",
     "latitude": 50.6783584598,
     "longitude": -1.1387118948
   },
   {
     "3alpha": "BDQ",
-    "station_name": "Bradford Forster Square Rail Station",
+    "station_name": "Bradford Forster Square",
     "latitude": 53.7969375902,
     "longitude": -1.7529651428
   },
   {
     "3alpha": "BDT",
-    "station_name": "Bridlington Rail Station",
+    "station_name": "Bridlington",
     "latitude": 54.0841498279,
     "longitude": -0.198733799
   },
   {
     "3alpha": "BDW",
-    "station_name": "Bedwyn Rail Station",
+    "station_name": "Bedwyn",
     "latitude": 51.3796362626,
     "longitude": -1.5987734873
   },
   {
     "3alpha": "BDY",
-    "station_name": "Bredbury Rail Station",
+    "station_name": "Bredbury",
     "latitude": 53.423168059,
     "longitude": -2.1104866302
   },
   {
     "3alpha": "BEA",
-    "station_name": "Bridge of Allan Rail Station",
+    "station_name": "Bridge of Allan",
     "latitude": 56.1566272012,
     "longitude": -3.9572209128
   },
   {
     "3alpha": "BEB",
-    "station_name": "Bebington Rail Station",
+    "station_name": "Bebington",
     "latitude": 53.3576688627,
     "longitude": -3.0036346698
   },
   {
     "3alpha": "BEC",
-    "station_name": "Beckenham Hill Rail Station",
+    "station_name": "Beckenham Hill",
     "latitude": 51.4245803532,
     "longitude": -0.0159250385
   },
   {
     "3alpha": "BEE",
-    "station_name": "Beeston Rail Station",
+    "station_name": "Beeston",
     "latitude": 52.920772808,
     "longitude": -1.2076539126
   },
   {
     "3alpha": "BEF",
-    "station_name": "Benfleet Rail Station",
+    "station_name": "Benfleet",
     "latitude": 51.543946833,
     "longitude": 0.5617405199
   },
   {
     "3alpha": "BEG",
-    "station_name": "Beltring Rail Station",
+    "station_name": "Beltring",
     "latitude": 51.2047052539,
     "longitude": 0.4035240323
   },
   {
     "3alpha": "BEH",
-    "station_name": "Bedworth Rail Station",
+    "station_name": "Bedworth",
     "latitude": 52.4793121537,
     "longitude": -1.4673840381
   },
   {
     "3alpha": "BEL",
-    "station_name": "Beauly Rail Station",
+    "station_name": "Beauly",
     "latitude": 57.4782638344,
     "longitude": -4.4698634331
   },
   {
     "3alpha": "BEM",
-    "station_name": "Bempton Rail Station",
+    "station_name": "Bempton",
     "latitude": 54.1276779105,
     "longitude": -0.1804704307
   },
   {
     "3alpha": "BEN",
-    "station_name": "Bentham Rail Station",
+    "station_name": "Bentham",
     "latitude": 54.115527405,
     "longitude": -2.5106784228
   },
   {
     "3alpha": "BEP",
-    "station_name": "Bermuda Park Rail Station",
+    "station_name": "Bermuda Park",
     "latitude": 52.5014490814,
     "longitude": -1.4721692914
   },
   {
     "3alpha": "BER",
-    "station_name": "Bearley Rail Station",
+    "station_name": "Bearley",
     "latitude": 52.2444229433,
     "longitude": -1.7502469172
   },
   {
     "3alpha": "BES",
-    "station_name": "Bescar Lane Rail Station",
+    "station_name": "Bescar Lane",
     "latitude": 53.6238666357,
     "longitude": -2.914609859
   },
   {
     "3alpha": "BET",
-    "station_name": "Bethnal Green Rail Station",
+    "station_name": "Bethnal Green",
     "latitude": 51.5239168448,
     "longitude": -0.0595413255
   },
   {
     "3alpha": "BEU",
-    "station_name": "Beaulieu Road Rail Station",
+    "station_name": "Beaulieu Road",
     "latitude": 50.8550379245,
     "longitude": -1.5047402125
   },
   {
     "3alpha": "BEV",
-    "station_name": "Beverley Rail Station",
+    "station_name": "Beverley",
     "latitude": 53.8422910042,
     "longitude": -0.4229880841
   },
   {
     "3alpha": "BEX",
-    "station_name": "Bexhill Rail Station",
+    "station_name": "Bexhill",
     "latitude": 50.8410361246,
     "longitude": 0.4770465179
   },
   {
     "3alpha": "BEY",
-    "station_name": "Ben Rhydding Rail Station",
+    "station_name": "Ben Rhydding",
     "latitude": 53.9257271035,
     "longitude": -1.797433526
   },
   {
     "3alpha": "BFD",
-    "station_name": "Brentford Rail Station",
+    "station_name": "Brentford",
     "latitude": 51.4875455966,
     "longitude": -0.3096291503
   },
   {
     "3alpha": "BFE",
-    "station_name": "Bere Ferrers Rail Station",
+    "station_name": "Bere Ferrers",
     "latitude": 50.4512627598,
     "longitude": -4.1814634554
   },
   {
     "3alpha": "BFF",
-    "station_name": "Blaenau Ffestiniog Rail Station",
+    "station_name": "Blaenau Ffestiniog",
     "latitude": 52.9945625755,
     "longitude": -3.9386014215
   },
   {
     "3alpha": "BFN",
-    "station_name": "Byfleet & New Haw Rail Station",
+    "station_name": "Byfleet & New Haw",
     "latitude": 51.3497933814,
     "longitude": -0.4813698884
   },
   {
     "3alpha": "BFR",
-    "station_name": "London Blackfriars Rail Station",
+    "station_name": "London Blackfriars",
     "latitude": 51.511809604,
     "longitude": -0.1033064322
   },
   {
     "3alpha": "BGA",
-    "station_name": "Brundall Gardens Rail Station",
+    "station_name": "Brundall Gardens",
     "latitude": 52.6234667847,
     "longitude": 1.4184395543
   },
   {
     "3alpha": "BGD",
-    "station_name": "Bargoed Rail Station",
+    "station_name": "Bargoed",
     "latitude": 51.6923106201,
     "longitude": -3.2296893004
   },
   {
     "3alpha": "BGE",
-    "station_name": "Broad Green Rail Station",
+    "station_name": "Broad Green",
     "latitude": 53.4065176265,
     "longitude": -2.8934838097
   },
   {
     "3alpha": "BGG",
-    "station_name": "Brigg Rail Station",
+    "station_name": "Brigg",
     "latitude": 53.5491644813,
     "longitude": -0.4861278561
   },
   {
     "3alpha": "BGH",
-    "station_name": "Brighouse Rail Station",
+    "station_name": "Brighouse",
     "latitude": 53.6982108642,
     "longitude": -1.7794410593
   },
   {
     "3alpha": "BGI",
-    "station_name": "Bargeddie Rail Station",
+    "station_name": "Bargeddie",
     "latitude": 55.8512854533,
     "longitude": -4.073795488
   },
   {
     "3alpha": "BGL",
-    "station_name": "Bugle Rail Station",
+    "station_name": "Bugle",
     "latitude": 50.4003357574,
     "longitude": -4.7921412594
   },
   {
     "3alpha": "BGM",
-    "station_name": "Bellingham Rail Station",
+    "station_name": "Bellingham",
     "latitude": 51.432910924,
     "longitude": -0.0193048772
   },
   {
     "3alpha": "BGN",
-    "station_name": "Bridgend Rail Station",
+    "station_name": "Bridgend",
     "latitude": 51.5069726538,
     "longitude": -3.5752917878
   },
   {
     "3alpha": "BGS",
-    "station_name": "Bogston Rail Station",
+    "station_name": "Bogston",
     "latitude": 55.9370336273,
     "longitude": -4.7113815133
   },
   {
+    "3alpha": "BGV",
+    "station_name": "Barking Riverside",
+    "latitude": 51.519108,
+    "longitude": 0.114764
+  },
+  {
     "3alpha": "BHC",
-    "station_name": "Balloch Rail Station",
+    "station_name": "Balloch",
     "latitude": 56.0029254961,
     "longitude": -4.5834681974
   },
   {
     "3alpha": "BHD",
-    "station_name": "Brithdir Rail Station",
+    "station_name": "Brithdir",
     "latitude": 51.7103040613,
     "longitude": -3.2287299229
   },
   {
     "3alpha": "BHG",
-    "station_name": "Bathgate Rail Station",
+    "station_name": "Bathgate",
     "latitude": 55.8971463148,
     "longitude": -3.6360891747
   },
   {
     "3alpha": "BHI",
-    "station_name": "Birmingham International Rail Station",
+    "station_name": "Birmingham International",
     "latitude": 52.4508199122,
     "longitude": -1.7258497513
   },
   {
     "3alpha": "BHK",
-    "station_name": "Bush Hill Park Rail Station",
+    "station_name": "Bush Hill Park",
     "latitude": 51.6415193249,
     "longitude": -0.0691949356
   },
   {
     "3alpha": "BHM",
-    "station_name": "Birmingham New Street Rail Station",
+    "station_name": "Birmingham New Street",
     "latitude": 52.4778312827,
     "longitude": -1.9002004707
   },
   {
     "3alpha": "BHO",
-    "station_name": "Blackhorse Road Rail Station",
+    "station_name": "Blackhorse Road",
     "latitude": 51.5866055024,
     "longitude": -0.041209942
   },
   {
     "3alpha": "BHR",
-    "station_name": "Builth Road Rail Station",
+    "station_name": "Builth Road",
     "latitude": 52.1693300616,
     "longitude": -3.4270408474
   },
   {
     "3alpha": "BHS",
-    "station_name": "Brockholes Rail Station",
+    "station_name": "Brockholes",
     "latitude": 53.5969856546,
     "longitude": -1.7696922549
   },
   {
     "3alpha": "BIA",
-    "station_name": "Bishop Auckland Rail Station",
+    "station_name": "Bishop Auckland",
     "latitude": 54.6572030524,
     "longitude": -1.6777249795
   },
@@ -1339,1981 +1351,1987 @@
   },
   {
     "3alpha": "BIC",
-    "station_name": "Billericay Rail Station",
+    "station_name": "Billericay",
     "latitude": 51.6288849556,
     "longitude": 0.4186576571
   },
   {
     "3alpha": "BID",
-    "station_name": "Bidston Rail Station",
+    "station_name": "Bidston",
     "latitude": 53.4091524654,
     "longitude": -3.0785590277
   },
   {
     "3alpha": "BIF",
-    "station_name": "Barrow-in-Furness Rail Station",
+    "station_name": "Barrow-in-Furness",
     "latitude": 54.1190066162,
     "longitude": -3.2261172119
   },
   {
     "3alpha": "BIG",
-    "station_name": "Billingshurst Rail Station",
+    "station_name": "Billingshurst",
     "latitude": 51.0151974096,
     "longitude": -0.4502767801
   },
   {
     "3alpha": "BIK",
-    "station_name": "Birkbeck Rail Station",
+    "station_name": "Birkbeck",
     "latitude": 51.403888888,
     "longitude": -0.0557126082
   },
   {
     "3alpha": "BIL",
-    "station_name": "Billingham Rail Station",
+    "station_name": "Billingham",
     "latitude": 54.6056166679,
     "longitude": -1.2797344554
   },
   {
     "3alpha": "BIN",
-    "station_name": "Bingham Rail Station",
+    "station_name": "Bingham",
     "latitude": 52.9542094023,
     "longitude": -0.9515394619
   },
   {
     "3alpha": "BIO",
-    "station_name": "Baillieston Rail Station",
+    "station_name": "Baillieston",
     "latitude": 55.8444952694,
     "longitude": -4.1136857366
   },
   {
     "3alpha": "BIP",
-    "station_name": "Bishopstone Rail Station",
+    "station_name": "Bishopstone",
     "latitude": 50.7801363721,
     "longitude": 0.0827845347
   },
   {
     "3alpha": "BIS",
-    "station_name": "Bishops Stortford Rail Station",
+    "station_name": "Bishops Stortford",
     "latitude": 51.8666972924,
     "longitude": 0.1649202653
   },
   {
     "3alpha": "BIT",
-    "station_name": "Bicester Village Rail Station",
+    "station_name": "Bicester Village",
     "latitude": 51.8930294144,
     "longitude": -1.1487446761
   },
   {
     "3alpha": "BIW",
-    "station_name": "Biggleswade Rail Station",
+    "station_name": "Biggleswade",
     "latitude": 52.0846893974,
     "longitude": -0.2611631855
   },
   {
     "3alpha": "BIY",
-    "station_name": "Bingley Rail Station",
+    "station_name": "Bingley",
     "latitude": 53.8486270204,
     "longitude": -1.8373250124
   },
   {
     "3alpha": "BKA",
-    "station_name": "Bookham Rail Station",
+    "station_name": "Bookham",
     "latitude": 51.2887348796,
     "longitude": -0.3839979684
   },
   {
     "3alpha": "BKC",
-    "station_name": "Birkenhead Central Rail Station",
+    "station_name": "Birkenhead Central",
     "latitude": 53.388328806,
     "longitude": -3.0208206224
   },
   {
     "3alpha": "BKD",
-    "station_name": "Blakedown Rail Station",
+    "station_name": "Blakedown",
     "latitude": 52.406413288,
     "longitude": -2.1768606091
   },
   {
     "3alpha": "BKG",
-    "station_name": "Barking Rail Station",
+    "station_name": "Barking",
     "latitude": 51.5394940483,
     "longitude": 0.0809293557
   },
   {
     "3alpha": "BKH",
-    "station_name": "Blackheath Rail Station",
+    "station_name": "Blackheath",
     "latitude": 51.4657947771,
     "longitude": 0.0088974464
   },
   {
     "3alpha": "BKJ",
-    "station_name": "Beckenham Junction Rail Station",
+    "station_name": "Beckenham Junction",
     "latitude": 51.4111710618,
     "longitude": -0.0259963666
   },
   {
     "3alpha": "BKL",
-    "station_name": "Bickley Rail Station",
+    "station_name": "Bickley",
     "latitude": 51.4001025009,
     "longitude": 0.0452659962
   },
   {
     "3alpha": "BKM",
-    "station_name": "Berkhamsted Rail Station",
+    "station_name": "Berkhamsted",
     "latitude": 51.7631393379,
     "longitude": -0.5619899853
   },
   {
     "3alpha": "BKN",
-    "station_name": "Birkenhead North Rail Station",
+    "station_name": "Birkenhead North",
     "latitude": 53.4044504204,
     "longitude": -3.057532076
   },
   {
     "3alpha": "BKO",
-    "station_name": "Brookwood Rail Station",
+    "station_name": "Brookwood",
     "latitude": 51.3037544754,
     "longitude": -0.6357308777
   },
   {
     "3alpha": "BKP",
-    "station_name": "Birkenhead Park Rail Station",
+    "station_name": "Birkenhead Park",
     "latitude": 53.3974209727,
     "longitude": -3.039100208
   },
   {
     "3alpha": "BKQ",
-    "station_name": "Birkenhead Hamilton Square Rail Station",
+    "station_name": "Birkenhead Hamilton Square",
     "latitude": 53.3947090805,
     "longitude": -3.013679563
   },
   {
     "3alpha": "BKR",
-    "station_name": "Blackridge Rail Station",
+    "station_name": "Blackridge",
     "latitude": 55.8842459211,
     "longitude": -3.7507875146
   },
   {
     "3alpha": "BKS",
-    "station_name": "Bekesbourne Rail Station",
+    "station_name": "Bekesbourne",
     "latitude": 51.2613599688,
     "longitude": 1.136737067
   },
   {
     "3alpha": "BKT",
-    "station_name": "Blake Street Rail Station",
+    "station_name": "Blake Street",
     "latitude": 52.6048991066,
     "longitude": -1.8449076544
   },
   {
     "3alpha": "BKW",
-    "station_name": "Berkswell Rail Station",
+    "station_name": "Berkswell",
     "latitude": 52.3958946388,
     "longitude": -1.6428309089
   },
   {
     "3alpha": "BLA",
-    "station_name": "Blair Atholl Rail Station",
+    "station_name": "Blair Atholl",
     "latitude": 56.7655325077,
     "longitude": -3.8502251597
   },
   {
     "3alpha": "BLB",
-    "station_name": "Battlesbridge Rail Station",
+    "station_name": "Battlesbridge",
     "latitude": 51.6248280358,
     "longitude": 0.5653129218
   },
   {
     "3alpha": "BLD",
-    "station_name": "Baildon Rail Station",
+    "station_name": "Baildon",
     "latitude": 53.8502374199,
     "longitude": -1.7536396791
   },
   {
     "3alpha": "BLE",
-    "station_name": "Bramley (West Yorks) Rail Station",
+    "station_name": "Bramley (West Yorks)",
     "latitude": 53.8053627078,
     "longitude": -1.6372110715
   },
   {
     "3alpha": "BLG",
-    "station_name": "Bellgrove Rail Station",
+    "station_name": "Bellgrove",
     "latitude": 55.8566980297,
     "longitude": -4.2243600625
   },
   {
     "3alpha": "BLH",
-    "station_name": "Bellshill Rail Station",
+    "station_name": "Bellshill",
     "latitude": 55.8170582892,
     "longitude": -4.0244880674
   },
   {
     "3alpha": "BLK",
-    "station_name": "Blackrod Rail Station",
+    "station_name": "Blackrod",
     "latitude": 53.5915357166,
     "longitude": -2.5695231754
   },
   {
     "3alpha": "BLL",
-    "station_name": "Bardon Mill Rail Station",
+    "station_name": "Bardon Mill",
     "latitude": 54.9744979891,
     "longitude": -2.346513133
   },
   {
     "3alpha": "BLM",
-    "station_name": "Belmont Rail Station",
+    "station_name": "Belmont",
     "latitude": 51.3438116974,
     "longitude": -0.1988301486
   },
   {
     "3alpha": "BLN",
-    "station_name": "Blundellsands & Crosby Rail Station",
+    "station_name": "Blundellsands & Crosby",
     "latitude": 53.4876981044,
     "longitude": -3.0398576774
   },
   {
     "3alpha": "BLO",
-    "station_name": "Blaydon Rail Station",
+    "station_name": "Blaydon",
     "latitude": 54.9657939357,
     "longitude": -1.7125935978
   },
   {
     "3alpha": "BLP",
-    "station_name": "Belper Rail Station",
+    "station_name": "Belper",
     "latitude": 53.0237754008,
     "longitude": -1.482508538
   },
   {
     "3alpha": "BLT",
-    "station_name": "Blantyre Rail Station",
+    "station_name": "Blantyre",
     "latitude": 55.7973203505,
     "longitude": -4.0869580948
   },
   {
     "3alpha": "BLV",
-    "station_name": "Belle Vue Rail Station",
+    "station_name": "Belle Vue",
     "latitude": 53.4623891164,
     "longitude": -2.1805056874
   },
   {
     "3alpha": "BLW",
-    "station_name": "Bulwell Rail Station",
+    "station_name": "Bulwell",
     "latitude": 52.9997132956,
     "longitude": -1.1962272378
   },
   {
     "3alpha": "BLX",
-    "station_name": "Bloxwich Rail Station",
+    "station_name": "Bloxwich",
     "latitude": 52.6182145823,
     "longitude": -2.0114721566
   },
   {
     "3alpha": "BLY",
-    "station_name": "Bletchley Rail Station",
+    "station_name": "Bletchley",
     "latitude": 51.9953423523,
     "longitude": -0.7362994344
   },
   {
     "3alpha": "BMB",
-    "station_name": "Bamber Bridge Rail Station",
+    "station_name": "Bamber Bridge",
     "latitude": 53.7268807835,
     "longitude": -2.6607719493
   },
   {
     "3alpha": "BMC",
-    "station_name": "Bromley Cross Rail Station",
+    "station_name": "Bromley Cross",
     "latitude": 53.61405521,
     "longitude": -2.4108970227
   },
   {
     "3alpha": "BMD",
-    "station_name": "Brimsdown Rail Station",
+    "station_name": "Brimsdown",
     "latitude": 51.6555835568,
     "longitude": -0.0307911888
   },
   {
     "3alpha": "BME",
-    "station_name": "Broome Rail Station",
+    "station_name": "Broome",
     "latitude": 52.4227839595,
     "longitude": -2.8852059507
   },
   {
     "3alpha": "BMF",
-    "station_name": "Broomfleet Rail Station",
+    "station_name": "Broomfleet",
     "latitude": 53.7402272872,
     "longitude": -0.6718345795
   },
   {
     "3alpha": "BMG",
-    "station_name": "Barming Rail Station",
+    "station_name": "Barming",
     "latitude": 51.2848921433,
     "longitude": 0.4789874974
   },
   {
     "3alpha": "BMH",
-    "station_name": "Bournemouth Rail Station",
+    "station_name": "Bournemouth",
     "latitude": 50.7272603225,
     "longitude": -1.8644946471
   },
   {
     "3alpha": "BML",
-    "station_name": "Bramhall Rail Station",
+    "station_name": "Bramhall",
     "latitude": 53.3606279318,
     "longitude": -2.1635920263
   },
   {
     "3alpha": "BMN",
-    "station_name": "Bromley North Rail Station",
+    "station_name": "Bromley North",
     "latitude": 51.4083255508,
     "longitude": 0.0170184004
   },
   {
     "3alpha": "BMO",
-    "station_name": "Birmingham Moor Street Rail Station",
+    "station_name": "Birmingham Moor Street",
     "latitude": 52.4790920668,
     "longitude": -1.8924677323
   },
   {
     "3alpha": "BMP",
-    "station_name": "Brampton (Cumbria) Rail Station",
+    "station_name": "Brampton (Cumbria)",
     "latitude": 54.9323952275,
     "longitude": -2.7029523076
   },
   {
     "3alpha": "BMR",
-    "station_name": "Bromborough Rake Rail Station",
+    "station_name": "Bromborough Rake",
     "latitude": 53.3299208626,
     "longitude": -2.9894688327
   },
   {
     "3alpha": "BMS",
-    "station_name": "Bromley South Rail Station",
+    "station_name": "Bromley South",
     "latitude": 51.3999742022,
     "longitude": 0.0173696569
   },
   {
     "3alpha": "BMT",
-    "station_name": "Bedminster Rail Station",
+    "station_name": "Bedminster",
     "latitude": 51.4400845068,
     "longitude": -2.5941516846
   },
   {
     "3alpha": "BMV",
-    "station_name": "Bromsgrove Rail Station",
+    "station_name": "Bromsgrove",
     "latitude": 52.3222981835,
     "longitude": -2.0473389281
   },
   {
     "3alpha": "BMY",
-    "station_name": "Bramley (Hants) Rail Station",
+    "station_name": "Bramley (Hants)",
     "latitude": 51.330292014,
     "longitude": -1.0609834929
   },
   {
     "3alpha": "BNA",
-    "station_name": "Burnage Rail Station",
+    "station_name": "Burnage",
     "latitude": 53.4211811715,
     "longitude": -2.2156768396
   },
   {
     "3alpha": "BNC",
-    "station_name": "Burnley Central Rail Station",
+    "station_name": "Burnley Central",
     "latitude": 53.7935247085,
     "longitude": -2.2449718815
   },
   {
     "3alpha": "BND",
-    "station_name": "Brandon Rail Station",
+    "station_name": "Brandon",
     "latitude": 52.4540242165,
     "longitude": 0.6247556786
   },
   {
     "3alpha": "BNE",
-    "station_name": "Bourne End Rail Station",
+    "station_name": "Bourne End",
     "latitude": 51.5771193996,
     "longitude": -0.7104544193
   },
   {
     "3alpha": "BNF",
-    "station_name": "Briton Ferry Rail Station",
+    "station_name": "Briton Ferry",
     "latitude": 51.6378987804,
     "longitude": -3.8192683057
   },
   {
     "3alpha": "BNG",
-    "station_name": "Bangor (Gwynedd) Rail Station",
+    "station_name": "Bangor (Gwynedd)",
     "latitude": 53.2222979654,
     "longitude": -4.1358869294
   },
   {
     "3alpha": "BNH",
-    "station_name": "Barnehurst Rail Station",
+    "station_name": "Barnehurst",
     "latitude": 51.4649576152,
     "longitude": 0.1596730747
   },
   {
     "3alpha": "BNI",
-    "station_name": "Barnes Bridge Rail Station",
+    "station_name": "Barnes Bridge",
     "latitude": 51.4720070868,
     "longitude": -0.2526072102
   },
   {
     "3alpha": "BNL",
-    "station_name": "Barnhill Rail Station",
+    "station_name": "Barnhill",
     "latitude": 55.8774834443,
     "longitude": -4.2229911506
   },
   {
     "3alpha": "BNM",
-    "station_name": "Burnham (Berks) Rail Station",
+    "station_name": "Burnham (Berks)",
     "latitude": 51.5235064374,
     "longitude": -0.6463561439
   },
   {
     "3alpha": "BNP",
-    "station_name": "Barnstaple Rail Station",
+    "station_name": "Barnstaple",
     "latitude": 51.0739644921,
     "longitude": -4.0631402025
   },
   {
     "3alpha": "BNR",
-    "station_name": "Brockley Whins Rail Station",
+    "station_name": "Brockley Whins",
     "latitude": 54.9595502728,
     "longitude": -1.4613667215
   },
   {
     "3alpha": "BNS",
-    "station_name": "Barnes Rail Station",
+    "station_name": "Barnes",
     "latitude": 51.4670846365,
     "longitude": -0.2421410454
   },
   {
     "3alpha": "BNT",
-    "station_name": "Brinnington Rail Station",
+    "station_name": "Brinnington",
     "latitude": 53.432131208,
     "longitude": -2.1351183485
   },
   {
     "3alpha": "BNV",
-    "station_name": "Banavie Rail Station",
+    "station_name": "Banavie",
     "latitude": 56.8432899877,
     "longitude": -5.0954121623
   },
   {
     "3alpha": "BNW",
-    "station_name": "Bootle New Strand Rail Station",
+    "station_name": "Bootle New Strand",
     "latitude": 53.4534030856,
     "longitude": -2.9947465497
   },
   {
     "3alpha": "BNY",
-    "station_name": "Barnsley Rail Station",
+    "station_name": "Barnsley",
     "latitude": 53.5543175422,
     "longitude": -1.47716617
   },
   {
     "3alpha": "BOA",
-    "station_name": "Bradford-on-Avon Rail Station",
+    "station_name": "Bradford-on-Avon",
     "latitude": 51.3449090983,
     "longitude": -2.2523240424
   },
   {
     "3alpha": "BOC",
-    "station_name": "Bootle (Cumbria) Rail Station",
+    "station_name": "Bootle (Cumbria)",
     "latitude": 54.291308954,
     "longitude": -3.3938621381
   },
   {
     "3alpha": "BOD",
-    "station_name": "Bodmin Parkway Rail Station",
+    "station_name": "Bodmin Parkway",
     "latitude": 50.4458496871,
     "longitude": -4.6629674421
   },
   {
     "3alpha": "BOE",
-    "station_name": "Botley Rail Station",
+    "station_name": "Botley",
     "latitude": 50.9164438022,
     "longitude": -1.2592242694
   },
   {
     "3alpha": "BOG",
-    "station_name": "Bognor Regis Rail Station",
+    "station_name": "Bognor Regis",
     "latitude": 50.786547177,
     "longitude": -0.6761573725
   },
   {
     "3alpha": "BOH",
-    "station_name": "Bosham Rail Station",
+    "station_name": "Bosham",
     "latitude": 50.8427366135,
     "longitude": -0.8474129936
   },
   {
     "3alpha": "BOM",
-    "station_name": "Bromborough Rail Station",
+    "station_name": "Bromborough",
     "latitude": 53.321860927,
     "longitude": -2.9868952277
   },
   {
     "3alpha": "BON",
-    "station_name": "Bolton Rail Station",
+    "station_name": "Bolton",
     "latitude": 53.5741575045,
     "longitude": -2.425822783
   },
   {
     "3alpha": "BOP",
-    "station_name": "Bowes Park Rail Station",
+    "station_name": "Bowes Park",
     "latitude": 51.6070128955,
     "longitude": -0.1205568702
   },
   {
     "3alpha": "BOR",
-    "station_name": "Bodorgan Rail Station",
+    "station_name": "Bodorgan",
     "latitude": 53.2043181126,
     "longitude": -4.4180098996
   },
   {
     "3alpha": "BOT",
-    "station_name": "Bootle Oriel Road Rail Station",
+    "station_name": "Bootle Oriel Road",
     "latitude": 53.4466353518,
     "longitude": -2.9957327823
   },
   {
+    "3alpha": "BOW",
+    "station_name": "Bow Street",
+    "latitude": 52.4400,
+    "longitude": -4.0303
+  },
+  {
     "3alpha": "BPB",
-    "station_name": "Blackpool Pleasure Beach Rail Station",
+    "station_name": "Blackpool Pleasure Beach",
     "latitude": 53.7879651191,
     "longitude": -3.0538730548
   },
   {
     "3alpha": "BPC",
-    "station_name": "Penychain Rail Station",
+    "station_name": "Penychain",
     "latitude": 52.9028982685,
     "longitude": -4.3387298378
   },
   {
     "3alpha": "BPK",
-    "station_name": "Brookmans Park Rail Station",
+    "station_name": "Brookmans Park",
     "latitude": 51.7210644329,
     "longitude": -0.204525873
   },
   {
     "3alpha": "BPN",
-    "station_name": "Blackpool North Rail Station",
+    "station_name": "Blackpool North",
     "latitude": 53.8219272752,
     "longitude": -3.0492707494
   },
   {
     "3alpha": "BPS",
-    "station_name": "Blackpool South Rail Station",
+    "station_name": "Blackpool South",
     "latitude": 53.7987134952,
     "longitude": -3.0489347667
   },
   {
     "3alpha": "BPT",
-    "station_name": "Bishopton Rail Station",
+    "station_name": "Bishopton",
     "latitude": 55.9022563659,
     "longitude": -4.5004702272
   },
   {
     "3alpha": "BPW",
-    "station_name": "Bristol Parkway Rail Station",
+    "station_name": "Bristol Parkway",
     "latitude": 51.5137984154,
     "longitude": -2.5421644857
   },
   {
     "3alpha": "BRA",
-    "station_name": "Brora Rail Station",
+    "station_name": "Brora",
     "latitude": 58.012933425,
     "longitude": -3.8522865622
   },
   {
     "3alpha": "BRC",
-    "station_name": "Breich Rail Station",
+    "station_name": "Breich",
     "latitude": 55.8273074741,
     "longitude": -3.6681187271
   },
   {
     "3alpha": "BRE",
-    "station_name": "Brentwood Rail Station",
+    "station_name": "Brentwood",
     "latitude": 51.6136062194,
     "longitude": 0.2996132443
   },
   {
     "3alpha": "BRF",
-    "station_name": "Brierfield Rail Station",
+    "station_name": "Brierfield",
     "latitude": 53.8239929448,
     "longitude": -2.2364914709
   },
   {
     "3alpha": "BRG",
-    "station_name": "Borough Green & Wrotham Rail Station",
+    "station_name": "Borough Green & Wrotham",
     "latitude": 51.293215966,
     "longitude": 0.3062721999
   },
   {
     "3alpha": "BRH",
-    "station_name": "Borth Rail Station",
+    "station_name": "Borth",
     "latitude": 52.4910411643,
     "longitude": -4.0501863389
   },
   {
     "3alpha": "BRI",
-    "station_name": "Bristol Temple Meads Rail Station",
+    "station_name": "Bristol Temple Meads",
     "latitude": 51.4491404983,
     "longitude": -2.5813170589
   },
   {
     "3alpha": "BRK",
-    "station_name": "Berwick (Sussex) Rail Station",
+    "station_name": "Berwick (Sussex)",
     "latitude": 50.8403713146,
     "longitude": 0.1660450404
   },
   {
     "3alpha": "BRL",
-    "station_name": "Barrhill Rail Station",
+    "station_name": "Barrhill",
     "latitude": 55.0970097604,
     "longitude": -4.7817610115
   },
   {
     "3alpha": "BRM",
-    "station_name": "Barmouth Rail Station",
+    "station_name": "Barmouth",
     "latitude": 52.7229049113,
     "longitude": -4.0566037471
   },
   {
     "3alpha": "BRN",
-    "station_name": "Bearsden Rail Station",
+    "station_name": "Bearsden",
     "latitude": 55.9171219632,
     "longitude": -4.3320048257
   },
   {
     "3alpha": "BRO",
-    "station_name": "Bridge of Orchy Rail Station",
+    "station_name": "Bridge of Orchy",
     "latitude": 56.5158519882,
     "longitude": -4.7629778286
   },
   {
     "3alpha": "BRP",
-    "station_name": "Brampton (Suffolk) Rail Station",
+    "station_name": "Brampton (Suffolk)",
     "latitude": 52.39545585,
     "longitude": 1.5438396721
   },
   {
     "3alpha": "BRR",
-    "station_name": "Barrhead Rail Station",
+    "station_name": "Barrhead",
     "latitude": 55.8037470316,
     "longitude": -4.3972682443
   },
   {
     "3alpha": "BRS",
-    "station_name": "Berrylands Rail Station",
+    "station_name": "Berrylands",
     "latitude": 51.3990426839,
     "longitude": -0.280691098
   },
   {
     "3alpha": "BRT",
-    "station_name": "Barlaston Rail Station",
+    "station_name": "Barlaston",
     "latitude": 52.9428868109,
     "longitude": -2.1681101939
   },
   {
     "3alpha": "BRU",
-    "station_name": "Bruton Rail Station",
+    "station_name": "Bruton",
     "latitude": 51.1116312549,
     "longitude": -2.4470735628
   },
   {
     "3alpha": "BRV",
-    "station_name": "Bournville Rail Station",
+    "station_name": "Bournville",
     "latitude": 52.4269759491,
     "longitude": -1.9264177275
   },
   {
     "3alpha": "BRW",
-    "station_name": "Brunswick Rail Station",
+    "station_name": "Brunswick",
     "latitude": 53.3832558566,
     "longitude": -2.9760770621
   },
   {
     "3alpha": "BRX",
-    "station_name": "Brixton Rail Station",
+    "station_name": "Brixton",
     "latitude": 51.4632979174,
     "longitude": -0.1141578263
   },
   {
     "3alpha": "BRY",
-    "station_name": "Barry Rail Station",
+    "station_name": "Barry",
     "latitude": 51.3967799856,
     "longitude": -3.2849950221
   },
   {
     "3alpha": "BSB",
-    "station_name": "Bleasby Rail Station",
+    "station_name": "Bleasby",
     "latitude": 53.0413834346,
     "longitude": -0.9436832322
   },
   {
     "3alpha": "BSC",
-    "station_name": "Bescot Stadium Rail Station",
+    "station_name": "Bescot Stadium",
     "latitude": 52.5631069514,
     "longitude": -1.9911001339
   },
   {
     "3alpha": "BSD",
-    "station_name": "Bearsted Rail Station",
+    "station_name": "Bearsted",
     "latitude": 51.2758186317,
     "longitude": 0.5776101903
   },
   {
     "3alpha": "BSE",
-    "station_name": "Bury St Edmunds Rail Station",
+    "station_name": "Bury St Edmunds",
     "latitude": 52.2537779145,
     "longitude": 0.7133353034
   },
   {
     "3alpha": "BSH",
-    "station_name": "Bushey Rail Station",
+    "station_name": "Bushey",
     "latitude": 51.6457542219,
     "longitude": -0.3852982939
   },
   {
     "3alpha": "BSI",
-    "station_name": "Balmossie Rail Station",
+    "station_name": "Balmossie",
     "latitude": 56.4745544268,
     "longitude": -2.8389594192
   },
   {
     "3alpha": "BSJ",
-    "station_name": "Bedford St Johns Rail Station",
+    "station_name": "Bedford St Johns",
     "latitude": 52.1294885146,
     "longitude": -0.4674793726
   },
   {
     "3alpha": "BSK",
-    "station_name": "Basingstoke Rail Station",
+    "station_name": "Basingstoke",
     "latitude": 51.2683550841,
     "longitude": -1.0872452751
   },
   {
     "3alpha": "BSL",
-    "station_name": "Beasdale Rail Station",
+    "station_name": "Beasdale",
     "latitude": 56.8995320852,
     "longitude": -5.7637827088
   },
   {
     "3alpha": "BSM",
-    "station_name": "Branksome Rail Station",
+    "station_name": "Branksome",
     "latitude": 50.7269511745,
     "longitude": -1.9197490477
   },
   {
     "3alpha": "BSN",
-    "station_name": "Boston Rail Station",
+    "station_name": "Boston",
     "latitude": 52.9781123717,
     "longitude": -0.0309954737
   },
   {
     "3alpha": "BSO",
-    "station_name": "Basildon Rail Station",
+    "station_name": "Basildon",
     "latitude": 51.5681072863,
     "longitude": 0.4568185797
   },
   {
     "3alpha": "BSP",
-    "station_name": "Brondesbury Park Rail Station",
+    "station_name": "Brondesbury Park",
     "latitude": 51.5406994758,
     "longitude": -0.2101030164
   },
   {
     "3alpha": "BSR",
-    "station_name": "Broadstairs Rail Station",
+    "station_name": "Broadstairs",
     "latitude": 51.3606801474,
     "longitude": 1.4335860392
   },
   {
     "3alpha": "BSS",
-    "station_name": "Barassie Rail Station",
+    "station_name": "Barassie",
     "latitude": 55.5610564283,
     "longitude": -4.6511181093
   },
   {
     "3alpha": "BSU",
-    "station_name": "Brunstane Rail Station",
+    "station_name": "Brunstane",
     "latitude": 55.9425045311,
     "longitude": -3.1009897555
   },
   {
     "3alpha": "BSV",
-    "station_name": "Buckshaw Parkway Rail Station",
+    "station_name": "Buckshaw Parkway",
     "latitude": 53.6733558277,
     "longitude": -2.6608267264
   },
   {
     "3alpha": "BSW",
-    "station_name": "Birmingham Snow Hill Rail Station",
+    "station_name": "Birmingham Snow Hill",
     "latitude": 52.4833681846,
     "longitude": -1.89908361
   },
   {
     "3alpha": "BSY",
-    "station_name": "Brondesbury Rail Station",
+    "station_name": "Brondesbury",
     "latitude": 51.5451661494,
     "longitude": -0.2022838772
   },
   {
     "3alpha": "BTB",
-    "station_name": "Barnetby Rail Station",
+    "station_name": "Barnetby",
     "latitude": 53.5751404569,
     "longitude": -0.4096836565
   },
   {
     "3alpha": "BTD",
-    "station_name": "Bolton-Upon-Dearne Rail Station",
+    "station_name": "Bolton-Upon-Dearne",
     "latitude": 53.5189640059,
     "longitude": -1.3115478698
   },
   {
     "3alpha": "BTE",
-    "station_name": "Bitterne Rail Station",
+    "station_name": "Bitterne",
     "latitude": 50.9182096759,
     "longitude": -1.3769901266
   },
   {
     "3alpha": "BTF",
-    "station_name": "Bottesford Rail Station",
+    "station_name": "Bottesford",
     "latitude": 52.944634247,
     "longitude": -0.7948377662
   },
   {
     "3alpha": "BTG",
-    "station_name": "Barnt Green Rail Station",
+    "station_name": "Barnt Green",
     "latitude": 52.3611012481,
     "longitude": -1.9924584823
   },
   {
     "3alpha": "BTH",
-    "station_name": "Bath Spa Rail Station",
+    "station_name": "Bath Spa",
     "latitude": 51.3776813346,
     "longitude": -2.3570165586
   },
   {
     "3alpha": "BTL",
-    "station_name": "Batley Rail Station",
+    "station_name": "Batley",
     "latitude": 53.7099546488,
     "longitude": -1.6229560553
   },
   {
     "3alpha": "BTN",
-    "station_name": "Brighton Rail Station",
+    "station_name": "Brighton",
     "latitude": 50.8289969623,
     "longitude": -0.1412525289
   },
   {
     "3alpha": "BTO",
-    "station_name": "Betchworth Rail Station",
+    "station_name": "Betchworth",
     "latitude": 51.2481856234,
     "longitude": -0.2669489143
   },
   {
     "3alpha": "BTP",
-    "station_name": "Braintree Freeport Rail Station",
+    "station_name": "Braintree Freeport",
     "latitude": 51.86942396,
     "longitude": 0.5684631055
   },
   {
     "3alpha": "BTR",
-    "station_name": "Braintree Rail Station",
+    "station_name": "Braintree",
     "latitude": 51.8753991861,
     "longitude": 0.5567148512
   },
   {
     "3alpha": "BTS",
-    "station_name": "Burntisland Rail Station",
+    "station_name": "Burntisland",
     "latitude": 56.0570735491,
     "longitude": -3.233198596
   },
   {
     "3alpha": "BTT",
-    "station_name": "Battersby Rail Station",
+    "station_name": "Battersby",
     "latitude": 54.4576909817,
     "longitude": -1.092985447
   },
   {
     "3alpha": "BTY",
-    "station_name": "Bentley (Hants) Rail Station",
+    "station_name": "Bentley (Hants)",
     "latitude": 51.1812286564,
     "longitude": -0.8681101444
   },
   {
     "3alpha": "BUB",
-    "station_name": "Burnley Barracks Rail Station",
+    "station_name": "Burnley Barracks",
     "latitude": 53.7908906624,
     "longitude": -2.2580864157
   },
   {
     "3alpha": "BUC",
-    "station_name": "Buckenham Rail Station",
+    "station_name": "Buckenham",
     "latitude": 52.5977618232,
     "longitude": 1.4703489483
   },
   {
     "3alpha": "BUD",
-    "station_name": "Burneside (Cumbria) Rail Station",
+    "station_name": "Burneside (Cumbria)",
     "latitude": 54.3549872461,
     "longitude": -2.7666793226
   },
   {
     "3alpha": "BUE",
-    "station_name": "Bures Rail Station",
+    "station_name": "Bures",
     "latitude": 51.9711715742,
     "longitude": 0.7691763467
   },
   {
     "3alpha": "BUG",
-    "station_name": "Burgess Hill Rail Station",
+    "station_name": "Burgess Hill",
     "latitude": 50.9536493887,
     "longitude": -0.1273860328
   },
   {
     "3alpha": "BUH",
-    "station_name": "Brough Rail Station",
+    "station_name": "Brough",
     "latitude": 53.7269790626,
     "longitude": -0.5787296823
   },
   {
     "3alpha": "BUI",
-    "station_name": "Burnside (Strathclyde) Rail Station",
+    "station_name": "Burnside (Strathclyde)",
     "latitude": 55.8169207887,
     "longitude": -4.2023757518
   },
   {
     "3alpha": "BUJ",
-    "station_name": "Burton Joyce Rail Station",
+    "station_name": "Burton Joyce",
     "latitude": 52.9834597732,
     "longitude": -1.0408745342
   },
   {
     "3alpha": "BUK",
-    "station_name": "Bucknell Rail Station",
+    "station_name": "Bucknell",
     "latitude": 52.3573903067,
     "longitude": -2.94737686
   },
   {
     "3alpha": "BUL",
-    "station_name": "Butlers Lane Rail Station",
+    "station_name": "Butlers Lane",
     "latitude": 52.5924838341,
     "longitude": -1.8380133232
   },
   {
     "3alpha": "BUO",
-    "station_name": "Bursledon Rail Station",
+    "station_name": "Bursledon",
     "latitude": 50.8836771224,
     "longitude": -1.3050217804
   },
   {
     "3alpha": "BUS",
-    "station_name": "Busby Rail Station",
+    "station_name": "Busby",
     "latitude": 55.7803335966,
     "longitude": -4.2621874207
   },
   {
     "3alpha": "BUT",
-    "station_name": "Burton-on-Trent Rail Station",
+    "station_name": "Burton-on-Trent",
     "latitude": 52.805831535,
     "longitude": -1.6424549107
   },
   {
     "3alpha": "BUU",
-    "station_name": "Burnham-on-Crouch Rail Station",
+    "station_name": "Burnham-on-Crouch",
     "latitude": 51.6336616952,
     "longitude": 0.8140576821
   },
   {
     "3alpha": "BUW",
-    "station_name": "Burley-in-Wharfedale Rail Station",
+    "station_name": "Burley-in-Wharfedale",
     "latitude": 53.9081639278,
     "longitude": -1.7533757307
   },
   {
     "3alpha": "BUX",
-    "station_name": "Buxton Rail Station",
+    "station_name": "Buxton",
     "latitude": 53.2607356445,
     "longitude": -1.9128621475
   },
   {
     "3alpha": "BUY",
-    "station_name": "Burley Park Rail Station",
+    "station_name": "Burley Park",
     "latitude": 53.8120445498,
     "longitude": -1.5777714582
   },
   {
     "3alpha": "BVD",
-    "station_name": "Belvedere Rail Station",
+    "station_name": "Belvedere",
     "latitude": 51.4921169254,
     "longitude": 0.1523141776
   },
   {
     "3alpha": "BWB",
-    "station_name": "Bow Brickhill Rail Station",
+    "station_name": "Bow Brickhill",
     "latitude": 52.0043090172,
     "longitude": -0.6960564274
   },
   {
     "3alpha": "BWD",
-    "station_name": "Birchwood Rail Station",
+    "station_name": "Birchwood",
     "latitude": 53.4127333746,
     "longitude": -2.5253084603
   },
   {
     "3alpha": "BWG",
-    "station_name": "Bowling Rail Station",
+    "station_name": "Bowling",
     "latitude": 55.9310714655,
     "longitude": -4.4938258606
   },
   {
     "3alpha": "BWK",
-    "station_name": "Berwick-upon-Tweed Rail Station",
+    "station_name": "Berwick-upon-Tweed",
     "latitude": 55.774332462,
     "longitude": -2.0109833916
   },
   {
     "3alpha": "BWN",
-    "station_name": "Bloxwich North Rail Station",
+    "station_name": "Bloxwich North",
     "latitude": 52.6254506167,
     "longitude": -2.0176785833
   },
   {
     "3alpha": "BWO",
-    "station_name": "Bricket Wood Rail Station",
+    "station_name": "Bricket Wood",
     "latitude": 51.7054311593,
     "longitude": -0.3590920111
   },
   {
     "3alpha": "BWS",
-    "station_name": "Barrow upon Soar Rail Station",
+    "station_name": "Barrow upon Soar",
     "latitude": 52.7493534585,
     "longitude": -1.1448359281
   },
   {
     "3alpha": "BWT",
-    "station_name": "Bridgwater Rail Station",
+    "station_name": "Bridgwater",
     "latitude": 51.1278501854,
     "longitude": -2.9904134747
   },
   {
     "3alpha": "BXB",
-    "station_name": "Broxbourne Rail Station",
+    "station_name": "Broxbourne",
     "latitude": 51.746913795,
     "longitude": -0.0110606305
   },
   {
     "3alpha": "BXD",
-    "station_name": "Buxted Rail Station",
+    "station_name": "Buxted",
     "latitude": 50.9900076084,
     "longitude": 0.1314658692
   },
   {
     "3alpha": "BXH",
-    "station_name": "Bexleyheath Rail Station",
+    "station_name": "Bexleyheath",
     "latitude": 51.4634986628,
     "longitude": 0.1337619475
   },
   {
     "3alpha": "BXW",
-    "station_name": "Box Hill & Westhumble Rail Station",
+    "station_name": "Box Hill & Westhumble",
     "latitude": 51.2540077838,
     "longitude": -0.3284670481
   },
   {
     "3alpha": "BXY",
-    "station_name": "Bexley Rail Station",
+    "station_name": "Bexley",
     "latitude": 51.4402179279,
     "longitude": 0.1479285922
   },
   {
     "3alpha": "BYA",
-    "station_name": "Berney Arms Rail Station",
+    "station_name": "Berney Arms",
     "latitude": 52.5898102913,
     "longitude": 1.6303988741
   },
   {
     "3alpha": "BYB",
-    "station_name": "Blythe Bridge Rail Station",
+    "station_name": "Blythe Bridge",
     "latitude": 52.9681588029,
     "longitude": -2.0669597492
   },
   {
     "3alpha": "BYC",
-    "station_name": "Betws-y-Coed Rail Station",
+    "station_name": "Betws-y-Coed",
     "latitude": 53.0920807045,
     "longitude": -3.8008660334
   },
   {
     "3alpha": "BYD",
-    "station_name": "Barry Docks Rail Station",
+    "station_name": "Barry Docks",
     "latitude": 51.4024388396,
     "longitude": -3.2607138987
   },
   {
     "3alpha": "BYE",
-    "station_name": "Bynea Rail Station",
+    "station_name": "Bynea",
     "latitude": 51.6720355869,
     "longitude": -4.0989020803
   },
   {
     "3alpha": "BYF",
-    "station_name": "Broughty Ferry Rail Station",
+    "station_name": "Broughty Ferry",
     "latitude": 56.467149407,
     "longitude": -2.8731557887
   },
   {
     "3alpha": "BYI",
-    "station_name": "Barry Island Rail Station",
+    "station_name": "Barry Island",
     "latitude": 51.3924107233,
     "longitude": -3.2733735249
   },
   {
     "3alpha": "BYK",
-    "station_name": "Bentley (S Yorks) Rail Station",
+    "station_name": "Bentley (S Yorks)",
     "latitude": 53.5439546043,
     "longitude": -1.1509511595
   },
   {
     "3alpha": "BYL",
-    "station_name": "Barry Links Rail Station",
+    "station_name": "Barry Links",
     "latitude": 56.4931375583,
     "longitude": -2.7454472508
   },
   {
     "3alpha": "BYM",
-    "station_name": "Burnley Manchester Road Rail Station",
+    "station_name": "Burnley Manchester Road",
     "latitude": 53.7849780535,
     "longitude": -2.2488678001
   },
   {
     "3alpha": "BYN",
-    "station_name": "Bryn Rail Station",
+    "station_name": "Bryn",
     "latitude": 53.4998801227,
     "longitude": -2.6472139369
   },
   {
     "3alpha": "BYS",
-    "station_name": "Braystones Rail Station",
+    "station_name": "Braystones",
     "latitude": 54.4393680606,
     "longitude": -3.5418249064
   },
   {
     "3alpha": "CAA",
-    "station_name": "Coventry Arena Rail Station",
+    "station_name": "Coventry Arena",
     "latitude": 52.4477480204,
     "longitude": -1.4941167693
   },
   {
     "3alpha": "CAC",
-    "station_name": "Caldercruix Rail Station",
+    "station_name": "Caldercruix",
     "latitude": 55.887937313,
     "longitude": -3.8877014781
   },
   {
     "3alpha": "CAD",
-    "station_name": "Cadoxton Rail Station",
+    "station_name": "Cadoxton",
     "latitude": 51.4122775163,
     "longitude": -3.2489057172
   },
   {
     "3alpha": "CAG",
-    "station_name": "Carrbridge Rail Station",
+    "station_name": "Carrbridge",
     "latitude": 57.2794851095,
     "longitude": -3.8282023232
   },
   {
     "3alpha": "CAK",
-    "station_name": "Cark Rail Station",
+    "station_name": "Cark",
     "latitude": 54.177962852,
     "longitude": -2.9740635997
   },
   {
     "3alpha": "CAM",
-    "station_name": "Camberley Rail Station",
+    "station_name": "Camberley",
     "latitude": 51.3363253942,
     "longitude": -0.7442546332
   },
   {
     "3alpha": "CAN",
-    "station_name": "Carnoustie Rail Station",
+    "station_name": "Carnoustie",
     "latitude": 56.5005520159,
     "longitude": -2.7066067008
   },
   {
     "3alpha": "CAO",
-    "station_name": "Cannock Rail Station",
+    "station_name": "Cannock",
     "latitude": 52.6861755085,
     "longitude": -2.0221416067
   },
   {
     "3alpha": "CAR",
-    "station_name": "Carlisle Rail Station",
+    "station_name": "Carlisle",
     "latitude": 54.8906568723,
     "longitude": -2.9331955073
   },
   {
     "3alpha": "CAS",
-    "station_name": "Castleton (Manchester) Rail Station",
+    "station_name": "Castleton (Manchester)",
     "latitude": 53.5918610828,
     "longitude": -2.1782323207
   },
   {
     "3alpha": "CAT",
-    "station_name": "Caterham Rail Station",
+    "station_name": "Caterham",
     "latitude": 51.2821380427,
     "longitude": -0.0782806392
   },
   {
     "3alpha": "CAU",
-    "station_name": "Causeland Rail Station",
+    "station_name": "Causeland",
     "latitude": 50.4056755023,
     "longitude": -4.466483549
   },
   {
     "3alpha": "CAY",
-    "station_name": "Carntyne Rail Station",
+    "station_name": "Carntyne",
     "latitude": 55.8548667252,
     "longitude": -4.178558829
   },
   {
     "3alpha": "CBB",
-    "station_name": "Carbis Bay Rail Station",
+    "station_name": "Carbis Bay",
     "latitude": 50.1970388168,
     "longitude": -5.4633147211
   },
   {
     "3alpha": "CBC",
-    "station_name": "Coatbridge Central Rail Station",
+    "station_name": "Coatbridge Central",
     "latitude": 55.8624998584,
     "longitude": -4.0318858547
   },
   {
     "3alpha": "CBD",
-    "station_name": "Conon Bridge Rail Station",
+    "station_name": "Conon Bridge",
     "latitude": 57.5617327905,
     "longitude": -4.4404033769
   },
   {
     "3alpha": "CBE",
-    "station_name": "Canterbury East Rail Station",
+    "station_name": "Canterbury East",
     "latitude": 51.2742704504,
     "longitude": 1.0759983241
   },
   {
     "3alpha": "CBG",
-    "station_name": "Cambridge Rail Station",
+    "station_name": "Cambridge",
     "latitude": 52.1940786826,
     "longitude": 0.1374844883
   },
   {
     "3alpha": "CBH",
-    "station_name": "Cambridge Heath (London) Rail Station",
+    "station_name": "Cambridge Heath (London)",
     "latitude": 51.5319721727,
     "longitude": -0.0572520963
   },
   {
     "3alpha": "CBK",
-    "station_name": "Cranbrook Rail Station",
+    "station_name": "Cranbrook",
     "latitude": 50.7500793373,
     "longitude": -3.4204288894
   },
   {
     "3alpha": "CBL",
-    "station_name": "Cambuslang Rail Station",
+    "station_name": "Cambuslang",
     "latitude": 55.8196005407,
     "longitude": -4.1729949447
   },
   {
     "3alpha": "CBN",
-    "station_name": "Camborne Rail Station",
+    "station_name": "Camborne",
     "latitude": 50.210424474,
     "longitude": -5.2974601339
   },
   {
     "3alpha": "CBP",
-    "station_name": "Castle Bar Park Rail Station",
+    "station_name": "Castle Bar Park",
     "latitude": 51.5229296496,
     "longitude": -0.3315265492
   },
   {
     "3alpha": "CBR",
-    "station_name": "Cooksbridge Rail Station",
+    "station_name": "Cooksbridge",
     "latitude": 50.9037495693,
     "longitude": -0.0091755079
   },
   {
     "3alpha": "CBS",
-    "station_name": "Coatbridge Sunnyside Rail Station",
+    "station_name": "Coatbridge Sunnyside",
     "latitude": 55.8668282944,
     "longitude": -4.0282763675
   },
   {
     "3alpha": "CBW",
-    "station_name": "Canterbury West Rail Station",
+    "station_name": "Canterbury West",
     "latitude": 51.284271981,
     "longitude": 1.0753330452
   },
   {
     "3alpha": "CBY",
-    "station_name": "Charlbury Rail Station",
+    "station_name": "Charlbury",
     "latitude": 51.8724337794,
     "longitude": -1.4896781604
   },
   {
     "3alpha": "CCC",
-    "station_name": "Criccieth Rail Station",
+    "station_name": "Criccieth",
     "latitude": 52.9184246922,
     "longitude": -4.2375196432
   },
   {
     "3alpha": "CCH",
-    "station_name": "Chichester Rail Station",
+    "station_name": "Chichester",
     "latitude": 50.8320420668,
     "longitude": -0.7817301783
   },
   {
     "3alpha": "CCT",
-    "station_name": "Cathcart Rail Station",
+    "station_name": "Cathcart",
     "latitude": 55.8176625197,
     "longitude": -4.260522045
   },
   {
     "3alpha": "CDB",
-    "station_name": "Cardiff Bay Rail Station",
+    "station_name": "Cardiff Bay",
     "latitude": 51.4671073886,
     "longitude": -3.1664118035
   },
   {
     "3alpha": "CDD",
-    "station_name": "Cardenden Rail Station",
+    "station_name": "Cardenden",
     "latitude": 56.1412469307,
     "longitude": -3.2616419946
   },
   {
     "3alpha": "CDF",
-    "station_name": "Cardiff Central Rail Station",
+    "station_name": "Cardiff Central",
     "latitude": 51.4760241554,
     "longitude": -3.1793104707
   },
   {
     "3alpha": "CDI",
-    "station_name": "Crediton Rail Station",
+    "station_name": "Crediton",
     "latitude": 50.7832916037,
     "longitude": -3.6467942575
   },
   {
     "3alpha": "CDN",
-    "station_name": "Coulsdon Town Rail Station",
+    "station_name": "Coulsdon Town",
     "latitude": 51.3220392402,
     "longitude": -0.1344387303
   },
   {
     "3alpha": "CDO",
-    "station_name": "Cardonald Rail Station",
+    "station_name": "Cardonald",
     "latitude": 55.8525617165,
     "longitude": -4.340677662
   },
   {
     "3alpha": "CDQ",
-    "station_name": "Cardiff Queen Street Rail Station",
+    "station_name": "Cardiff Queen Street",
     "latitude": 51.4819604384,
     "longitude": -3.1701891748
   },
   {
     "3alpha": "CDR",
-    "station_name": "Cardross Rail Station",
+    "station_name": "Cardross",
     "latitude": 55.9603705466,
     "longitude": -4.6530550015
   },
   {
     "3alpha": "CDS",
-    "station_name": "Coulsdon South Rail Station",
+    "station_name": "Coulsdon South",
     "latitude": 51.3158346141,
     "longitude": -0.1378616075
   },
   {
     "3alpha": "CDT",
-    "station_name": "Caldicot Rail Station",
+    "station_name": "Caldicot",
     "latitude": 51.5847886548,
     "longitude": -2.7605785503
   },
   {
     "3alpha": "CDU",
-    "station_name": "Cam & Dursley Rail Station",
+    "station_name": "Cam & Dursley",
     "latitude": 51.7176208933,
     "longitude": -2.3590816591
   },
   {
     "3alpha": "CDY",
-    "station_name": "Cartsdyke Rail Station",
+    "station_name": "Cartsdyke",
     "latitude": 55.9422051727,
     "longitude": -4.7315711125
   },
   {
     "3alpha": "CEA",
-    "station_name": "Cleland Rail Station",
+    "station_name": "Cleland",
     "latitude": 55.8046428518,
     "longitude": -3.9102338035
   },
   {
     "3alpha": "CED",
-    "station_name": "Cheddington Rail Station",
+    "station_name": "Cheddington",
     "latitude": 51.8579248983,
     "longitude": -0.6621263072
   },
   {
     "3alpha": "CEF",
-    "station_name": "Chapel-en-le-Frith Rail Station",
+    "station_name": "Chapel-en-le-Frith",
     "latitude": 53.3122450065,
     "longitude": -1.9187614767
   },
   {
     "3alpha": "CEH",
-    "station_name": "Coleshill Parkway Rail Station",
+    "station_name": "Coleshill Parkway",
     "latitude": 52.5165405856,
     "longitude": -1.7081695542
   },
   {
     "3alpha": "CEL",
-    "station_name": "Chelford Rail Station",
+    "station_name": "Chelford",
     "latitude": 53.270324898,
     "longitude": -2.2805759167
   },
   {
     "3alpha": "CES",
-    "station_name": "Cressing Rail Station",
+    "station_name": "Cressing",
     "latitude": 51.8523442178,
     "longitude": 0.5779891355
   },
   {
     "3alpha": "CET",
-    "station_name": "Colchester Town Rail Station",
+    "station_name": "Colchester Town",
     "latitude": 51.8864651647,
     "longitude": 0.904792312
   },
   {
     "3alpha": "CEY",
-    "station_name": "Cononley Rail Station",
+    "station_name": "Cononley",
     "latitude": 53.917582567,
     "longitude": -2.012071028
   },
   {
     "3alpha": "CFB",
-    "station_name": "Catford Bridge Rail Station",
+    "station_name": "Catford Bridge",
     "latitude": 51.4447386824,
     "longitude": -0.0247654501
   },
   {
     "3alpha": "CFD",
-    "station_name": "Castleford Rail Station",
+    "station_name": "Castleford",
     "latitude": 53.7240933891,
     "longitude": -1.3546560801
   },
   {
     "3alpha": "CFF",
-    "station_name": "Croftfoot Rail Station",
+    "station_name": "Croftfoot",
     "latitude": 55.818250801,
     "longitude": -4.2283107571
   },
   {
     "3alpha": "CFH",
-    "station_name": "Chafford Hundred Rail Station",
+    "station_name": "Chafford Hundred",
     "latitude": 51.4855557794,
     "longitude": 0.2874752389
   },
   {
     "3alpha": "CFL",
-    "station_name": "Crossflatts Rail Station",
+    "station_name": "Crossflatts",
     "latitude": 53.8584785,
     "longitude": -1.8448891769
   },
   {
     "3alpha": "CFN",
-    "station_name": "Clifton Down Rail Station",
+    "station_name": "Clifton Down",
     "latitude": 51.4645414825,
     "longitude": -2.6117434096
   },
   {
     "3alpha": "CFO",
-    "station_name": "Chalfont & Latimer Rail Station",
+    "station_name": "Chalfont & Latimer",
     "latitude": 51.6681107756,
     "longitude": -0.5605042796
   },
   {
     "3alpha": "CFR",
-    "station_name": "Chandlers Ford Rail Station",
+    "station_name": "Chandlers Ford",
     "latitude": 50.9836745047,
     "longitude": -1.3851600502
   },
   {
     "3alpha": "CFT",
-    "station_name": "Crofton Park Rail Station",
+    "station_name": "Crofton Park",
     "latitude": 51.45518736,
     "longitude": -0.036477467
   },
   {
     "3alpha": "CGD",
-    "station_name": "Craigendoran Rail Station",
+    "station_name": "Craigendoran",
     "latitude": 55.9947875724,
     "longitude": -4.7112248712
   },
   {
     "3alpha": "CGM",
-    "station_name": "Cottingham Rail Station",
+    "station_name": "Cottingham",
     "latitude": 53.7816677653,
     "longitude": -0.4064399418
   },
   {
     "3alpha": "CGN",
-    "station_name": "Cogan Rail Station",
+    "station_name": "Cogan",
     "latitude": 51.4459907902,
     "longitude": -3.189098989
   },
   {
     "3alpha": "CGW",
-    "station_name": "Caergwrle Rail Station",
+    "station_name": "Caergwrle",
     "latitude": 53.1078775755,
     "longitude": -3.0329132338
   },
   {
     "3alpha": "CHC",
-    "station_name": "Charing Cross (Glasgow) Rail Station",
+    "station_name": "Charing Cross (Glasgow)",
     "latitude": 55.8646752269,
     "longitude": -4.2698055885
   },
   {
     "3alpha": "CHD",
-    "station_name": "Chesterfield Rail Station",
+    "station_name": "Chesterfield",
     "latitude": 53.2382369384,
     "longitude": -1.4201139064
   },
   {
     "3alpha": "CHE",
-    "station_name": "Cheam Rail Station",
+    "station_name": "Cheam",
     "latitude": 51.3554760901,
     "longitude": -0.2141426137
   },
   {
     "3alpha": "CHF",
-    "station_name": "Church Fenton Rail Station",
+    "station_name": "Church Fenton",
     "latitude": 53.826617281,
     "longitude": -1.227593241
   },
   {
     "3alpha": "CHG",
-    "station_name": "Charing (Kent) Rail Station",
+    "station_name": "Charing (Kent)",
     "latitude": 51.2080968918,
     "longitude": 0.790361474
   },
   {
     "3alpha": "CHH",
-    "station_name": "Christs Hospital Rail Station",
+    "station_name": "Christs Hospital",
     "latitude": 51.0506799602,
     "longitude": -0.3635305612
   },
   {
     "3alpha": "CHI",
-    "station_name": "Chingford Rail Station",
+    "station_name": "Chingford",
     "latitude": 51.6330861875,
     "longitude": 0.0099231874
   },
   {
     "3alpha": "CHK",
-    "station_name": "Chiswick Rail Station",
+    "station_name": "Chiswick",
     "latitude": 51.4811352623,
     "longitude": -0.2678126102
   },
   {
     "3alpha": "CHL",
-    "station_name": "Chilworth Rail Station",
+    "station_name": "Chilworth",
     "latitude": 51.2152082426,
     "longitude": -0.5248019553
   },
   {
     "3alpha": "CHM",
-    "station_name": "Chelmsford Rail Station",
+    "station_name": "Chelmsford",
     "latitude": 51.736377313,
     "longitude": 0.4685976033
   },
   {
     "3alpha": "CHN",
-    "station_name": "Cheshunt Rail Station",
+    "station_name": "Cheshunt",
     "latitude": 51.7028782333,
     "longitude": -0.0239334005
   },
   {
     "3alpha": "CHO",
-    "station_name": "Cholsey Rail Station",
+    "station_name": "Cholsey",
     "latitude": 51.5702030857,
     "longitude": -1.1580033162
   },
   {
     "3alpha": "CHP",
-    "station_name": "Chipstead Rail Station",
+    "station_name": "Chipstead",
     "latitude": 51.3092732695,
     "longitude": -0.1694772828
   },
   {
     "3alpha": "CHR",
-    "station_name": "Christchurch Rail Station",
+    "station_name": "Christchurch",
     "latitude": 50.7382022761,
     "longitude": -1.7845391826
   },
   {
     "3alpha": "CHT",
-    "station_name": "Chathill Rail Station",
+    "station_name": "Chathill",
     "latitude": 55.5367311282,
     "longitude": -1.7063916064
   },
   {
     "3alpha": "CHU",
-    "station_name": "Cheadle Hulme Rail Station",
+    "station_name": "Cheadle Hulme",
     "latitude": 53.3759438577,
     "longitude": -2.1883016906
   },
   {
     "3alpha": "CHW",
-    "station_name": "Chalkwell Rail Station",
+    "station_name": "Chalkwell",
     "latitude": 51.5387210852,
     "longitude": 0.6706212378
   },
   {
     "3alpha": "CHX",
-    "station_name": "London Charing Cross Rail Station",
+    "station_name": "London Charing Cross",
     "latitude": 51.5080271291,
     "longitude": -0.124776951
   },
   {
     "3alpha": "CHY",
-    "station_name": "Chertsey Rail Station",
+    "station_name": "Chertsey",
     "latitude": 51.3870662195,
     "longitude": -0.5092980361
   },
   {
     "3alpha": "CIL",
-    "station_name": "Chilham Rail Station",
+    "station_name": "Chilham",
     "latitude": 51.244611699,
     "longitude": 0.9759253356
   },
   {
     "3alpha": "CIM",
-    "station_name": "Cilmeri Rail Station",
+    "station_name": "Cilmeri",
     "latitude": 52.1505372986,
     "longitude": -3.456549557
   },
   {
     "3alpha": "CIR",
-    "station_name": "Caledonian Road & Barnsbury Rail Station",
+    "station_name": "Caledonian Road & Barnsbury",
     "latitude": 51.5430414168,
     "longitude": -0.1167032568
   },
   {
     "3alpha": "CIT",
-    "station_name": "Chislehurst Rail Station",
+    "station_name": "Chislehurst",
     "latitude": 51.4055548954,
     "longitude": 0.0574432034
   },
   {
     "3alpha": "CKH",
-    "station_name": "Corkerhill Rail Station",
+    "station_name": "Corkerhill",
     "latitude": 55.8374943521,
     "longitude": -4.3342780321
   },
   {
     "3alpha": "CKL",
-    "station_name": "Corkickle Rail Station",
+    "station_name": "Corkickle",
     "latitude": 54.5416855173,
     "longitude": -3.5821649914
   },
   {
     "3alpha": "CKN",
-    "station_name": "Crewkerne Rail Station",
+    "station_name": "Crewkerne",
     "latitude": 50.8735260536,
     "longitude": -2.7784973275
   },
   {
     "3alpha": "CKS",
-    "station_name": "Clarkston Rail Station",
+    "station_name": "Clarkston",
     "latitude": 55.7893425756,
     "longitude": -4.2756304312
   },
   {
     "3alpha": "CKT",
-    "station_name": "Crookston Rail Station",
+    "station_name": "Crookston",
     "latitude": 55.842306531,
     "longitude": -4.3646599927
   },
   {
     "3alpha": "CKY",
-    "station_name": "Crosskeys Rail Station",
+    "station_name": "Crosskeys",
     "latitude": 51.6209031401,
     "longitude": -3.1261795275
   },
   {
     "3alpha": "CLA",
-    "station_name": "Clandon Rail Station",
+    "station_name": "Clandon",
     "latitude": 51.2640008411,
     "longitude": -0.5027439883
   },
   {
     "3alpha": "CLC",
-    "station_name": "Castle Cary Rail Station",
+    "station_name": "Castle Cary",
     "latitude": 51.0998071422,
     "longitude": -2.5227962269
   },
   {
     "3alpha": "CLD",
-    "station_name": "Chelsfield Rail Station",
+    "station_name": "Chelsfield",
     "latitude": 51.3562553945,
     "longitude": 0.109096599
   },
   {
     "3alpha": "CLE",
-    "station_name": "Cleethorpes Rail Station",
+    "station_name": "Cleethorpes",
     "latitude": 53.5619299115,
     "longitude": -0.0292269788
   },
   {
     "3alpha": "CLG",
-    "station_name": "Claygate Rail Station",
+    "station_name": "Claygate",
     "latitude": 51.3612107148,
     "longitude": -0.3482245539
   },
   {
     "3alpha": "CLH",
-    "station_name": "Clitheroe Rail Station",
+    "station_name": "Clitheroe",
     "latitude": 53.8734784154,
     "longitude": -2.3943371754
   },
   {
     "3alpha": "CLI",
-    "station_name": "Clifton (Manchester) Rail Station",
+    "station_name": "Clifton (Manchester)",
     "latitude": 53.5225049162,
     "longitude": -2.3147448248
   },
   {
     "3alpha": "CLJ",
-    "station_name": "Clapham Junction Rail Station",
+    "station_name": "Clapham Junction",
     "latitude": 51.4641869937,
     "longitude": -0.1702686508
   },
   {
     "3alpha": "CLK",
-    "station_name": "Clock House Rail Station",
+    "station_name": "Clock House",
     "latitude": 51.4085837591,
     "longitude": -0.0406309221
   },
   {
     "3alpha": "CLL",
-    "station_name": "Collington Rail Station",
+    "station_name": "Collington",
     "latitude": 50.8392826491,
     "longitude": 0.4578912206
   },
   {
     "3alpha": "CLM",
-    "station_name": "Collingham Rail Station",
+    "station_name": "Collingham",
     "latitude": 53.1441054305,
     "longitude": -0.7503911592
   },
   {
     "3alpha": "CLN",
-    "station_name": "Chapeltown Rail Station",
+    "station_name": "Chapeltown",
     "latitude": 53.46235275,
     "longitude": -1.4662753767
   },
   {
     "3alpha": "CLP",
-    "station_name": "Clapham High Street Rail Station",
+    "station_name": "Clapham High Street",
     "latitude": 51.4654799498,
     "longitude": -0.1324962988
   },
   {
     "3alpha": "CLR",
-    "station_name": "Clarbeston Road Rail Station",
+    "station_name": "Clarbeston Road",
     "latitude": 51.8516764519,
     "longitude": -4.883577935
   },
   {
     "3alpha": "CLS",
-    "station_name": "Chester-le-Street Rail Station",
+    "station_name": "Chester-le-Street",
     "latitude": 54.8546014236,
     "longitude": -1.5780279033
   },
   {
     "3alpha": "CLT",
-    "station_name": "Clacton-on-Sea Rail Station",
+    "station_name": "Clacton-on-Sea",
     "latitude": 51.7940121532,
     "longitude": 1.1541237294
   },
   {
     "3alpha": "CLU",
-    "station_name": "Carluke Rail Station",
+    "station_name": "Carluke",
     "latitude": 55.7312612023,
     "longitude": -3.8489142324
   },
   {
     "3alpha": "CLV",
-    "station_name": "Claverdon Rail Station",
+    "station_name": "Claverdon",
     "latitude": 52.2771032987,
     "longitude": -1.696549552
   },
   {
     "3alpha": "CLW",
-    "station_name": "Chorleywood Rail Station",
+    "station_name": "Chorleywood",
     "latitude": 51.6542505776,
     "longitude": -0.5182984244
   },
   {
     "3alpha": "CLY",
-    "station_name": "Chinley Rail Station",
+    "station_name": "Chinley",
     "latitude": 53.3403042037,
     "longitude": -1.9439397765
   },
   {
     "3alpha": "CMB",
-    "station_name": "Cambridge North Rail Station",
+    "station_name": "Cambridge North",
     "latitude": 52.2244936969,
     "longitude": 0.158507305
   },
   {
     "3alpha": "CMD",
-    "station_name": "Camden Road Rail Station",
+    "station_name": "Camden Road",
     "latitude": 51.5417913143,
     "longitude": -0.1386752331
   },
   {
     "3alpha": "CME",
-    "station_name": "Combe (Oxon) Rail Station",
+    "station_name": "Combe (Oxon)",
     "latitude": 51.8325979785,
     "longitude": -1.3940563489
   },
   {
     "3alpha": "CMF",
-    "station_name": "Cromford Rail Station",
+    "station_name": "Cromford",
     "latitude": 53.1129487944,
     "longitude": -1.5491593967
   },
   {
     "3alpha": "CMH",
-    "station_name": "Cwmbach Rail Station",
+    "station_name": "Cwmbach",
     "latitude": 51.7019306049,
     "longitude": -3.4137347518
   },
   {
     "3alpha": "CML",
-    "station_name": "Carmyle Rail Station",
+    "station_name": "Carmyle",
     "latitude": 55.8343311624,
     "longitude": -4.1581669693
   },
   {
     "3alpha": "CMN",
-    "station_name": "Carmarthen Rail Station",
+    "station_name": "Carmarthen",
     "latitude": 51.8533597764,
     "longitude": -4.3059837569
   },
   {
     "3alpha": "CMO",
-    "station_name": "Camelon Rail Station",
+    "station_name": "Camelon",
     "latitude": 56.0060850872,
     "longitude": -3.8175985504
   },
   {
     "3alpha": "CMR",
-    "station_name": "Cromer Rail Station",
+    "station_name": "Cromer",
     "latitude": 52.9301115682,
     "longitude": 1.2928430662
   },
   {
     "3alpha": "CMY",
-    "station_name": "Crossmyloof Rail Station",
+    "station_name": "Crossmyloof",
     "latitude": 55.8339394759,
     "longitude": -4.2843030651
   },
   {
     "3alpha": "CNE",
-    "station_name": "Colne Rail Station",
+    "station_name": "Colne",
     "latitude": 53.854755007,
     "longitude": -2.1818613773
   },
   {
     "3alpha": "CNF",
-    "station_name": "Carnforth Rail Station",
+    "station_name": "Carnforth",
     "latitude": 54.1296866595,
     "longitude": -2.7712312791
   },
   {
     "3alpha": "CNG",
-    "station_name": "Congleton Rail Station",
+    "station_name": "Congleton",
     "latitude": 53.1578702503,
     "longitude": -2.1925793889
   },
   {
     "3alpha": "CNL",
-    "station_name": "Canley Rail Station",
+    "station_name": "Canley",
     "latitude": 52.3992554076,
     "longitude": -1.5475652767
   },
   {
     "3alpha": "CNM",
-    "station_name": "Cheltenham Spa Rail Station",
+    "station_name": "Cheltenham Spa",
     "latitude": 51.8974028753,
     "longitude": -2.0996135055
   },
   {
     "3alpha": "CNN",
-    "station_name": "Canonbury Rail Station",
+    "station_name": "Canonbury",
     "latitude": 51.5487325338,
     "longitude": -0.09216443
   },
   {
     "3alpha": "CNO",
-    "station_name": "Chetnole Rail Station",
+    "station_name": "Chetnole",
     "latitude": 50.8663529505,
     "longitude": -2.5729267275
   },
   {
     "3alpha": "CNP",
-    "station_name": "Conway Park Rail Station",
+    "station_name": "Conway Park",
     "latitude": 53.3933739019,
     "longitude": -3.0226705989
   },
   {
     "3alpha": "CNR",
-    "station_name": "Crianlarich Rail Station",
+    "station_name": "Crianlarich",
     "latitude": 56.3904637247,
     "longitude": -4.6184189492
   },
   {
     "3alpha": "CNS",
-    "station_name": "Conisbrough Rail Station",
+    "station_name": "Conisbrough",
     "latitude": 53.4893269216,
     "longitude": -1.2343330775
   },
   {
     "3alpha": "CNW",
-    "station_name": "Conwy Rail Station",
+    "station_name": "Conwy",
     "latitude": 53.2801164248,
     "longitude": -3.8305284521
   },
   {
     "3alpha": "CNY",
-    "station_name": "Cantley Rail Station",
+    "station_name": "Cantley",
     "latitude": 52.5787715007,
     "longitude": 1.5134359903
   },
   {
     "3alpha": "COA",
-    "station_name": "Coatdyke Rail Station",
+    "station_name": "Coatdyke",
     "latitude": 55.8643346399,
     "longitude": -4.0049736959
   },
   {
     "3alpha": "COB",
-    "station_name": "Cooden Beach Rail Station",
+    "station_name": "Cooden Beach",
     "latitude": 50.8333660029,
     "longitude": 0.4268882942
   },
@@ -3325,3799 +3343,3823 @@
   },
   {
     "3alpha": "COH",
-    "station_name": "Crowborough Rail Station",
+    "station_name": "Crowborough",
     "latitude": 51.0463770048,
     "longitude": 0.1880407337
   },
   {
     "3alpha": "COI",
-    "station_name": "Crosshill Rail Station",
+    "station_name": "Crosshill",
     "latitude": 55.8332791971,
     "longitude": -4.2567970862
   },
   {
     "3alpha": "COL",
-    "station_name": "Colchester Rail Station",
+    "station_name": "Colchester",
     "latitude": 51.9007230246,
     "longitude": 0.8926284517
   },
   {
     "3alpha": "COM",
-    "station_name": "Commondale Rail Station",
+    "station_name": "Commondale",
     "latitude": 54.4812856119,
     "longitude": -0.9751641461
   },
   {
     "3alpha": "CON",
-    "station_name": "Connel Ferry Rail Station",
+    "station_name": "Connel Ferry",
     "latitude": 56.45233723,
     "longitude": -5.3854201352
   },
   {
     "3alpha": "COO",
-    "station_name": "Cookham Rail Station",
+    "station_name": "Cookham",
     "latitude": 51.5574642725,
     "longitude": -0.7220603119
   },
   {
     "3alpha": "COP",
-    "station_name": "Copplestone Rail Station",
+    "station_name": "Copplestone",
     "latitude": 50.8144563375,
     "longitude": -3.751590555
   },
   {
     "3alpha": "COR",
-    "station_name": "Corby Rail Station",
+    "station_name": "Corby",
     "latitude": 52.4888659511,
     "longitude": -0.6883213327
   },
   {
     "3alpha": "COS",
-    "station_name": "Cosford Rail Station",
+    "station_name": "Cosford",
     "latitude": 52.6448470661,
     "longitude": -2.3002712165
   },
   {
     "3alpha": "COT",
-    "station_name": "Cottingley Rail Station",
+    "station_name": "Cottingley",
     "latitude": 53.7678308023,
     "longitude": -1.5877119373
   },
   {
     "3alpha": "COV",
-    "station_name": "Coventry Rail Station",
+    "station_name": "Coventry",
     "latitude": 52.4008284145,
     "longitude": -1.5134504816
   },
   {
     "3alpha": "COW",
-    "station_name": "Cowdenbeath Rail Station",
+    "station_name": "Cowdenbeath",
     "latitude": 56.112083991,
     "longitude": -3.3431844925
   },
   {
     "3alpha": "COY",
-    "station_name": "Coryton Rail Station",
+    "station_name": "Coryton",
     "latitude": 51.5204358321,
     "longitude": -3.2318279619
   },
   {
     "3alpha": "CPA",
-    "station_name": "Corpach Rail Station",
+    "station_name": "Corpach",
     "latitude": 56.8428086004,
     "longitude": -5.121943037
   },
   {
     "3alpha": "CPH",
-    "station_name": "Caerphilly Rail Station",
+    "station_name": "Caerphilly",
     "latitude": 51.5715771276,
     "longitude": -3.2184921838
   },
   {
     "3alpha": "CPK",
-    "station_name": "Carpenders Park Rail Station",
+    "station_name": "Carpenders Park",
     "latitude": 51.6283534546,
     "longitude": -0.3859168008
   },
   {
     "3alpha": "CPM",
-    "station_name": "Chippenham Rail Station",
+    "station_name": "Chippenham",
     "latitude": 51.4624852566,
     "longitude": -2.1153890334
   },
   {
     "3alpha": "CPN",
-    "station_name": "Chapelton (Devon) Rail Station",
+    "station_name": "Chapelton (Devon)",
     "latitude": 51.0165289386,
     "longitude": -4.0247448242
   },
   {
     "3alpha": "CPT",
-    "station_name": "Clapton Rail Station",
+    "station_name": "Clapton",
     "latitude": 51.5616436677,
     "longitude": -0.0569984893
   },
   {
     "3alpha": "CPU",
-    "station_name": "Capenhurst Rail Station",
+    "station_name": "Capenhurst",
     "latitude": 53.2601877687,
     "longitude": -2.9422844784
   },
   {
     "3alpha": "CPW",
-    "station_name": "Chepstow Rail Station",
+    "station_name": "Chepstow",
     "latitude": 51.6401793133,
     "longitude": -2.6719110922
   },
   {
     "3alpha": "CPY",
-    "station_name": "Clapham (N Yorks) Rail Station",
+    "station_name": "Clapham (N Yorks)",
     "latitude": 54.1053962118,
     "longitude": -2.4103793434
   },
   {
     "3alpha": "CRA",
-    "station_name": "Cradley Heath Rail Station",
+    "station_name": "Cradley Heath",
     "latitude": 52.4696668258,
     "longitude": -2.0904823836
   },
   {
     "3alpha": "CRB",
-    "station_name": "Corbridge Rail Station",
+    "station_name": "Corbridge",
     "latitude": 54.9662659971,
     "longitude": -2.0184091796
   },
   {
     "3alpha": "CRD",
-    "station_name": "Chester Road Rail Station",
+    "station_name": "Chester Road",
     "latitude": 52.5356593313,
     "longitude": -1.832472162
   },
   {
     "3alpha": "CRE",
-    "station_name": "Crewe Rail Station",
+    "station_name": "Crewe",
     "latitude": 53.089639576,
     "longitude": -2.4329694874
   },
   {
     "3alpha": "CRF",
-    "station_name": "Carfin Rail Station",
+    "station_name": "Carfin",
     "latitude": 55.8073342674,
     "longitude": -3.9562432142
   },
   {
     "3alpha": "CRG",
-    "station_name": "Cross Gates Rail Station",
+    "station_name": "Cross Gates",
     "latitude": 53.8049283962,
     "longitude": -1.4515849362
   },
   {
     "3alpha": "CRH",
-    "station_name": "Crouch Hill Rail Station",
+    "station_name": "Crouch Hill",
     "latitude": 51.5713028362,
     "longitude": -0.11712295
   },
   {
     "3alpha": "CRI",
-    "station_name": "Cricklewood Rail Station",
+    "station_name": "Cricklewood",
     "latitude": 51.5584538453,
     "longitude": -0.212652067
   },
   {
     "3alpha": "CRK",
-    "station_name": "Chirk Rail Station",
+    "station_name": "Chirk",
     "latitude": 52.9330999763,
     "longitude": -3.0656421264
   },
   {
     "3alpha": "CRL",
-    "station_name": "Chorley Rail Station",
+    "station_name": "Chorley",
     "latitude": 53.6525509696,
     "longitude": -2.6268378803
   },
   {
     "3alpha": "CRM",
-    "station_name": "Cramlington Rail Station",
+    "station_name": "Cramlington",
     "latitude": 55.0877729503,
     "longitude": -1.5986098387
   },
   {
     "3alpha": "CRN",
-    "station_name": "Crowthorne Rail Station",
+    "station_name": "Crowthorne",
     "latitude": 51.3667259688,
     "longitude": -0.8192566155
   },
   {
     "3alpha": "CRO",
-    "station_name": "Croy Rail Station",
+    "station_name": "Croy",
     "latitude": 55.9556707554,
     "longitude": -4.0359670002
   },
   {
     "3alpha": "CRR",
-    "station_name": "Corrour Rail Station",
+    "station_name": "Corrour",
     "latitude": 56.7601959475,
     "longitude": -4.6905898827
   },
   {
     "3alpha": "CRS",
-    "station_name": "Carstairs Rail Station",
+    "station_name": "Carstairs",
     "latitude": 55.6910435615,
     "longitude": -3.6684653164
   },
   {
     "3alpha": "CRT",
-    "station_name": "Chartham Rail Station",
+    "station_name": "Chartham",
     "latitude": 51.2572676132,
     "longitude": 1.0180692196
   },
   {
     "3alpha": "CRV",
-    "station_name": "Craven Arms Rail Station",
+    "station_name": "Craven Arms",
     "latitude": 52.4425511842,
     "longitude": -2.8374211059
   },
   {
     "3alpha": "CRW",
-    "station_name": "Crawley Rail Station",
+    "station_name": "Crawley",
     "latitude": 51.1122079127,
     "longitude": -0.1866457301
   },
   {
     "3alpha": "CRY",
-    "station_name": "Crayford Rail Station",
+    "station_name": "Crayford",
     "latitude": 51.4482784318,
     "longitude": 0.1789624549
   },
   {
     "3alpha": "CSA",
-    "station_name": "Cosham Rail Station",
+    "station_name": "Cosham",
     "latitude": 50.8419131216,
     "longitude": -1.0673147963
   },
   {
     "3alpha": "CSB",
-    "station_name": "Carshalton Beeches Rail Station",
+    "station_name": "Carshalton Beeches",
     "latitude": 51.3574078701,
     "longitude": -0.1697719787
   },
   {
     "3alpha": "CSD",
-    "station_name": "Cobham & Stoke d'Abernon Rail Station",
+    "station_name": "Cobham & Stoke d'Abernon",
     "latitude": 51.3180974283,
     "longitude": -0.389323466
   },
   {
     "3alpha": "CSG",
-    "station_name": "Cressington Rail Station",
+    "station_name": "Cressington",
     "latitude": 53.3587637655,
     "longitude": -2.9120028641
   },
   {
     "3alpha": "CSH",
-    "station_name": "Carshalton Rail Station",
+    "station_name": "Carshalton",
     "latitude": 51.368451556,
     "longitude": -0.166343454
   },
   {
     "3alpha": "CSK",
-    "station_name": "Calstock Rail Station",
+    "station_name": "Calstock",
     "latitude": 50.497783854,
     "longitude": -4.2090174117
   },
   {
     "3alpha": "CSL",
-    "station_name": "Codsall Rail Station",
+    "station_name": "Codsall",
     "latitude": 52.6273016994,
     "longitude": -2.2017584348
   },
   {
     "3alpha": "CSM",
-    "station_name": "Castleton Moor Rail Station",
+    "station_name": "Castleton Moor",
     "latitude": 54.4671552873,
     "longitude": -0.9466648318
   },
   {
     "3alpha": "CSN",
-    "station_name": "Chessington North Rail Station",
+    "station_name": "Chessington North",
     "latitude": 51.3640376909,
     "longitude": -0.3006757682
   },
   {
     "3alpha": "CSO",
-    "station_name": "Croston Rail Station",
+    "station_name": "Croston",
     "latitude": 53.6675742668,
     "longitude": -2.7777477556
   },
   {
     "3alpha": "CSR",
-    "station_name": "Chassen Road Rail Station",
+    "station_name": "Chassen Road",
     "latitude": 53.4461736991,
     "longitude": -2.3682321593
   },
   {
     "3alpha": "CSS",
-    "station_name": "Chessington South Rail Station",
+    "station_name": "Chessington South",
     "latitude": 51.3565467942,
     "longitude": -0.3081340168
   },
   {
     "3alpha": "CST",
-    "station_name": "London Cannon Street Rail Station",
+    "station_name": "London Cannon Street",
     "latitude": 51.5113821708,
     "longitude": -0.0902671514
   },
   {
     "3alpha": "CSW",
-    "station_name": "Chestfield & Swalecliffe Rail Station",
+    "station_name": "Chestfield & Swalecliffe",
     "latitude": 51.3602434955,
     "longitude": 1.0669610537
   },
   {
     "3alpha": "CSY",
-    "station_name": "Coseley Rail Station",
+    "station_name": "Coseley",
     "latitude": 52.545096174,
     "longitude": -2.0857720388
   },
   {
     "3alpha": "CTE",
-    "station_name": "Chatelherault Rail Station",
+    "station_name": "Chatelherault",
     "latitude": 55.7652139884,
     "longitude": -4.004665396
   },
   {
     "3alpha": "CTF",
-    "station_name": "Catford Rail Station",
+    "station_name": "Catford",
     "latitude": 51.4444046468,
     "longitude": -0.0262908765
   },
   {
     "3alpha": "CTH",
-    "station_name": "Chadwell Heath Rail Station",
+    "station_name": "Chadwell Heath",
     "latitude": 51.5680380571,
     "longitude": 0.1289849608
   },
   {
     "3alpha": "CTK",
-    "station_name": "City Thameslink Rail Station",
+    "station_name": "City Thameslink",
     "latitude": 51.5139360643,
     "longitude": -0.1035639706
   },
   {
     "3alpha": "CTL",
-    "station_name": "Cattal Rail Station",
+    "station_name": "Cattal",
     "latitude": 53.997454781,
     "longitude": -1.3205413788
   },
   {
     "3alpha": "CTM",
-    "station_name": "Chatham Rail Station",
+    "station_name": "Chatham",
     "latitude": 51.3803760302,
     "longitude": 0.5211794412
   },
   {
     "3alpha": "CTN",
-    "station_name": "Charlton Rail Station",
+    "station_name": "Charlton",
     "latitude": 51.4868121438,
     "longitude": 0.0312832554
   },
   {
     "3alpha": "CTO",
-    "station_name": "Carlton Rail Station",
+    "station_name": "Carlton",
     "latitude": 52.9651058655,
     "longitude": -1.0786513766
   },
   {
     "3alpha": "CTR",
-    "station_name": "Chester Rail Station",
+    "station_name": "Chester",
     "latitude": 53.1967089901,
     "longitude": -2.8795954639
   },
   {
     "3alpha": "CTT",
-    "station_name": "Church Stretton Rail Station",
+    "station_name": "Church Stretton",
     "latitude": 52.5374347501,
     "longitude": -2.8036939757
   },
   {
     "3alpha": "CTW",
-    "station_name": "Church & Oswaldtwistle Rail Station",
+    "station_name": "Church & Oswaldtwistle",
     "latitude": 53.7505339398,
     "longitude": -2.3912114012
   },
   {
     "3alpha": "CUA",
-    "station_name": "Culrain Rail Station",
+    "station_name": "Culrain",
     "latitude": 57.9194946106,
     "longitude": -4.4042721672
   },
   {
     "3alpha": "CUB",
-    "station_name": "Cumbernauld Rail Station",
+    "station_name": "Cumbernauld",
     "latitude": 55.942019023,
     "longitude": -3.9803257587
   },
   {
     "3alpha": "CUD",
-    "station_name": "Cuddington Rail Station",
+    "station_name": "Cuddington",
     "latitude": 53.2399328038,
     "longitude": -2.5993047996
   },
   {
     "3alpha": "CUF",
-    "station_name": "Cuffley Rail Station",
+    "station_name": "Cuffley",
     "latitude": 51.708723054,
     "longitude": -0.1097585788
   },
   {
     "3alpha": "CUH",
-    "station_name": "Curriehill Rail Station",
+    "station_name": "Curriehill",
     "latitude": 55.9005593257,
     "longitude": -3.3187497327
   },
   {
     "3alpha": "CUM",
-    "station_name": "Culham Rail Station",
+    "station_name": "Culham",
     "latitude": 51.653795137,
     "longitude": -1.2364953245
   },
   {
     "3alpha": "CUP",
-    "station_name": "Cupar Rail Station",
+    "station_name": "Cupar",
     "latitude": 56.3169774524,
     "longitude": -3.0087585168
   },
   {
     "3alpha": "CUW",
-    "station_name": "Clunderwen Rail Station",
+    "station_name": "Clunderwen",
     "latitude": 51.8405496199,
     "longitude": -4.731870145
   },
   {
     "3alpha": "CUX",
-    "station_name": "Cuxton Rail Station",
+    "station_name": "Cuxton",
     "latitude": 51.3739247395,
     "longitude": 0.4617373125
   },
   {
     "3alpha": "CWB",
-    "station_name": "Colwyn Bay Rail Station",
+    "station_name": "Colwyn Bay",
     "latitude": 53.2963736339,
     "longitude": -3.7254203797
   },
   {
     "3alpha": "CWC",
-    "station_name": "Chappel & Wakes Colne Rail Station",
+    "station_name": "Chappel & Wakes Colne",
     "latitude": 51.9259156453,
     "longitude": 0.7585305397
   },
   {
     "3alpha": "CWD",
-    "station_name": "Creswell (Derbys) Rail Station",
+    "station_name": "Creswell (Derbys)",
     "latitude": 53.2641317653,
     "longitude": -1.2163932459
   },
   {
     "3alpha": "CWE",
-    "station_name": "Crowle Rail Station",
+    "station_name": "Crowle",
     "latitude": 53.589752526,
     "longitude": -0.8173624763
   },
   {
     "3alpha": "CWH",
-    "station_name": "Crews Hill Rail Station",
+    "station_name": "Crews Hill",
     "latitude": 51.6844869604,
     "longitude": -0.1068615213
   },
   {
     "3alpha": "CWL",
-    "station_name": "Colwall Rail Station",
+    "station_name": "Colwall",
     "latitude": 52.0798767311,
     "longitude": -2.3569466545
   },
   {
     "3alpha": "CWM",
-    "station_name": "Cwmbran Rail Station",
+    "station_name": "Cwmbran",
     "latitude": 51.6565871606,
     "longitude": -3.01621063
   },
   {
     "3alpha": "CWN",
-    "station_name": "Cowden Rail Station",
+    "station_name": "Cowden",
     "latitude": 51.1556324991,
     "longitude": 0.1100591285
   },
   {
     "3alpha": "CWS",
-    "station_name": "Caersws Rail Station",
+    "station_name": "Caersws",
     "latitude": 52.5161370252,
     "longitude": -3.4325032748
   },
   {
     "3alpha": "CWU",
-    "station_name": "Crowhurst Rail Station",
+    "station_name": "Crowhurst",
     "latitude": 50.8885735262,
     "longitude": 0.5013656464
   },
   {
+    "3alpha": "CWX",
+    "station_name": "Canary Wharf",
+    "latitude": 51.5061,
+    "longitude": -0.01578
+  },
+  {
     "3alpha": "CYB",
-    "station_name": "Cefn-y-Bedd Rail Station",
+    "station_name": "Cefn-y-Bedd",
     "latitude": 53.0988144368,
     "longitude": -3.0310532391
   },
   {
     "3alpha": "CYK",
-    "station_name": "Clydebank Rail Station",
+    "station_name": "Clydebank",
     "latitude": 55.9006838001,
     "longitude": -4.4043987103
   },
   {
     "3alpha": "CYN",
-    "station_name": "Cynghordy Rail Station",
+    "station_name": "Cynghordy",
     "latitude": 52.0515055365,
     "longitude": -3.7482227844
   },
   {
     "3alpha": "CYP",
-    "station_name": "Crystal Palace Rail Station",
+    "station_name": "Crystal Palace",
     "latitude": 51.4181067019,
     "longitude": -0.0725839873
   },
   {
     "3alpha": "CYS",
-    "station_name": "Cathays Rail Station",
+    "station_name": "Cathays",
     "latitude": 51.4888980023,
     "longitude": -3.178691896
   },
   {
     "3alpha": "CYT",
-    "station_name": "Cherry Tree Rail Station",
+    "station_name": "Cherry Tree",
     "latitude": 53.7328842568,
     "longitude": -2.5183765976
   },
   {
     "3alpha": "DAG",
-    "station_name": "Dalgety Bay Rail Station",
+    "station_name": "Dalgety Bay",
     "latitude": 56.0420879876,
     "longitude": -3.367719234
   },
   {
     "3alpha": "DAK",
-    "station_name": "Dalmarnock Rail Station",
+    "station_name": "Dalmarnock",
     "latitude": 55.8420793253,
     "longitude": -4.2176948019
   },
   {
     "3alpha": "DAL",
-    "station_name": "Dalmally Rail Station",
+    "station_name": "Dalmally",
     "latitude": 56.40117566,
     "longitude": -4.9835317937
   },
   {
     "3alpha": "DAM",
-    "station_name": "Dalmeny Rail Station",
+    "station_name": "Dalmeny",
     "latitude": 55.9863117819,
     "longitude": -3.381617481
   },
   {
     "3alpha": "DAN",
-    "station_name": "Darnall Rail Station",
+    "station_name": "Darnall",
     "latitude": 53.3846003446,
     "longitude": -1.4125666166
   },
   {
     "3alpha": "DAR",
-    "station_name": "Darlington Rail Station",
+    "station_name": "Darlington",
     "latitude": 54.5204574957,
     "longitude": -1.5473329223
   },
   {
     "3alpha": "DAT",
-    "station_name": "Datchet Rail Station",
+    "station_name": "Datchet",
     "latitude": 51.4830766846,
     "longitude": -0.5794049222
   },
   {
     "3alpha": "DBC",
-    "station_name": "Dumbarton Central Rail Station",
+    "station_name": "Dumbarton Central",
     "latitude": 55.9466469118,
     "longitude": -4.5669032007
   },
   {
     "3alpha": "DBD",
-    "station_name": "Denby Dale Rail Station",
+    "station_name": "Denby Dale",
     "latitude": 53.5726454936,
     "longitude": -1.6632128419
   },
   {
     "3alpha": "DBE",
-    "station_name": "Dumbarton East Rail Station",
+    "station_name": "Dumbarton East",
     "latitude": 55.9422389396,
     "longitude": -4.5541195047
   },
   {
     "3alpha": "DBG",
-    "station_name": "Mottisfont & Dunbridge Rail Station",
+    "station_name": "Mottisfont & Dunbridge",
     "latitude": 51.0339180849,
     "longitude": -1.5470733978
   },
   {
     "3alpha": "DBL",
-    "station_name": "Dunblane Rail Station",
+    "station_name": "Dunblane",
     "latitude": 56.1858813154,
     "longitude": -3.9654784274
   },
   {
     "3alpha": "DBR",
-    "station_name": "Derby Road (Ipswich) Rail Station",
+    "station_name": "Derby Road (Ipswich)",
     "latitude": 52.0505675726,
     "longitude": 1.182673697
   },
   {
     "3alpha": "DBY",
-    "station_name": "Derby Rail Station",
+    "station_name": "Derby",
     "latitude": 52.9165645679,
     "longitude": -1.4633507475
   },
   {
     "3alpha": "DCG",
-    "station_name": "Duncraig Rail Station",
+    "station_name": "Duncraig",
     "latitude": 57.3369773237,
     "longitude": -5.6371200748
   },
   {
     "3alpha": "DCH",
-    "station_name": "Dorchester South Rail Station",
+    "station_name": "Dorchester South",
     "latitude": 50.7092808049,
     "longitude": -2.43724064
   },
   {
     "3alpha": "DCT",
-    "station_name": "Danescourt Rail Station",
+    "station_name": "Danescourt",
     "latitude": 51.5005053214,
     "longitude": -3.2339264723
   },
   {
     "3alpha": "DCW",
-    "station_name": "Dorchester West Rail Station",
+    "station_name": "Dorchester West",
     "latitude": 50.7109424746,
     "longitude": -2.4425389873
   },
   {
     "3alpha": "DDG",
-    "station_name": "Dorridge Rail Station",
+    "station_name": "Dorridge",
     "latitude": 52.3720819757,
     "longitude": -1.7528919248
   },
   {
     "3alpha": "DDK",
-    "station_name": "Dagenham Dock Rail Station",
+    "station_name": "Dagenham Dock",
     "latitude": 51.5260887461,
     "longitude": 0.1461308631
   },
   {
     "3alpha": "DDP",
-    "station_name": "Dudley Port Rail Station",
+    "station_name": "Dudley Port",
     "latitude": 52.5246649483,
     "longitude": -2.0494739583
   },
   {
     "3alpha": "DEA",
-    "station_name": "Deal Rail Station",
+    "station_name": "Deal",
     "latitude": 51.2230510827,
     "longitude": 1.3988758198
   },
   {
     "3alpha": "DEE",
-    "station_name": "Dundee Rail Station",
+    "station_name": "Dundee",
     "latitude": 56.4564750929,
     "longitude": -2.9712080372
   },
   {
     "3alpha": "DEN",
-    "station_name": "Dean Rail Station",
+    "station_name": "Dean",
     "latitude": 51.0424533409,
     "longitude": -1.6348555051
   },
   {
     "3alpha": "DEP",
-    "station_name": "Deptford Rail Station",
+    "station_name": "Deptford",
     "latitude": 51.4788466717,
     "longitude": -0.0262441885
   },
   {
     "3alpha": "DEW",
-    "station_name": "Dewsbury Rail Station",
+    "station_name": "Dewsbury",
     "latitude": 53.6921445094,
     "longitude": -1.6331100451
   },
   {
     "3alpha": "DFD",
-    "station_name": "Dartford Rail Station",
+    "station_name": "Dartford",
     "latitude": 51.4473695898,
     "longitude": 0.2192754223
   },
   {
     "3alpha": "DFE",
-    "station_name": "Dunfermline Town Rail Station",
+    "station_name": "Dunfermline Town",
     "latitude": 56.0681835684,
     "longitude": -3.4525246789
   },
   {
     "3alpha": "DFI",
-    "station_name": "Duffield Rail Station",
+    "station_name": "Duffield",
     "latitude": 52.9884176714,
     "longitude": -1.4859685231
   },
   {
     "3alpha": "DFL",
-    "station_name": "Dunfermline Queen Margaret Rail Station",
+    "station_name": "Dunfermline Queen Margaret",
     "latitude": 56.0805680436,
     "longitude": -3.4214651879
   },
   {
     "3alpha": "DFR",
-    "station_name": "Drumfrochar Rail Station",
+    "station_name": "Drumfrochar",
     "latitude": 55.9412399388,
     "longitude": -4.7747462431
   },
   {
     "3alpha": "DGC",
-    "station_name": "Denham Golf Club Rail Station",
+    "station_name": "Denham Golf Club",
     "latitude": 51.5805981628,
     "longitude": -0.5177663959
   },
   {
     "3alpha": "DGL",
-    "station_name": "Dingle Road Rail Station",
+    "station_name": "Dingle Road",
     "latitude": 51.4400518803,
     "longitude": -3.1805995641
   },
   {
     "3alpha": "DGT",
-    "station_name": "Deansgate Rail Station",
+    "station_name": "Deansgate",
     "latitude": 53.4741986483,
     "longitude": -2.251049342
   },
   {
     "3alpha": "DGY",
-    "station_name": "Deganwy Rail Station",
+    "station_name": "Deganwy",
     "latitude": 53.2947621319,
     "longitude": -3.8333901264
   },
   {
     "3alpha": "DHM",
-    "station_name": "Durham Rail Station",
+    "station_name": "Durham",
     "latitude": 54.7793980708,
     "longitude": -1.5817625077
   },
   {
     "3alpha": "DHN",
-    "station_name": "Deighton Rail Station",
+    "station_name": "Deighton",
     "latitude": 53.6684962139,
     "longitude": -1.7518983268
   },
   {
     "3alpha": "DID",
-    "station_name": "Didcot Parkway Rail Station",
+    "station_name": "Didcot Parkway",
     "latitude": 51.6109553482,
     "longitude": -1.2428749913
   },
   {
     "3alpha": "DIG",
-    "station_name": "Digby & Sowton Rail Station",
+    "station_name": "Digby & Sowton",
     "latitude": 50.7139764327,
     "longitude": -3.4735740965
   },
   {
     "3alpha": "DIN",
-    "station_name": "Dingwall Rail Station",
+    "station_name": "Dingwall",
     "latitude": 57.5942168221,
     "longitude": -4.4221973842
   },
   {
     "3alpha": "DIS",
-    "station_name": "Diss Rail Station",
+    "station_name": "Diss",
     "latitude": 52.3736757898,
     "longitude": 1.1237252182
   },
   {
     "3alpha": "DKD",
-    "station_name": "Dunkeld & Birnam Rail Station",
+    "station_name": "Dunkeld & Birnam",
     "latitude": 56.5570452529,
     "longitude": -3.5783964404
   },
   {
     "3alpha": "DKG",
-    "station_name": "Dorking Rail Station",
+    "station_name": "Dorking",
     "latitude": 51.2409257562,
     "longitude": -0.3242277761
   },
   {
     "3alpha": "DKT",
-    "station_name": "Dorking West Rail Station",
+    "station_name": "Dorking West",
     "latitude": 51.2362217787,
     "longitude": -0.3399557367
   },
   {
     "3alpha": "DLG",
-    "station_name": "Dolgarrog Rail Station",
+    "station_name": "Dolgarrog",
     "latitude": 53.1863628038,
     "longitude": -3.8226405143
   },
   {
     "3alpha": "DLH",
-    "station_name": "Doleham Rail Station",
+    "station_name": "Doleham",
     "latitude": 50.9185826306,
     "longitude": 0.6100042375
   },
   {
     "3alpha": "DLJ",
-    "station_name": "Dalston Junction Rail Station",
+    "station_name": "Dalston Junction",
     "latitude": 51.5461154595,
     "longitude": -0.0751109378
   },
   {
     "3alpha": "DLK",
-    "station_name": "Dalston Kingsland Rail Station",
+    "station_name": "Dalston Kingsland",
     "latitude": 51.5481480385,
     "longitude": -0.0756742388
   },
   {
     "3alpha": "DLM",
-    "station_name": "Delamere Rail Station",
+    "station_name": "Delamere",
     "latitude": 53.2287882936,
     "longitude": -2.6665587536
   },
   {
     "3alpha": "DLR",
-    "station_name": "Dalreoch Rail Station",
+    "station_name": "Dalreoch",
     "latitude": 55.9474070119,
     "longitude": -4.5778455124
   },
   {
     "3alpha": "DLS",
-    "station_name": "Dalston (Cumbria) Rail Station",
+    "station_name": "Dalston (Cumbria)",
     "latitude": 54.8461812399,
     "longitude": -2.9888562179
   },
   {
     "3alpha": "DLT",
-    "station_name": "Dalton Rail Station",
+    "station_name": "Dalton",
     "latitude": 54.1542436887,
     "longitude": -3.1790013184
   },
   {
     "3alpha": "DLW",
-    "station_name": "Dalwhinnie Rail Station",
+    "station_name": "Dalwhinnie",
     "latitude": 56.9351543012,
     "longitude": -4.2461914619
   },
   {
     "3alpha": "DLY",
-    "station_name": "Dalry Rail Station",
+    "station_name": "Dalry",
     "latitude": 55.7062150527,
     "longitude": -4.7110594286
   },
   {
     "3alpha": "DMC",
-    "station_name": "Drumchapel Rail Station",
+    "station_name": "Drumchapel",
     "latitude": 55.9048050133,
     "longitude": -4.3628637433
   },
   {
     "3alpha": "DMF",
-    "station_name": "Dumfries Rail Station",
+    "station_name": "Dumfries",
     "latitude": 55.072559544,
     "longitude": -3.604300351
   },
   {
     "3alpha": "DMG",
-    "station_name": "Dinas (Rhondda) Rail Station",
+    "station_name": "Dinas (Rhondda)",
     "latitude": 51.6178352115,
     "longitude": -3.437552058
   },
   {
     "3alpha": "DMH",
-    "station_name": "Dilton Marsh Rail Station",
+    "station_name": "Dilton Marsh",
     "latitude": 51.2489808553,
     "longitude": -2.2079111292
   },
   {
     "3alpha": "DMK",
-    "station_name": "Denmark Hill Rail Station",
+    "station_name": "Denmark Hill",
     "latitude": 51.4682016412,
     "longitude": -0.0893351949
   },
   {
     "3alpha": "DMP",
-    "station_name": "Dumpton Park Rail Station",
+    "station_name": "Dumpton Park",
     "latitude": 51.3457052089,
     "longitude": 1.4258444805
   },
   {
     "3alpha": "DMR",
-    "station_name": "Dalmuir Rail Station",
+    "station_name": "Dalmuir",
     "latitude": 55.911921651,
     "longitude": -4.4266657755
   },
   {
     "3alpha": "DMS",
-    "station_name": "Dormans Rail Station",
+    "station_name": "Dormans",
     "latitude": 51.1557866779,
     "longitude": -0.0042811467
   },
   {
     "3alpha": "DMY",
-    "station_name": "Drumry Rail Station",
+    "station_name": "Drumry",
     "latitude": 55.9045847687,
     "longitude": -4.3854571409
   },
   {
     "3alpha": "DND",
-    "station_name": "Dinsdale Rail Station",
+    "station_name": "Dinsdale",
     "latitude": 54.5147386026,
     "longitude": -1.4670752041
   },
   {
     "3alpha": "DNG",
-    "station_name": "Dunton Green Rail Station",
+    "station_name": "Dunton Green",
     "latitude": 51.2964873167,
     "longitude": 0.1709649125
   },
   {
     "3alpha": "DNL",
-    "station_name": "Dunlop Rail Station",
+    "station_name": "Dunlop",
     "latitude": 55.7118747945,
     "longitude": -4.5323721773
   },
   {
     "3alpha": "DNM",
-    "station_name": "Denham Rail Station",
+    "station_name": "Denham",
     "latitude": 51.5788378122,
     "longitude": -0.4974160111
   },
   {
     "3alpha": "DNO",
-    "station_name": "Dunrobin Castle Rail Station",
+    "station_name": "Dunrobin Castle",
     "latitude": 57.9855164027,
     "longitude": -3.9489241071
   },
   {
     "3alpha": "DNS",
-    "station_name": "Dinas Powys Rail Station",
+    "station_name": "Dinas Powys",
     "latitude": 51.4316627486,
     "longitude": -3.2183612689
   },
   {
     "3alpha": "DNT",
-    "station_name": "Dent Rail Station",
+    "station_name": "Dent",
     "latitude": 54.2824184109,
     "longitude": -2.3636026167
   },
   {
     "3alpha": "DNY",
-    "station_name": "Danby Rail Station",
+    "station_name": "Danby",
     "latitude": 54.4661651822,
     "longitude": -0.9109721492
   },
   {
     "3alpha": "DOC",
-    "station_name": "Dockyard (Plymouth) Rail Station",
+    "station_name": "Dockyard (Plymouth)",
     "latitude": 50.3821534706,
     "longitude": -4.1759268375
   },
   {
     "3alpha": "DOD",
-    "station_name": "Dodworth Rail Station",
+    "station_name": "Dodworth",
     "latitude": 53.5443407648,
     "longitude": -1.5316921206
   },
   {
     "3alpha": "DOL",
-    "station_name": "Dolau Rail Station",
+    "station_name": "Dolau",
     "latitude": 52.2953601526,
     "longitude": -3.2636234021
   },
   {
     "3alpha": "DON",
-    "station_name": "Doncaster Rail Station",
+    "station_name": "Doncaster",
     "latitude": 53.522167905,
     "longitude": -1.1398476982
   },
   {
     "3alpha": "DOR",
-    "station_name": "Dore & Totley Rail Station",
+    "station_name": "Dore & Totley",
     "latitude": 53.3276504838,
     "longitude": -1.5152967348
   },
   {
     "3alpha": "DOT",
-    "station_name": "Dunston Rail Station",
+    "station_name": "Dunston",
     "latitude": 54.9500607179,
     "longitude": -1.6420561513
   },
   {
     "3alpha": "DOW",
-    "station_name": "Downham Market Rail Station",
+    "station_name": "Downham Market",
     "latitude": 52.6041264601,
     "longitude": 0.3656997898
   },
   {
     "3alpha": "DPD",
-    "station_name": "Dorking Deepdene Rail Station",
+    "station_name": "Dorking Deepdene",
     "latitude": 51.2388000949,
     "longitude": -0.3246201844
   },
   {
     "3alpha": "DPT",
-    "station_name": "Devonport Rail Station",
+    "station_name": "Devonport",
     "latitude": 50.3785177656,
     "longitude": -4.1707389477
   },
   {
     "3alpha": "DRF",
-    "station_name": "Driffield Rail Station",
+    "station_name": "Driffield",
     "latitude": 54.001546492,
     "longitude": -0.4346760339
   },
   {
     "3alpha": "DRG",
-    "station_name": "Drayton Green Rail Station",
+    "station_name": "Drayton Green",
     "latitude": 51.5166156836,
     "longitude": -0.3301719985
   },
   {
     "3alpha": "DRI",
-    "station_name": "Drigg Rail Station",
+    "station_name": "Drigg",
     "latitude": 54.3769668358,
     "longitude": -3.443413857
   },
   {
     "3alpha": "DRM",
-    "station_name": "Drem Rail Station",
+    "station_name": "Drem",
     "latitude": 56.0051170654,
     "longitude": -2.7860534175
   },
   {
     "3alpha": "DRN",
-    "station_name": "Duirinish Rail Station",
+    "station_name": "Duirinish",
     "latitude": 57.319951049,
     "longitude": -5.6913048804
   },
   {
     "3alpha": "DRO",
-    "station_name": "Dronfield Rail Station",
+    "station_name": "Dronfield",
     "latitude": 53.3013854109,
     "longitude": -1.4687777286
   },
   {
     "3alpha": "DRT",
-    "station_name": "Darton Rail Station",
+    "station_name": "Darton",
     "latitude": 53.5883833705,
     "longitude": -1.5316604623
   },
   {
     "3alpha": "DRU",
-    "station_name": "Drumgelloch Rail Station",
+    "station_name": "Drumgelloch",
     "latitude": 55.8673480624,
     "longitude": -3.9488717169
   },
   {
     "3alpha": "DSL",
-    "station_name": "Disley Rail Station",
+    "station_name": "Disley",
     "latitude": 53.3581971647,
     "longitude": -2.0424809658
   },
   {
     "3alpha": "DSM",
-    "station_name": "Darsham Rail Station",
+    "station_name": "Darsham",
     "latitude": 52.2730184572,
     "longitude": 1.5235008921
   },
   {
     "3alpha": "DST",
-    "station_name": "Duke Street Rail Station",
+    "station_name": "Duke Street",
     "latitude": 55.8584302018,
     "longitude": -4.213033844
   },
   {
     "3alpha": "DSY",
-    "station_name": "Daisy Hill Rail Station",
+    "station_name": "Daisy Hill",
     "latitude": 53.5394676714,
     "longitude": -2.5158611336
   },
   {
     "3alpha": "DTG",
-    "station_name": "Dinting Rail Station",
+    "station_name": "Dinting",
     "latitude": 53.4493453873,
     "longitude": -1.9702958822
   },
   {
     "3alpha": "DTN",
-    "station_name": "Denton Rail Station",
+    "station_name": "Denton",
     "latitude": 53.456880489,
     "longitude": -2.1316584707
   },
   {
     "3alpha": "DTW",
-    "station_name": "Droitwich Spa Rail Station",
+    "station_name": "Droitwich Spa",
     "latitude": 52.2682155287,
     "longitude": -2.1583562459
   },
   {
     "3alpha": "DUD",
-    "station_name": "Duddeston Rail Station",
+    "station_name": "Duddeston",
     "latitude": 52.4883756068,
     "longitude": -1.8713859825
   },
   {
     "3alpha": "DUL",
-    "station_name": "Dullingham Rail Station",
+    "station_name": "Dullingham",
     "latitude": 52.2016639915,
     "longitude": 0.3666921781
   },
   {
     "3alpha": "DUM",
-    "station_name": "Dumbreck Rail Station",
+    "station_name": "Dumbreck",
     "latitude": 55.8446425043,
     "longitude": -4.3012244995
   },
   {
     "3alpha": "DUN",
-    "station_name": "Dunbar Rail Station",
+    "station_name": "Dunbar",
     "latitude": 55.9982866312,
     "longitude": -2.513351643
   },
   {
     "3alpha": "DUR",
-    "station_name": "Durrington-on-Sea Rail Station",
+    "station_name": "Durrington-on-Sea",
     "latitude": 50.817518034,
     "longitude": -0.4114439
   },
   {
     "3alpha": "DVC",
-    "station_name": "Dovercourt Rail Station",
+    "station_name": "Dovercourt",
     "latitude": 51.9387503243,
     "longitude": 1.2806410709
   },
   {
     "3alpha": "DVH",
-    "station_name": "Dove Holes Rail Station",
+    "station_name": "Dove Holes",
     "latitude": 53.3000420778,
     "longitude": -1.8897505662
   },
   {
     "3alpha": "DVN",
-    "station_name": "Davenport Rail Station",
+    "station_name": "Davenport",
     "latitude": 53.3909155002,
     "longitude": -2.1529566556
   },
   {
     "3alpha": "DVP",
-    "station_name": "Dover Priory Rail Station",
+    "station_name": "Dover Priory",
     "latitude": 51.1257054631,
     "longitude": 1.3053252348
   },
   {
     "3alpha": "DVY",
-    "station_name": "Dovey Junction Rail Station",
+    "station_name": "Dovey Junction",
     "latitude": 52.5643723647,
     "longitude": -3.9239110192
   },
   {
     "3alpha": "DWD",
-    "station_name": "Dolwyddelan Rail Station",
+    "station_name": "Dolwyddelan",
     "latitude": 53.0520264903,
     "longitude": -3.885137383
   },
   {
     "3alpha": "DWL",
-    "station_name": "Dawlish Rail Station",
+    "station_name": "Dawlish",
     "latitude": 50.5808060844,
     "longitude": -3.4646385825
   },
   {
     "3alpha": "DWN",
-    "station_name": "Darwen Rail Station",
+    "station_name": "Darwen",
     "latitude": 53.6980500658,
     "longitude": -2.4649373867
   },
   {
     "3alpha": "DWW",
-    "station_name": "Dawlish Warren Rail Station",
+    "station_name": "Dawlish Warren",
     "latitude": 50.5986963334,
     "longitude": -3.4435746881
   },
   {
     "3alpha": "DYC",
-    "station_name": "Dyce Rail Station",
+    "station_name": "Dyce",
     "latitude": 57.2056334738,
     "longitude": -2.1923277179
   },
   {
     "3alpha": "DYF",
-    "station_name": "Dyffryn Ardudwy Rail Station",
+    "station_name": "Dyffryn Ardudwy",
     "latitude": 52.7888658497,
     "longitude": -4.1046506676
   },
   {
     "3alpha": "DYP",
-    "station_name": "Drayton Park Rail Station",
+    "station_name": "Drayton Park",
     "latitude": 51.5527705023,
     "longitude": -0.1054827348
   },
   {
     "3alpha": "DZY",
-    "station_name": "Danzey Rail Station",
+    "station_name": "Danzey",
     "latitude": 52.3248260043,
     "longitude": -1.8208686258
   },
   {
     "3alpha": "EAD",
-    "station_name": "Earlsfield Rail Station",
+    "station_name": "Earlsfield",
     "latitude": 51.4423352541,
     "longitude": -0.1876904006
   },
   {
     "3alpha": "EAG",
-    "station_name": "Eaglescliffe Rail Station",
+    "station_name": "Eaglescliffe",
     "latitude": 54.529441791,
     "longitude": -1.3494493173
   },
   {
     "3alpha": "EAL",
-    "station_name": "Ealing Broadway Rail Station",
+    "station_name": "Ealing Broadway",
     "latitude": 51.5148407171,
     "longitude": -0.3017293164
   },
   {
     "3alpha": "EAR",
-    "station_name": "Earley Rail Station",
+    "station_name": "Earley",
     "latitude": 51.4410992799,
     "longitude": -0.9179692021
   },
   {
     "3alpha": "EBA",
-    "station_name": "Euxton Balshaw Lane Rail Station",
+    "station_name": "Euxton Balshaw Lane",
     "latitude": 53.6604940469,
     "longitude": -2.6720207861
   },
   {
     "3alpha": "EBB",
-    "station_name": "Ebbw Vale Town Rail Station",
+    "station_name": "Ebbw Vale Town",
     "latitude": 51.7766906034,
     "longitude": -3.2025853559
   },
   {
     "3alpha": "EBD",
-    "station_name": "Ebbsfleet International Rail Station",
+    "station_name": "Ebbsfleet International",
     "latitude": 51.4429711416,
     "longitude": 0.3209500322
   },
   {
     "3alpha": "EBK",
-    "station_name": "Eastbrook Rail Station",
+    "station_name": "Eastbrook",
     "latitude": 51.4376339068,
     "longitude": -3.206146908
   },
   {
     "3alpha": "EBL",
-    "station_name": "East Boldon Rail Station",
+    "station_name": "East Boldon",
     "latitude": 54.9464212649,
     "longitude": -1.4203275453
   },
   {
     "3alpha": "EBN",
-    "station_name": "Eastbourne Rail Station",
+    "station_name": "Eastbourne",
     "latitude": 50.7693712403,
     "longitude": 0.2812755597
   },
   {
     "3alpha": "EBR",
-    "station_name": "Edenbridge Rail Station",
+    "station_name": "Edenbridge",
     "latitude": 51.2084314886,
     "longitude": 0.0606723709
   },
   {
     "3alpha": "EBT",
-    "station_name": "Edenbridge Town Rail Station",
+    "station_name": "Edenbridge Town",
     "latitude": 51.2000785009,
     "longitude": 0.0671991686
   },
   {
     "3alpha": "EBV",
-    "station_name": "Ebbw Vale Parkway Rail Station",
+    "station_name": "Ebbw Vale Parkway",
     "latitude": 51.7571458261,
     "longitude": -3.1961117844
   },
   {
     "3alpha": "ECC",
-    "station_name": "Eccles Rail Station",
+    "station_name": "Eccles",
     "latitude": 53.4853736806,
     "longitude": -2.3345132824
   },
   {
     "3alpha": "ECL",
-    "station_name": "Eccleston Park Rail Station",
+    "station_name": "Eccleston Park",
     "latitude": 53.4308004759,
     "longitude": -2.7800407784
   },
   {
     "3alpha": "ECP",
-    "station_name": "Energlyn & Churchill Park Rail Station",
+    "station_name": "Energlyn & Churchill Park",
     "latitude": 51.5832131774,
     "longitude": -3.2288061419
   },
   {
     "3alpha": "ECR",
-    "station_name": "East Croydon Rail Station",
+    "station_name": "East Croydon",
     "latitude": 51.3754518482,
     "longitude": -0.0927543224
   },
   {
     "3alpha": "ECS",
-    "station_name": "Eccles Road Rail Station",
+    "station_name": "Eccles Road",
     "latitude": 52.4709032665,
     "longitude": 0.9699418209
   },
   {
     "3alpha": "EDB",
-    "station_name": "Edinburgh Rail Station",
+    "station_name": "Edinburgh",
     "latitude": 55.9523865322,
     "longitude": -3.1882291087
   },
   {
     "3alpha": "EDG",
-    "station_name": "Edge Hill Rail Station",
+    "station_name": "Edge Hill",
     "latitude": 53.402631221,
     "longitude": -2.9464830162
   },
   {
     "3alpha": "EDL",
-    "station_name": "Edale Rail Station",
+    "station_name": "Edale",
     "latitude": 53.3649856666,
     "longitude": -1.8166247959
   },
   {
     "3alpha": "EDN",
-    "station_name": "Eden Park Rail Station",
+    "station_name": "Eden Park",
     "latitude": 51.3900885752,
     "longitude": -0.0263287699
   },
   {
     "3alpha": "EDP",
-    "station_name": "Edinburgh Park Rail Station",
+    "station_name": "Edinburgh Park",
     "latitude": 55.9275440803,
     "longitude": -3.3076630256
   },
   {
     "3alpha": "EDR",
-    "station_name": "Edmonton Green Rail Station",
+    "station_name": "Edmonton Green",
     "latitude": 51.6249290203,
     "longitude": -0.0610875153
   },
   {
     "3alpha": "EDW",
-    "station_name": "East Dulwich Rail Station",
+    "station_name": "East Dulwich",
     "latitude": 51.4614932275,
     "longitude": -0.080545987
   },
   {
     "3alpha": "EDY",
-    "station_name": "East Didsbury Rail Station",
+    "station_name": "East Didsbury",
     "latitude": 53.4093226957,
     "longitude": -2.221995354
   },
   {
     "3alpha": "EFF",
-    "station_name": "Effingham Junction Rail Station",
+    "station_name": "Effingham Junction",
     "latitude": 51.2914916148,
     "longitude": -0.4199426403
   },
   {
     "3alpha": "EFL",
-    "station_name": "East Farleigh Rail Station",
+    "station_name": "East Farleigh",
     "latitude": 51.2552346504,
     "longitude": 0.484758691
   },
   {
     "3alpha": "EGF",
-    "station_name": "East Garforth Rail Station",
+    "station_name": "East Garforth",
     "latitude": 53.7919924434,
     "longitude": -1.3705405592
   },
   {
     "3alpha": "EGG",
-    "station_name": "Eggesford Rail Station",
+    "station_name": "Eggesford",
     "latitude": 50.887727229,
     "longitude": -3.8747670951
   },
   {
     "3alpha": "EGH",
-    "station_name": "Egham Rail Station",
+    "station_name": "Egham",
     "latitude": 51.4296448509,
     "longitude": -0.5464936108
   },
   {
     "3alpha": "EGN",
-    "station_name": "Eastrington Rail Station",
+    "station_name": "Eastrington",
     "latitude": 53.7551798175,
     "longitude": -0.7876353437
   },
   {
     "3alpha": "EGR",
-    "station_name": "East Grinstead Rail Station",
+    "station_name": "East Grinstead",
     "latitude": 51.1262681111,
     "longitude": -0.0178726978
   },
   {
     "3alpha": "EGT",
-    "station_name": "Egton Rail Station",
+    "station_name": "Egton",
     "latitude": 54.4374940456,
     "longitude": -0.7614806216
   },
   {
     "3alpha": "EGY",
-    "station_name": "Edinburgh Gateway Rail Station",
+    "station_name": "Edinburgh Gateway",
     "latitude": 55.940932789,
     "longitude": -3.3202500314
   },
   {
     "3alpha": "EKB",
-    "station_name": "Eskbank Rail Station",
+    "station_name": "Eskbank",
     "latitude": 55.8817963943,
     "longitude": -3.0830769228
   },
   {
     "3alpha": "EKL",
-    "station_name": "East Kilbride Rail Station",
+    "station_name": "East Kilbride",
     "latitude": 55.7659978238,
     "longitude": -4.1802138231
   },
   {
     "3alpha": "ELD",
-    "station_name": "Earlswood (Surrey) Rail Station",
+    "station_name": "Earlswood (Surrey)",
     "latitude": 51.2273248317,
     "longitude": -0.1707971701
   },
   {
     "3alpha": "ELE",
-    "station_name": "Elmers End Rail Station",
+    "station_name": "Elmers End",
     "latitude": 51.398489582,
     "longitude": -0.0495441803
   },
   {
     "3alpha": "ELG",
-    "station_name": "Elgin Rail Station",
+    "station_name": "Elgin",
     "latitude": 57.6428926912,
     "longitude": -3.3112425277
   },
   {
     "3alpha": "ELO",
-    "station_name": "Elton & Orston Rail Station",
+    "station_name": "Elton & Orston",
     "latitude": 52.9521557025,
     "longitude": -0.8555074435
   },
   {
     "3alpha": "ELP",
-    "station_name": "Ellesmere Port Rail Station",
+    "station_name": "Ellesmere Port",
     "latitude": 53.2822052615,
     "longitude": -2.8964224623
   },
   {
     "3alpha": "ELR",
-    "station_name": "Elsecar Rail Station",
+    "station_name": "Elsecar",
     "latitude": 53.4986759683,
     "longitude": -1.4274252148
   },
   {
     "3alpha": "ELS",
-    "station_name": "Elstree & Borehamwood Rail Station",
+    "station_name": "Elstree & Borehamwood",
     "latitude": 51.6530715786,
     "longitude": -0.2800577261
   },
   {
+    "3alpha": "ELT",
+    "station_name": "East Linton",
+    "latitude": 55.9856,
+    "longitude": -2.6579
+  },
+  {
     "3alpha": "ELW",
-    "station_name": "Eltham Rail Station",
+    "station_name": "Eltham",
     "latitude": 51.4556421114,
     "longitude": 0.0524986776
   },
   {
     "3alpha": "ELY",
-    "station_name": "Ely Rail Station",
+    "station_name": "Ely",
     "latitude": 52.391244221,
     "longitude": 0.2668510603
   },
   {
     "3alpha": "EMD",
-    "station_name": "East Midlands Parkway Rail Station",
+    "station_name": "East Midlands Parkway",
     "latitude": 52.8625182507,
     "longitude": -1.2632265891
   },
   {
     "3alpha": "EML",
-    "station_name": "East Malling Rail Station",
+    "station_name": "East Malling",
     "latitude": 51.2858069522,
     "longitude": 0.439309906
   },
   {
     "3alpha": "EMP",
-    "station_name": "Emerson Park Rail Station",
+    "station_name": "Emerson Park",
     "latitude": 51.5686424022,
     "longitude": 0.2201396373
   },
   {
     "3alpha": "EMS",
-    "station_name": "Emsworth Rail Station",
+    "station_name": "Emsworth",
     "latitude": 50.8516027835,
     "longitude": -0.9384144303
   },
   {
     "3alpha": "ENC",
-    "station_name": "Enfield Chase Rail Station",
+    "station_name": "Enfield Chase",
     "latitude": 51.6532550128,
     "longitude": -0.0906697288
   },
   {
     "3alpha": "ENF",
-    "station_name": "Enfield Town Rail Station",
+    "station_name": "Enfield Town",
     "latitude": 51.6520265184,
     "longitude": -0.0793010146
   },
   {
     "3alpha": "ENL",
-    "station_name": "Enfield Lock Rail Station",
+    "station_name": "Enfield Lock",
     "latitude": 51.6709227126,
     "longitude": -0.0285062955
   },
   {
     "3alpha": "ENT",
-    "station_name": "Entwistle Rail Station",
+    "station_name": "Entwistle",
     "latitude": 53.6559908688,
     "longitude": -2.4145427951
   },
   {
     "3alpha": "EPD",
-    "station_name": "Epsom Downs Rail Station",
+    "station_name": "Epsom Downs",
     "latitude": 51.3236845001,
     "longitude": -0.23892976
   },
   {
     "3alpha": "EPH",
-    "station_name": "Elephant & Castle Rail Station",
+    "station_name": "Elephant & Castle",
     "latitude": 51.4940282398,
     "longitude": -0.098700214
   },
   {
     "3alpha": "EPS",
-    "station_name": "Epsom Rail Station",
+    "station_name": "Epsom",
     "latitude": 51.334389925,
     "longitude": -0.2687531384
   },
   {
     "3alpha": "ERA",
-    "station_name": "Eastham Rake Rail Station",
+    "station_name": "Eastham Rake",
     "latitude": 53.307552763,
     "longitude": -2.9811322454
   },
   {
     "3alpha": "ERD",
-    "station_name": "Erdington Rail Station",
+    "station_name": "Erdington",
     "latitude": 52.5282972975,
     "longitude": -1.8395023401
   },
   {
     "3alpha": "ERH",
-    "station_name": "Erith Rail Station",
+    "station_name": "Erith",
     "latitude": 51.481669408,
     "longitude": 0.1750812719
   },
   {
     "3alpha": "ERI",
-    "station_name": "Eridge Rail Station",
+    "station_name": "Eridge",
     "latitude": 51.0889610517,
     "longitude": 0.2014592494
   },
   {
     "3alpha": "ERL",
-    "station_name": "Earlestown Rail Station",
+    "station_name": "Earlestown",
     "latitude": 53.451151143,
     "longitude": -2.6376624607
   },
   {
     "3alpha": "ESD",
-    "station_name": "Elmstead Woods Rail Station",
+    "station_name": "Elmstead Woods",
     "latitude": 51.4171157446,
     "longitude": 0.0442997314
   },
   {
     "3alpha": "ESH",
-    "station_name": "Esher Rail Station",
+    "station_name": "Esher",
     "latitude": 51.3798880712,
     "longitude": -0.3533154601
   },
   {
     "3alpha": "ESL",
-    "station_name": "Eastleigh Rail Station",
+    "station_name": "Eastleigh",
     "latitude": 50.9692403635,
     "longitude": -1.350073969
   },
   {
     "3alpha": "ESM",
-    "station_name": "Elsenham Rail Station",
+    "station_name": "Elsenham",
     "latitude": 51.920551892,
     "longitude": 0.228097059
   },
   {
     "3alpha": "EST",
-    "station_name": "Easterhouse Rail Station",
+    "station_name": "Easterhouse",
     "latitude": 55.8597505142,
     "longitude": -4.1071641367
   },
   {
     "3alpha": "ESW",
-    "station_name": "Elmswell Rail Station",
+    "station_name": "Elmswell",
     "latitude": 52.2380555449,
     "longitude": 0.9126215916
   },
   {
     "3alpha": "ETC",
-    "station_name": "Etchingham Rail Station",
+    "station_name": "Etchingham",
     "latitude": 51.0105413018,
     "longitude": 0.4423847838
   },
   {
     "3alpha": "ETL",
-    "station_name": "East Tilbury Rail Station",
+    "station_name": "East Tilbury",
     "latitude": 51.4848306628,
     "longitude": 0.4129581196
   },
   {
     "3alpha": "EUS",
-    "station_name": "London Euston Rail Station",
+    "station_name": "London Euston",
     "latitude": 51.5281364316,
     "longitude": -0.1338981275
   },
   {
     "3alpha": "EVE",
-    "station_name": "Evesham Rail Station",
+    "station_name": "Evesham",
     "latitude": 52.0984067663,
     "longitude": -1.9473049925
   },
   {
     "3alpha": "EWD",
-    "station_name": "Earlswood (West Midlands) Rail Station",
+    "station_name": "Earlswood (West Midlands)",
     "latitude": 52.3665938407,
     "longitude": -1.861161636
   },
   {
     "3alpha": "EWE",
-    "station_name": "Ewell East Rail Station",
+    "station_name": "Ewell East",
     "latitude": 51.3452967584,
     "longitude": -0.2415048775
   },
   {
     "3alpha": "EWR",
-    "station_name": "East Worthing Rail Station",
+    "station_name": "East Worthing",
     "latitude": 50.8216357611,
     "longitude": -0.3548680158
   },
   {
     "3alpha": "EWW",
-    "station_name": "Ewell West Rail Station",
+    "station_name": "Ewell West",
     "latitude": 51.350041877,
     "longitude": -0.2569621791
   },
   {
     "3alpha": "EXC",
-    "station_name": "Exeter Central Rail Station",
+    "station_name": "Exeter Central",
     "latitude": 50.7264717379,
     "longitude": -3.5332911791
   },
   {
     "3alpha": "EXD",
-    "station_name": "Exeter St Davids Rail Station",
+    "station_name": "Exeter St Davids",
     "latitude": 50.7292625509,
     "longitude": -3.5433010662
   },
   {
     "3alpha": "EXG",
-    "station_name": "Exhibition Centre (Glasgow) Rail Station",
+    "station_name": "Exhibition Centre (Glasgow)",
     "latitude": 55.8615443927,
     "longitude": -4.2835742363
   },
   {
     "3alpha": "EXM",
-    "station_name": "Exmouth Rail Station",
+    "station_name": "Exmouth",
     "latitude": 50.6216212923,
     "longitude": -3.4149848889
   },
   {
     "3alpha": "EXN",
-    "station_name": "Exton Rail Station",
+    "station_name": "Exton",
     "latitude": 50.6682904818,
     "longitude": -3.4441097276
   },
   {
     "3alpha": "EXR",
-    "station_name": "Essex Road Rail Station",
+    "station_name": "Essex Road",
     "latitude": 51.5407057256,
     "longitude": -0.0962497405
   },
   {
     "3alpha": "EXT",
-    "station_name": "Exeter St Thomas Rail Station",
+    "station_name": "Exeter St Thomas",
     "latitude": 50.717135131,
     "longitude": -3.5388511334
   },
   {
     "3alpha": "EYN",
-    "station_name": "Eynsford Rail Station",
+    "station_name": "Eynsford",
     "latitude": 51.3627174333,
     "longitude": 0.2044201754
   },
   {
     "3alpha": "FAL",
-    "station_name": "Falmouth Docks Rail Station",
+    "station_name": "Falmouth Docks",
     "latitude": 50.1506931982,
     "longitude": -5.0560746226
   },
   {
     "3alpha": "FAV",
-    "station_name": "Faversham Rail Station",
+    "station_name": "Faversham",
     "latitude": 51.3117150831,
     "longitude": 0.8910755277
   },
   {
     "3alpha": "FAZ",
-    "station_name": "Fazakerley Rail Station",
+    "station_name": "Fazakerley",
     "latitude": 53.4690990636,
     "longitude": -2.936722397
   },
   {
     "3alpha": "FBY",
-    "station_name": "Formby Rail Station",
+    "station_name": "Formby",
     "latitude": 53.5534917106,
     "longitude": -3.0709054604
   },
   {
     "3alpha": "FCN",
-    "station_name": "Falconwood Rail Station",
+    "station_name": "Falconwood",
     "latitude": 51.4591529464,
     "longitude": 0.079330998
   },
   {
     "3alpha": "FEA",
-    "station_name": "Featherstone Rail Station",
+    "station_name": "Featherstone",
     "latitude": 53.6790826979,
     "longitude": -1.358447032
   },
   {
     "3alpha": "FEL",
-    "station_name": "Feltham Rail Station",
+    "station_name": "Feltham",
     "latitude": 51.4478965298,
     "longitude": -0.4098171801
   },
   {
     "3alpha": "FEN",
-    "station_name": "Fenny Stratford Rail Station",
+    "station_name": "Fenny Stratford",
     "latitude": 52.0000768774,
     "longitude": -0.7159762313
   },
   {
     "3alpha": "FER",
-    "station_name": "Fernhill Rail Station",
+    "station_name": "Fernhill",
     "latitude": 51.6864981097,
     "longitude": -3.3958946145
   },
   {
     "3alpha": "FFA",
-    "station_name": "Ffairfach Rail Station",
+    "station_name": "Ffairfach",
     "latitude": 51.8724808498,
     "longitude": -3.9928787809
   },
   {
     "3alpha": "FFD",
-    "station_name": "Freshford Rail Station",
+    "station_name": "Freshford",
     "latitude": 51.3420243729,
     "longitude": -2.3010063939
   },
   {
     "3alpha": "FGH",
-    "station_name": "Fishguard Harbour Rail Station",
+    "station_name": "Fishguard Harbour",
     "latitude": 52.011557061,
     "longitude": -4.985670408
   },
   {
     "3alpha": "FGT",
-    "station_name": "Faygate Rail Station",
+    "station_name": "Faygate",
     "latitude": 51.0958843958,
     "longitude": -0.2629910043
   },
   {
     "3alpha": "FGW",
-    "station_name": "Fishguard & Goodwick Rail Station",
+    "station_name": "Fishguard & Goodwick",
     "latitude": 52.0041284781,
     "longitude": -4.9948666231
   },
   {
     "3alpha": "FIL",
-    "station_name": "Filey Rail Station",
+    "station_name": "Filey",
     "latitude": 54.2098758908,
     "longitude": -0.2938654062
   },
   {
     "3alpha": "FIN",
-    "station_name": "Finstock Rail Station",
+    "station_name": "Finstock",
     "latitude": 51.8527876529,
     "longitude": -1.4693269485
   },
   {
     "3alpha": "FIT",
-    "station_name": "Filton Abbey Wood Rail Station",
+    "station_name": "Filton Abbey Wood",
     "latitude": 51.5049359236,
     "longitude": -2.5624320807
   },
   {
     "3alpha": "FKC",
-    "station_name": "Folkestone Central Rail Station",
+    "station_name": "Folkestone Central",
     "latitude": 51.0828894709,
     "longitude": 1.1695144099
   },
   {
     "3alpha": "FKG",
-    "station_name": "Falkirk Grahamston Rail Station",
+    "station_name": "Falkirk Grahamston",
     "latitude": 56.0026075153,
     "longitude": -3.7850391932
   },
   {
     "3alpha": "FKK",
-    "station_name": "Falkirk High Rail Station",
+    "station_name": "Falkirk High",
     "latitude": 55.9918091725,
     "longitude": -3.7922363145
   },
   {
     "3alpha": "FKW",
-    "station_name": "Folkestone West Rail Station",
+    "station_name": "Folkestone West",
     "latitude": 51.0845880696,
     "longitude": 1.1539352777
   },
   {
     "3alpha": "FLD",
-    "station_name": "Fauldhouse Rail Station",
+    "station_name": "Fauldhouse",
     "latitude": 55.8224687949,
     "longitude": -3.7193103999
   },
   {
     "3alpha": "FLE",
-    "station_name": "Fleet Rail Station",
+    "station_name": "Fleet",
     "latitude": 51.2906324021,
     "longitude": -0.8307895054
   },
   {
     "3alpha": "FLF",
-    "station_name": "Flowery Field Rail Station",
+    "station_name": "Flowery Field",
     "latitude": 53.4618690949,
     "longitude": -2.0810528443
   },
   {
     "3alpha": "FLI",
-    "station_name": "Flixton Rail Station",
+    "station_name": "Flixton",
     "latitude": 53.4438220233,
     "longitude": -2.3842455243
   },
   {
     "3alpha": "FLM",
-    "station_name": "Flimby Rail Station",
+    "station_name": "Flimby",
     "latitude": 54.6896927165,
     "longitude": -3.5207405823
   },
   {
     "3alpha": "FLN",
-    "station_name": "Flint Rail Station",
+    "station_name": "Flint",
     "latitude": 53.2495386637,
     "longitude": -3.1329931372
   },
   {
     "3alpha": "FLT",
-    "station_name": "Flitwick Rail Station",
+    "station_name": "Flitwick",
     "latitude": 52.0036505318,
     "longitude": -0.4952335864
   },
   {
     "3alpha": "FLW",
-    "station_name": "Fulwell Rail Station",
+    "station_name": "Fulwell",
     "latitude": 51.4339333056,
     "longitude": -0.3494462747
   },
   {
     "3alpha": "FLX",
-    "station_name": "Felixstowe Rail Station",
+    "station_name": "Felixstowe",
     "latitude": 51.9670846947,
     "longitude": 1.3504650975
   },
   {
     "3alpha": "FML",
-    "station_name": "Frimley Rail Station",
+    "station_name": "Frimley",
     "latitude": 51.3118599318,
     "longitude": -0.7469740068
   },
   {
     "3alpha": "FMR",
-    "station_name": "Falmer Rail Station",
+    "station_name": "Falmer",
     "latitude": 50.8621216711,
     "longitude": -0.0873578378
   },
   {
     "3alpha": "FMT",
-    "station_name": "Falmouth Town Rail Station",
+    "station_name": "Falmouth Town",
     "latitude": 50.1483262428,
     "longitude": -5.0649815419
   },
   {
     "3alpha": "FNB",
-    "station_name": "Farnborough (Main) Rail Station",
+    "station_name": "Farnborough (Main)",
     "latitude": 51.2966031825,
     "longitude": -0.7557080158
   },
   {
     "3alpha": "FNC",
-    "station_name": "Farncombe Rail Station",
+    "station_name": "Farncombe",
     "latitude": 51.1971482209,
     "longitude": -0.6045286271
   },
   {
     "3alpha": "FNH",
-    "station_name": "Farnham Rail Station",
+    "station_name": "Farnham",
     "latitude": 51.2119005959,
     "longitude": -0.7924099968
   },
   {
     "3alpha": "FNN",
-    "station_name": "Farnborough North Rail Station",
+    "station_name": "Farnborough North",
     "latitude": 51.3020427564,
     "longitude": -0.7430095202
   },
   {
     "3alpha": "FNR",
-    "station_name": "Farningham Road Rail Station",
+    "station_name": "Farningham Road",
     "latitude": 51.40166365,
     "longitude": 0.235479766
   },
   {
     "3alpha": "FNT",
-    "station_name": "Feniton Rail Station",
+    "station_name": "Feniton",
     "latitude": 50.7866658255,
     "longitude": -3.2854308727
   },
   {
     "3alpha": "FNV",
-    "station_name": "Furness Vale Rail Station",
+    "station_name": "Furness Vale",
     "latitude": 53.3487660512,
     "longitude": -1.9888438055
   },
   {
     "3alpha": "FNW",
-    "station_name": "Farnworth Rail Station",
+    "station_name": "Farnworth",
     "latitude": 53.5500180154,
     "longitude": -2.3878478205
   },
   {
     "3alpha": "FNY",
-    "station_name": "Finchley Road & Frognal Rail Station",
+    "station_name": "Finchley Road & Frognal",
     "latitude": 51.5502664369,
     "longitude": -0.1831154061
   },
   {
     "3alpha": "FOC",
-    "station_name": "Falls of Cruachan Rail Station",
+    "station_name": "Falls of Cruachan",
     "latitude": 56.3938689413,
     "longitude": -5.1124566704
   },
   {
     "3alpha": "FOD",
-    "station_name": "Ford Rail Station",
+    "station_name": "Ford",
     "latitude": 50.8293824048,
     "longitude": -0.5783872727
   },
   {
     "3alpha": "FOG",
-    "station_name": "Forest Gate Rail Station",
+    "station_name": "Forest Gate",
     "latitude": 51.549431694,
     "longitude": 0.0243798935
   },
   {
     "3alpha": "FOH",
-    "station_name": "Forest Hill Rail Station",
+    "station_name": "Forest Hill",
     "latitude": 51.4392780589,
     "longitude": -0.0531313997
   },
   {
     "3alpha": "FOK",
-    "station_name": "Four Oaks Rail Station",
+    "station_name": "Four Oaks",
     "latitude": 52.5797939503,
     "longitude": -1.8280248803
   },
   {
     "3alpha": "FOR",
-    "station_name": "Forres Rail Station",
+    "station_name": "Forres",
     "latitude": 57.6111680406,
     "longitude": -3.6248718523
   },
   {
     "3alpha": "FOX",
-    "station_name": "Foxfield Rail Station",
+    "station_name": "Foxfield",
     "latitude": 54.2586748544,
     "longitude": -3.216062854
   },
   {
     "3alpha": "FPK",
-    "station_name": "Finsbury Park Rail Station",
+    "station_name": "Finsbury Park",
     "latitude": 51.5643025324,
     "longitude": -0.1062590007
   },
   {
     "3alpha": "FRB",
-    "station_name": "Fairbourne Rail Station",
+    "station_name": "Fairbourne",
     "latitude": 52.6960557759,
     "longitude": -4.0494218463
   },
   {
     "3alpha": "FRD",
-    "station_name": "Frodsham Rail Station",
+    "station_name": "Frodsham",
     "latitude": 53.2958284679,
     "longitude": -2.7235668244
   },
   {
     "3alpha": "FRE",
-    "station_name": "Freshfield Rail Station",
+    "station_name": "Freshfield",
     "latitude": 53.5660676569,
     "longitude": -3.0718271848
   },
   {
     "3alpha": "FRF",
-    "station_name": "Fairfield Rail Station",
+    "station_name": "Fairfield",
     "latitude": 53.4713083714,
     "longitude": -2.1457740263
   },
   {
     "3alpha": "FRI",
-    "station_name": "Frinton-on-Sea Rail Station",
+    "station_name": "Frinton-on-Sea",
     "latitude": 51.8376925676,
     "longitude": 1.2432006998
   },
   {
     "3alpha": "FRL",
-    "station_name": "Fairlie Rail Station",
+    "station_name": "Fairlie",
     "latitude": 55.7519366963,
     "longitude": -4.8532464966
   },
   {
     "3alpha": "FRM",
-    "station_name": "Fareham Rail Station",
+    "station_name": "Fareham",
     "latitude": 50.8530232101,
     "longitude": -1.1920245124
   },
   {
     "3alpha": "FRN",
-    "station_name": "Fearn Rail Station",
+    "station_name": "Fearn",
     "latitude": 57.778126445,
     "longitude": -3.9939370006
   },
   {
     "3alpha": "FRO",
-    "station_name": "Frome Rail Station",
+    "station_name": "Frome",
     "latitude": 51.2272634789,
     "longitude": -2.3099932958
   },
   {
     "3alpha": "FRR",
-    "station_name": "Frosterley Rail Station",
+    "station_name": "Frosterley",
     "latitude": 54.7270012002,
     "longitude": -1.9644205566
   },
   {
     "3alpha": "FRS",
-    "station_name": "Forsinard Rail Station",
+    "station_name": "Forsinard",
     "latitude": 58.3568834527,
     "longitude": -3.8968870161
   },
   {
     "3alpha": "FRT",
-    "station_name": "Frant Rail Station",
+    "station_name": "Frant",
     "latitude": 51.1040247127,
     "longitude": 0.2945703279
   },
   {
     "3alpha": "FRW",
-    "station_name": "Fairwater Rail Station",
+    "station_name": "Fairwater",
     "latitude": 51.4939058847,
     "longitude": -3.2338488071
   },
   {
     "3alpha": "FRY",
-    "station_name": "Ferriby Rail Station",
+    "station_name": "Ferriby",
     "latitude": 53.7171721074,
     "longitude": -0.5078355516
   },
   {
     "3alpha": "FSB",
-    "station_name": "Fishbourne Rail Station",
+    "station_name": "Fishbourne",
     "latitude": 50.8390401424,
     "longitude": -0.8150655546
   },
   {
     "3alpha": "FSG",
-    "station_name": "Fishersgate Rail Station",
+    "station_name": "Fishersgate",
     "latitude": 50.834226328,
     "longitude": -0.2193956669
   },
   {
     "3alpha": "FSK",
-    "station_name": "Fiskerton Rail Station",
+    "station_name": "Fiskerton",
     "latitude": 53.0602929309,
     "longitude": -0.9121833385
   },
   {
     "3alpha": "FST",
-    "station_name": "London Fenchurch Street Rail Station",
+    "station_name": "London Fenchurch Street",
     "latitude": 51.5116455824,
     "longitude": -0.0788707296
   },
   {
     "3alpha": "FTM",
-    "station_name": "Fort Matilda Rail Station",
+    "station_name": "Fort Matilda",
     "latitude": 55.9590229231,
     "longitude": -4.7952474713
   },
   {
     "3alpha": "FTN",
-    "station_name": "Fratton Rail Station",
+    "station_name": "Fratton",
     "latitude": 50.7963261465,
     "longitude": -1.0739689378
   },
   {
     "3alpha": "FTW",
-    "station_name": "Fort William Rail Station",
+    "station_name": "Fort William",
     "latitude": 56.820425796,
     "longitude": -5.1061294153
   },
   {
     "3alpha": "FWY",
-    "station_name": "Five Ways Rail Station",
+    "station_name": "Five Ways",
     "latitude": 52.4711078714,
     "longitude": -1.9129492479
   },
   {
     "3alpha": "FXN",
-    "station_name": "Foxton Rail Station",
+    "station_name": "Foxton",
     "latitude": 52.1192233456,
     "longitude": 0.0563363619
   },
   {
     "3alpha": "FYS",
-    "station_name": "Ferryside Rail Station",
+    "station_name": "Ferryside",
     "latitude": 51.7683736213,
     "longitude": -4.3694828095
   },
   {
     "3alpha": "FZH",
-    "station_name": "Frizinghall Rail Station",
+    "station_name": "Frizinghall",
     "latitude": 53.8203830612,
     "longitude": -1.7690049748
   },
   {
     "3alpha": "FZP",
-    "station_name": "Furze Platt Rail Station",
+    "station_name": "Furze Platt",
     "latitude": 51.533021301,
     "longitude": -0.7284541823
   },
   {
     "3alpha": "FZW",
-    "station_name": "Fitzwilliam Rail Station",
+    "station_name": "Fitzwilliam",
     "latitude": 53.6325161611,
     "longitude": -1.3742749709
   },
   {
     "3alpha": "GAL",
-    "station_name": "Galashiels Rail Station",
+    "station_name": "Galashiels",
     "latitude": 55.618348945,
     "longitude": -2.8069043382
   },
   {
     "3alpha": "GAR",
-    "station_name": "Garrowhill Rail Station",
+    "station_name": "Garrowhill",
     "latitude": 55.8552326445,
     "longitude": -4.1294477285
   },
   {
     "3alpha": "GBD",
-    "station_name": "Gilberdyke Rail Station",
+    "station_name": "Gilberdyke",
     "latitude": 53.7479824021,
     "longitude": -0.7322489664
   },
   {
     "3alpha": "GBG",
-    "station_name": "Gorebridge Rail Station",
+    "station_name": "Gorebridge",
     "latitude": 55.8402677085,
     "longitude": -3.0465190236
   },
   {
     "3alpha": "GBK",
-    "station_name": "Greenbank Rail Station",
+    "station_name": "Greenbank",
     "latitude": 53.2514787515,
     "longitude": -2.5342692507
   },
   {
     "3alpha": "GBL",
-    "station_name": "Gainsborough Lea Road Rail Station",
+    "station_name": "Gainsborough Lea Road",
     "latitude": 53.3861086871,
     "longitude": -0.7685809379
   },
   {
     "3alpha": "GBS",
-    "station_name": "Goring-by-Sea Rail Station",
+    "station_name": "Goring-by-Sea",
     "latitude": 50.8177112854,
     "longitude": -0.4330585625
   },
   {
     "3alpha": "GCH",
-    "station_name": "Garelochhead Rail Station",
+    "station_name": "Garelochhead",
     "latitude": 56.0798548957,
     "longitude": -4.8256979183
   },
   {
     "3alpha": "GCL",
-    "station_name": "Glasgow Central Low Level Rail Station",
+    "station_name": "Glasgow Central Low Level",
     "latitude": 55.858673532,
     "longitude": -4.2584774599
   },
   {
     "3alpha": "GCR",
-    "station_name": "Gloucester Rail Station",
+    "station_name": "Gloucester",
     "latitude": 51.8655641361,
     "longitude": -2.2384843439
   },
   {
     "3alpha": "GCT",
-    "station_name": "Great Coates Rail Station",
+    "station_name": "Great Coates",
     "latitude": 53.5757759251,
     "longitude": -0.1302350444
   },
   {
     "3alpha": "GCW",
-    "station_name": "Glan Conwy Rail Station",
+    "station_name": "Glan Conwy",
     "latitude": 53.2674361965,
     "longitude": -3.797731864
   },
   {
     "3alpha": "GDH",
-    "station_name": "Gordon Hill Rail Station",
+    "station_name": "Gordon Hill",
     "latitude": 51.6633360633,
     "longitude": -0.0945839997
   },
   {
     "3alpha": "GDL",
-    "station_name": "Godley Rail Station",
+    "station_name": "Godley",
     "latitude": 53.4517179149,
     "longitude": -2.0547723093
   },
   {
     "3alpha": "GDN",
-    "station_name": "Godstone Rail Station",
+    "station_name": "Godstone",
     "latitude": 51.2181531133,
     "longitude": -0.0500583421
   },
   {
     "3alpha": "GDP",
-    "station_name": "Gidea Park Rail Station",
+    "station_name": "Gidea Park",
     "latitude": 51.5819043047,
     "longitude": 0.2059905265
   },
   {
     "3alpha": "GEA",
-    "station_name": "Gretna Green Rail Station",
+    "station_name": "Gretna Green",
     "latitude": 55.0010507027,
     "longitude": -3.0652008756
   },
   {
     "3alpha": "GER",
-    "station_name": "Gerrards Cross Rail Station",
+    "station_name": "Gerrards Cross",
     "latitude": 51.5890237128,
     "longitude": -0.5552555668
   },
   {
     "3alpha": "GFD",
-    "station_name": "Greenford Rail Station",
+    "station_name": "Greenford",
     "latitude": 51.5423307069,
     "longitude": -0.3458148281
   },
   {
     "3alpha": "GFF",
-    "station_name": "Gilfach Fargoed Rail Station",
+    "station_name": "Gilfach Fargoed",
     "latitude": 51.6842505424,
     "longitude": -3.2265776505
   },
   {
     "3alpha": "GFN",
-    "station_name": "Giffnock Rail Station",
+    "station_name": "Giffnock",
     "latitude": 55.8039838247,
     "longitude": -4.2930005917
   },
   {
     "3alpha": "GGJ",
-    "station_name": "Georgemas Junction Rail Station",
+    "station_name": "Georgemas Junction",
     "latitude": 58.5136083248,
     "longitude": -3.4521277157
   },
   {
     "3alpha": "GGV",
-    "station_name": "Gargrave Rail Station",
+    "station_name": "Gargrave",
     "latitude": 53.9784289792,
     "longitude": -2.1051749427
   },
   {
     "3alpha": "GIG",
-    "station_name": "Giggleswick Rail Station",
+    "station_name": "Giggleswick",
     "latitude": 54.0618113766,
     "longitude": -2.3028507825
   },
   {
     "3alpha": "GIL",
-    "station_name": "Gillingham (Dorset) Rail Station",
+    "station_name": "Gillingham (Dorset)",
     "latitude": 51.0340262862,
     "longitude": -2.2726193805
   },
   {
     "3alpha": "GIP",
-    "station_name": "Gipsy Hill Rail Station",
+    "station_name": "Gipsy Hill",
     "latitude": 51.424451003,
     "longitude": -0.0838100922
   },
   {
     "3alpha": "GIR",
-    "station_name": "Girvan Rail Station",
+    "station_name": "Girvan",
     "latitude": 55.2463156898,
     "longitude": -4.8483590289
   },
   {
     "3alpha": "GKC",
-    "station_name": "Greenock Central Rail Station",
+    "station_name": "Greenock Central",
     "latitude": 55.9453319247,
     "longitude": -4.7526142906
   },
   {
     "3alpha": "GKW",
-    "station_name": "Greenock West Rail Station",
+    "station_name": "Greenock West",
     "latitude": 55.9473282882,
     "longitude": -4.767813412
   },
   {
     "3alpha": "GLC",
-    "station_name": "Glasgow Central Rail Station",
+    "station_name": "Glasgow Central",
     "latitude": 55.8597496156,
     "longitude": -4.2576290605
   },
   {
     "3alpha": "GLD",
-    "station_name": "Guildford Rail Station",
+    "station_name": "Guildford",
     "latitude": 51.2369644453,
     "longitude": -0.5804043303
   },
   {
     "3alpha": "GLE",
-    "station_name": "Gleneagles Rail Station",
+    "station_name": "Gleneagles",
     "latitude": 56.2748401663,
     "longitude": -3.7311626664
   },
   {
     "3alpha": "GLF",
-    "station_name": "Glenfinnan Rail Station",
+    "station_name": "Glenfinnan",
     "latitude": 56.8723822491,
     "longitude": -5.449604955
   },
   {
     "3alpha": "GLG",
-    "station_name": "Glengarnock Rail Station",
+    "station_name": "Glengarnock",
     "latitude": 55.7388819511,
     "longitude": -4.6744823788
   },
   {
     "3alpha": "GLH",
-    "station_name": "Glasshoughton Rail Station",
+    "station_name": "Glasshoughton",
     "latitude": 53.7090594596,
     "longitude": -1.3420084086
   },
   {
     "3alpha": "GLM",
-    "station_name": "Gillingham (Kent) Rail Station",
+    "station_name": "Gillingham (Kent)",
     "latitude": 51.3865631854,
     "longitude": 0.5498787442
   },
   {
     "3alpha": "GLO",
-    "station_name": "Glossop Rail Station",
+    "station_name": "Glossop",
     "latitude": 53.4444844182,
     "longitude": -1.9490712229
   },
   {
     "3alpha": "GLQ",
-    "station_name": "Glasgow Queen Street Rail Station",
+    "station_name": "Glasgow Queen Street",
     "latitude": 55.8621817762,
     "longitude": -4.2514417118
   },
   {
     "3alpha": "GLS",
-    "station_name": "Glaisdale Rail Station",
+    "station_name": "Glaisdale",
     "latitude": 54.4393938445,
     "longitude": -0.7938035599
   },
   {
     "3alpha": "GLT",
-    "station_name": "Glenrothes with Thornton Rail Station",
+    "station_name": "Glenrothes with Thornton",
     "latitude": 56.1623481523,
     "longitude": -3.1430172976
   },
   {
     "3alpha": "GLY",
-    "station_name": "Glynde Rail Station",
+    "station_name": "Glynde",
     "latitude": 50.8591649295,
     "longitude": 0.0701049622
   },
   {
     "3alpha": "GLZ",
-    "station_name": "Glazebrook Rail Station",
+    "station_name": "Glazebrook",
     "latitude": 53.4283742205,
     "longitude": -2.459656827
   },
   {
     "3alpha": "GMB",
-    "station_name": "Grimsby Town Rail Station",
+    "station_name": "Grimsby Town",
     "latitude": 53.5634511917,
     "longitude": -0.0869883746
   },
   {
     "3alpha": "GMD",
-    "station_name": "Grimsby Docks Rail Station",
+    "station_name": "Grimsby Docks",
     "latitude": 53.5743443249,
     "longitude": -0.0756224261
   },
   {
     "3alpha": "GMG",
-    "station_name": "Garth (Bridgend) Rail Station",
+    "station_name": "Garth (Bridgend)",
     "latitude": 51.5964572422,
     "longitude": -3.6414648286
   },
   {
     "3alpha": "GMN",
-    "station_name": "Great Missenden Rail Station",
+    "station_name": "Great Missenden",
     "latitude": 51.7035218129,
     "longitude": -0.7091187725
   },
   {
     "3alpha": "GMT",
-    "station_name": "Grosmont Rail Station",
+    "station_name": "Grosmont",
     "latitude": 54.43612578,
     "longitude": -0.7249812388
   },
   {
     "3alpha": "GMV",
-    "station_name": "Great Malvern Rail Station",
+    "station_name": "Great Malvern",
     "latitude": 52.1092074558,
     "longitude": -2.3182662455
   },
   {
     "3alpha": "GMY",
-    "station_name": "Goodmayes Rail Station",
+    "station_name": "Goodmayes",
     "latitude": 51.5655781413,
     "longitude": 0.1108335454
   },
   {
     "3alpha": "GNB",
-    "station_name": "Gainsborough Central Rail Station",
+    "station_name": "Gainsborough Central",
     "latitude": 53.3996038827,
     "longitude": -0.7696962039
   },
   {
     "3alpha": "GNF",
-    "station_name": "Greenfield Rail Station",
+    "station_name": "Greenfield",
     "latitude": 53.5388735659,
     "longitude": -2.013841081
   },
   {
     "3alpha": "GNH",
-    "station_name": "Greenhithe for Bluewater Rail Station",
+    "station_name": "Greenhithe for Bluewater",
     "latitude": 51.4503693938,
     "longitude": 0.2803176704
   },
   {
     "3alpha": "GNL",
-    "station_name": "Green Lane Rail Station",
+    "station_name": "Green Lane",
     "latitude": 53.3832695481,
     "longitude": -3.0164148473
   },
   {
     "3alpha": "GNR",
-    "station_name": "Green Road Rail Station",
+    "station_name": "Green Road",
     "latitude": 54.2445321604,
     "longitude": -3.2455716728
   },
   {
     "3alpha": "GNT",
-    "station_name": "Gunton Rail Station",
+    "station_name": "Gunton",
     "latitude": 52.8663732165,
     "longitude": 1.3491365444
   },
   {
     "3alpha": "GNW",
-    "station_name": "Greenwich Rail Station",
+    "station_name": "Greenwich",
     "latitude": 51.4781335778,
     "longitude": -0.0133139144
   },
   {
     "3alpha": "GOB",
-    "station_name": "Gobowen Rail Station",
+    "station_name": "Gobowen",
     "latitude": 52.8935276407,
     "longitude": -3.0371715591
   },
   {
     "3alpha": "GOD",
-    "station_name": "Godalming Rail Station",
+    "station_name": "Godalming",
     "latitude": 51.1865810902,
     "longitude": -0.6188424046
   },
   {
     "3alpha": "GOE",
-    "station_name": "Goldthorpe Rail Station",
+    "station_name": "Goldthorpe",
     "latitude": 53.5342068606,
     "longitude": -1.3128096411
   },
   {
     "3alpha": "GOF",
-    "station_name": "Golf Street Rail Station",
+    "station_name": "Golf Street",
     "latitude": 56.4977824375,
     "longitude": -2.7195495703
   },
   {
     "3alpha": "GOL",
-    "station_name": "Golspie Rail Station",
+    "station_name": "Golspie",
     "latitude": 57.9714474115,
     "longitude": -3.9872179776
   },
   {
     "3alpha": "GOM",
-    "station_name": "Gomshall Rail Station",
+    "station_name": "Gomshall",
     "latitude": 51.2193937984,
     "longitude": -0.4418288518
   },
   {
     "3alpha": "GOO",
-    "station_name": "Goole Rail Station",
+    "station_name": "Goole",
     "latitude": 53.7049327129,
     "longitude": -0.8742176314
   },
   {
     "3alpha": "GOR",
-    "station_name": "Goring & Streatley Rail Station",
+    "station_name": "Goring & Streatley",
     "latitude": 51.5214927112,
     "longitude": -1.133029148
   },
   {
     "3alpha": "GOS",
-    "station_name": "Grange-over-Sands Rail Station",
+    "station_name": "Grange-over-Sands",
     "latitude": 54.1957302552,
     "longitude": -2.9027471889
   },
   {
     "3alpha": "GOX",
-    "station_name": "Goxhill Rail Station",
+    "station_name": "Goxhill",
     "latitude": 53.6767222975,
     "longitude": -0.3371266253
   },
   {
     "3alpha": "GPK",
-    "station_name": "Grange Park Rail Station",
+    "station_name": "Grange Park",
     "latitude": 51.6426082109,
     "longitude": -0.0973320762
   },
   {
     "3alpha": "GPO",
-    "station_name": "Gospel Oak Rail Station",
+    "station_name": "Gospel Oak",
     "latitude": 51.5553362208,
     "longitude": -0.1507445033
   },
   {
     "3alpha": "GQL",
-    "station_name": "Glasgow Queen Street Low Level Rail Station",
+    "station_name": "Glasgow Queen Street Low Level",
     "latitude": 55.8623403235,
     "longitude": -4.2506358523
   },
   {
     "3alpha": "GRA",
-    "station_name": "Grantham Rail Station",
+    "station_name": "Grantham",
     "latitude": 52.9064924179,
     "longitude": -0.6424450707
   },
   {
     "3alpha": "GRB",
-    "station_name": "Great Bentley Rail Station",
+    "station_name": "Great Bentley",
     "latitude": 51.8517695139,
     "longitude": 1.0651844079
   },
   {
     "3alpha": "GRC",
-    "station_name": "Great Chesterford Rail Station",
+    "station_name": "Great Chesterford",
     "latitude": 52.0598200469,
     "longitude": 0.1935488673
   },
   {
     "3alpha": "GRF",
-    "station_name": "Garforth Rail Station",
+    "station_name": "Garforth",
     "latitude": 53.7965926372,
     "longitude": -1.3823135001
   },
   {
     "3alpha": "GRH",
-    "station_name": "Gartcosh Rail Station",
+    "station_name": "Gartcosh",
     "latitude": 55.8856546592,
     "longitude": -4.0794827931
   },
   {
     "3alpha": "GRK",
-    "station_name": "Gourock Rail Station",
+    "station_name": "Gourock",
     "latitude": 55.962310977,
     "longitude": -4.8166374785
   },
   {
     "3alpha": "GRL",
-    "station_name": "Greenfaulds Rail Station",
+    "station_name": "Greenfaulds",
     "latitude": 55.9352259193,
     "longitude": -3.9930912233
   },
   {
     "3alpha": "GRN",
-    "station_name": "Grindleford Rail Station",
+    "station_name": "Grindleford",
     "latitude": 53.3055770449,
     "longitude": -1.6262956215
   },
   {
     "3alpha": "GRP",
-    "station_name": "Grove Park Rail Station",
+    "station_name": "Grove Park",
     "latitude": 51.4308613738,
     "longitude": 0.0217517094
   },
   {
     "3alpha": "GRS",
-    "station_name": "Garscadden Rail Station",
+    "station_name": "Garscadden",
     "latitude": 55.8876875396,
     "longitude": -4.3649893754
   },
   {
     "3alpha": "GRT",
-    "station_name": "Grateley Rail Station",
+    "station_name": "Grateley",
     "latitude": 51.1700524514,
     "longitude": -1.6207622447
   },
   {
     "3alpha": "GRV",
-    "station_name": "Gravesend Rail Station",
+    "station_name": "Gravesend",
     "latitude": 51.4413470696,
     "longitude": 0.3666726966
   },
   {
     "3alpha": "GRY",
-    "station_name": "Grays Rail Station",
+    "station_name": "Grays",
     "latitude": 51.4762461335,
     "longitude": 0.3218603146
   },
   {
     "3alpha": "GSC",
-    "station_name": "Gilshochill Rail Station",
+    "station_name": "Gilshochill",
     "latitude": 55.8973310545,
     "longitude": -4.2826700794
   },
   {
     "3alpha": "GSD",
-    "station_name": "Garsdale Rail Station",
+    "station_name": "Garsdale",
     "latitude": 54.3214395016,
     "longitude": -2.3263576927
   },
   {
     "3alpha": "GSL",
-    "station_name": "Gunnislake Rail Station",
+    "station_name": "Gunnislake",
     "latitude": 50.5160691161,
     "longitude": -4.2194356583
   },
   {
     "3alpha": "GSN",
-    "station_name": "Garston (Herts) Rail Station",
+    "station_name": "Garston (Herts)",
     "latitude": 51.6866190925,
     "longitude": -0.3817173062
   },
   {
     "3alpha": "GST",
-    "station_name": "Gathurst Rail Station",
+    "station_name": "Gathurst",
     "latitude": 53.5594164707,
     "longitude": -2.694392781
   },
   {
     "3alpha": "GSW",
-    "station_name": "Garswood Rail Station",
+    "station_name": "Garswood",
     "latitude": 53.4885342343,
     "longitude": -2.6721346367
   },
   {
     "3alpha": "GSY",
-    "station_name": "Guiseley Rail Station",
+    "station_name": "Guiseley",
     "latitude": 53.8759473312,
     "longitude": -1.7150832878
   },
   {
     "3alpha": "GTA",
-    "station_name": "Great Ayton Rail Station",
+    "station_name": "Great Ayton",
     "latitude": 54.4895819243,
     "longitude": -1.1153591094
   },
   {
     "3alpha": "GTH",
-    "station_name": "Garth (Powys) Rail Station",
+    "station_name": "Garth (Powys)",
     "latitude": 52.1332443119,
     "longitude": -3.5299153647
   },
   {
     "3alpha": "GTN",
-    "station_name": "Grangetown (Cardiff) Rail Station",
+    "station_name": "Grangetown (Cardiff)",
     "latitude": 51.4676101723,
     "longitude": -3.1897328323
   },
   {
     "3alpha": "GTO",
-    "station_name": "Gorton Rail Station",
+    "station_name": "Gorton",
     "latitude": 53.4690883466,
     "longitude": -2.1662083592
   },
   {
     "3alpha": "GTR",
-    "station_name": "Goostrey Rail Station",
+    "station_name": "Goostrey",
     "latitude": 53.2225673734,
     "longitude": -2.3264689479
   },
   {
     "3alpha": "GTW",
-    "station_name": "Gatwick Airport Rail Station",
+    "station_name": "Gatwick Airport",
     "latitude": 51.1564852744,
     "longitude": -0.1610141074
   },
   {
     "3alpha": "GTY",
-    "station_name": "Gatley Rail Station",
+    "station_name": "Gatley",
     "latitude": 53.3929193229,
     "longitude": -2.2312340568
   },
   {
     "3alpha": "GUI",
-    "station_name": "Guide Bridge Rail Station",
+    "station_name": "Guide Bridge",
     "latitude": 53.4746422166,
     "longitude": -2.1137102403
   },
   {
     "3alpha": "GUN",
-    "station_name": "Gunnersbury Rail Station",
+    "station_name": "Gunnersbury",
     "latitude": 51.4916766051,
     "longitude": -0.2752639989
   },
   {
     "3alpha": "GVE",
-    "station_name": "Garve Rail Station",
+    "station_name": "Garve",
     "latitude": 57.6130218771,
     "longitude": -4.6883911143
   },
   {
     "3alpha": "GVH",
-    "station_name": "Gravelly Hill Rail Station",
+    "station_name": "Gravelly Hill",
     "latitude": 52.5150091168,
     "longitude": -1.8525928905
   },
   {
     "3alpha": "GWE",
-    "station_name": "Gwersyllt Rail Station",
+    "station_name": "Gwersyllt",
     "latitude": 53.0725888841,
     "longitude": -3.0178887352
   },
   {
     "3alpha": "GWN",
-    "station_name": "Gowerton Rail Station",
+    "station_name": "Gowerton",
     "latitude": 51.6487287822,
     "longitude": -4.0359546516
   },
   {
     "3alpha": "GYM",
-    "station_name": "Great Yarmouth Rail Station",
+    "station_name": "Great Yarmouth",
     "latitude": 52.6121840141,
     "longitude": 1.7209095669
   },
   {
     "3alpha": "GYP",
-    "station_name": "Gypsy Lane Rail Station",
+    "station_name": "Gypsy Lane",
     "latitude": 54.5329024718,
     "longitude": -1.1794055894
   },
   {
     "3alpha": "HAB",
-    "station_name": "Habrough Rail Station",
+    "station_name": "Habrough",
     "latitude": 53.6060967313,
     "longitude": -0.2694661266
   },
   {
     "3alpha": "HAC",
-    "station_name": "Hackney Downs Rail Station",
+    "station_name": "Hackney Downs",
     "latitude": 51.548757028,
     "longitude": -0.0607923652
   },
   {
     "3alpha": "HAD",
-    "station_name": "Haddiscoe Rail Station",
+    "station_name": "Haddiscoe",
     "latitude": 52.5288110907,
     "longitude": 1.6230311744
   },
   {
     "3alpha": "HAF",
-    "station_name": "Heathrow Terminal 4 Rail Station",
+    "station_name": "Heathrow Terminal 4",
     "latitude": 51.458265962,
     "longitude": -0.4454428215
   },
   {
     "3alpha": "HAG",
-    "station_name": "Hagley Rail Station",
+    "station_name": "Hagley",
     "latitude": 52.4225023907,
     "longitude": -2.1464119812
   },
   {
     "3alpha": "HAI",
-    "station_name": "Halling Rail Station",
+    "station_name": "Halling",
     "latitude": 51.352475791,
     "longitude": 0.4449605383
   },
   {
     "3alpha": "HAL",
-    "station_name": "Hale Rail Station",
+    "station_name": "Hale",
     "latitude": 53.3787324238,
     "longitude": -2.3473557978
   },
   {
     "3alpha": "HAM",
-    "station_name": "Hamworthy Rail Station",
+    "station_name": "Hamworthy",
     "latitude": 50.7251804312,
     "longitude": -2.0193512479
   },
   {
     "3alpha": "HAN",
-    "station_name": "Hanwell Rail Station",
+    "station_name": "Hanwell",
     "latitude": 51.5118339425,
     "longitude": -0.3385615111
   },
   {
     "3alpha": "HAP",
-    "station_name": "Hatfield Peverel Rail Station",
+    "station_name": "Hatfield Peverel",
     "latitude": 51.7798704228,
     "longitude": 0.5921498316
   },
   {
     "3alpha": "HAS",
-    "station_name": "Halesworth Rail Station",
+    "station_name": "Halesworth",
     "latitude": 52.3468365087,
     "longitude": 1.505697432
   },
   {
     "3alpha": "HAT",
-    "station_name": "Hatfield (Herts) Rail Station",
+    "station_name": "Hatfield (Herts)",
     "latitude": 51.7638834885,
     "longitude": -0.215564807
   },
   {
     "3alpha": "HAV",
-    "station_name": "Havant Rail Station",
+    "station_name": "Havant",
     "latitude": 50.8544157698,
     "longitude": -0.9815958592
   },
   {
     "3alpha": "HAY",
-    "station_name": "Hayes & Harlington Rail Station",
+    "station_name": "Hayes & Harlington",
     "latitude": 51.5030948614,
     "longitude": -0.4206635166
   },
   {
     "3alpha": "HAZ",
-    "station_name": "Hazel Grove Rail Station",
+    "station_name": "Hazel Grove",
     "latitude": 53.3775580792,
     "longitude": -2.1220186129
   },
   {
     "3alpha": "HBB",
-    "station_name": "Hubberts Bridge Rail Station",
+    "station_name": "Hubberts Bridge",
     "latitude": 52.9753742831,
     "longitude": -0.1105219846
   },
   {
     "3alpha": "HBD",
-    "station_name": "Hebden Bridge Rail Station",
+    "station_name": "Hebden Bridge",
     "latitude": 53.7376009105,
     "longitude": -2.0090600757
   },
   {
+    "3alpha": "HBL",
+    "station_name": "Headbolt Lane",
+    "latitude": 53.4911,
+    "longitude": -2.8856
+  },
+  {
     "3alpha": "HBN",
-    "station_name": "Hollingbourne Rail Station",
+    "station_name": "Hollingbourne",
     "latitude": 51.2651766997,
     "longitude": 0.6278786652
   },
   {
     "3alpha": "HBP",
-    "station_name": "Hornbeam Park Rail Station",
+    "station_name": "Hornbeam Park",
     "latitude": 53.9798825753,
     "longitude": -1.5268279163
   },
   {
     "3alpha": "HBY",
-    "station_name": "Hartlebury Rail Station",
+    "station_name": "Hartlebury",
     "latitude": 52.3345074098,
     "longitude": -2.2211143855
   },
   {
     "3alpha": "HCB",
-    "station_name": "Hackbridge Rail Station",
+    "station_name": "Hackbridge",
     "latitude": 51.3778692696,
     "longitude": -0.1538824466
   },
   {
     "3alpha": "HCH",
-    "station_name": "Holmes Chapel Rail Station",
+    "station_name": "Holmes Chapel",
     "latitude": 53.1989461479,
     "longitude": -2.3511385797
   },
   {
     "3alpha": "HCN",
-    "station_name": "Headcorn Rail Station",
+    "station_name": "Headcorn",
     "latitude": 51.1657113933,
     "longitude": 0.6275122421
   },
   {
     "3alpha": "HCT",
-    "station_name": "Huncoat Rail Station",
+    "station_name": "Huncoat",
     "latitude": 53.7717900997,
     "longitude": -2.3475613545
   },
   {
     "3alpha": "HDB",
-    "station_name": "Haydon Bridge Rail Station",
+    "station_name": "Haydon Bridge",
     "latitude": 54.9751799008,
     "longitude": -2.247596044
   },
   {
     "3alpha": "HDE",
-    "station_name": "Hedge End Rail Station",
+    "station_name": "Hedge End",
     "latitude": 50.9323093202,
     "longitude": -1.2944922291
   },
   {
     "3alpha": "HDF",
-    "station_name": "Hadfield Rail Station",
+    "station_name": "Hadfield",
     "latitude": 53.4607595075,
     "longitude": -1.9653179115
   },
   {
     "3alpha": "HDG",
-    "station_name": "Heald Green Rail Station",
+    "station_name": "Heald Green",
     "latitude": 53.3694305097,
     "longitude": -2.2366663043
   },
   {
     "3alpha": "HDH",
-    "station_name": "Hampstead Heath Rail Station",
+    "station_name": "Hampstead Heath",
     "latitude": 51.555210868,
     "longitude": -0.1656799709
   },
   {
     "3alpha": "HDL",
-    "station_name": "Headstone Lane Rail Station",
+    "station_name": "Headstone Lane",
     "latitude": 51.6026499985,
     "longitude": -0.3571975148
   },
   {
     "3alpha": "HDM",
-    "station_name": "Haddenham & Thame Parkway Rail Station",
+    "station_name": "Haddenham & Thame Parkway",
     "latitude": 51.7708590202,
     "longitude": -0.9421154353
   },
   {
     "3alpha": "HDN",
-    "station_name": "Harlesden Rail Station",
+    "station_name": "Harlesden",
     "latitude": 51.536289123,
     "longitude": -0.2576441501
   },
   {
     "3alpha": "HDW",
-    "station_name": "Hadley Wood Rail Station",
+    "station_name": "Hadley Wood",
     "latitude": 51.6684984541,
     "longitude": -0.1761475828
   },
   {
     "3alpha": "HDY",
-    "station_name": "Headingley Rail Station",
+    "station_name": "Headingley",
     "latitude": 53.8179883371,
     "longitude": -1.5941914379
   },
   {
     "3alpha": "HEC",
-    "station_name": "Heckington Rail Station",
+    "station_name": "Heckington",
     "latitude": 52.9773390292,
     "longitude": -0.2939371983
   },
   {
     "3alpha": "HED",
-    "station_name": "Halewood Rail Station",
+    "station_name": "Halewood",
     "latitude": 53.3644936533,
     "longitude": -2.8301342149
   },
   {
     "3alpha": "HEI",
-    "station_name": "Heighington Rail Station",
+    "station_name": "Heighington",
     "latitude": 54.5969688714,
     "longitude": -1.5817749363
   },
   {
     "3alpha": "HEL",
-    "station_name": "Hensall Rail Station",
+    "station_name": "Hensall",
     "latitude": 53.6985625439,
     "longitude": -1.1145223177
   },
   {
     "3alpha": "HEN",
-    "station_name": "Hendon Rail Station",
+    "station_name": "Hendon",
     "latitude": 51.5800693984,
     "longitude": -0.2386485815
   },
   {
     "3alpha": "HER",
-    "station_name": "Hersham Rail Station",
+    "station_name": "Hersham",
     "latitude": 51.3768090642,
     "longitude": -0.3899376365
   },
   {
     "3alpha": "HES",
-    "station_name": "Hessle Rail Station",
+    "station_name": "Hessle",
     "latitude": 53.7174547293,
     "longitude": -0.4418278411
   },
   {
     "3alpha": "HEV",
-    "station_name": "Hever Rail Station",
+    "station_name": "Hever",
     "latitude": 51.18140673,
     "longitude": 0.0950955245
   },
   {
     "3alpha": "HEW",
-    "station_name": "Heworth Rail Station",
+    "station_name": "Heworth",
     "latitude": 54.951574003,
     "longitude": -1.5557793317
   },
   {
     "3alpha": "HEX",
-    "station_name": "Hexham Rail Station",
+    "station_name": "Hexham",
     "latitude": 54.9734640115,
     "longitude": -2.0948036947
   },
   {
     "3alpha": "HFD",
-    "station_name": "Hereford Rail Station",
+    "station_name": "Hereford",
     "latitude": 52.0611692914,
     "longitude": -2.7082118767
   },
   {
     "3alpha": "HFE",
-    "station_name": "Hertford East Rail Station",
+    "station_name": "Hertford East",
     "latitude": 51.7990391609,
     "longitude": -0.0729130019
   },
   {
     "3alpha": "HFN",
-    "station_name": "Hertford North Rail Station",
+    "station_name": "Hertford North",
     "latitude": 51.7988609689,
     "longitude": -0.0917600735
   },
   {
     "3alpha": "HFS",
-    "station_name": "Hatfield & Stainforth Rail Station",
+    "station_name": "Hatfield & Stainforth",
     "latitude": 53.5887339868,
     "longitude": -1.0233819902
   },
   {
     "3alpha": "HFX",
-    "station_name": "Halifax Rail Station",
+    "station_name": "Halifax",
     "latitude": 53.7209739882,
     "longitude": -1.853576757
   },
   {
     "3alpha": "HGD",
-    "station_name": "Hungerford Rail Station",
+    "station_name": "Hungerford",
     "latitude": 51.4149070262,
     "longitude": -1.5122717583
   },
   {
     "3alpha": "HGF",
-    "station_name": "Hag Fold Rail Station",
+    "station_name": "Hag Fold",
     "latitude": 53.5338672616,
     "longitude": -2.494821366
   },
   {
     "3alpha": "HGG",
-    "station_name": "Haggerston Rail Station",
+    "station_name": "Haggerston",
     "latitude": 51.5387053397,
     "longitude": -0.0756398309
   },
   {
     "3alpha": "HGM",
-    "station_name": "Higham Rail Station",
+    "station_name": "Higham",
     "latitude": 51.4265572516,
     "longitude": 0.4663063259
   },
   {
     "3alpha": "HGN",
-    "station_name": "Hough Green Rail Station",
+    "station_name": "Hough Green",
     "latitude": 53.3724056855,
     "longitude": -2.7750665578
   },
   {
     "3alpha": "HGR",
-    "station_name": "Hither Green Rail Station",
+    "station_name": "Hither Green",
     "latitude": 51.4520235715,
     "longitude": -0.0009184787
   },
   {
     "3alpha": "HGS",
-    "station_name": "Hastings Rail Station",
+    "station_name": "Hastings",
     "latitude": 50.8578901133,
     "longitude": 0.5767707918
   },
   {
     "3alpha": "HGT",
-    "station_name": "Harrogate Rail Station",
+    "station_name": "Harrogate",
     "latitude": 53.9931903958,
     "longitude": -1.5376134519
   },
   {
     "3alpha": "HGY",
-    "station_name": "Harringay Rail Station",
+    "station_name": "Harringay",
     "latitude": 51.577359069,
     "longitude": -0.1051105218
   },
   {
     "3alpha": "HHB",
-    "station_name": "Heysham Port Rail Station",
+    "station_name": "Heysham Port",
     "latitude": 54.0331542281,
     "longitude": -2.9131111175
   },
   {
     "3alpha": "HHD",
-    "station_name": "Holyhead Rail Station",
+    "station_name": "Holyhead",
     "latitude": 53.3076995179,
     "longitude": -4.6310080997
   },
   {
     "3alpha": "HHE",
-    "station_name": "Haywards Heath Rail Station",
+    "station_name": "Haywards Heath",
     "latitude": 51.0056759707,
     "longitude": -0.105050763
   },
   {
     "3alpha": "HHL",
-    "station_name": "Heath High Level Rail Station",
+    "station_name": "Heath High Level",
     "latitude": 51.5164298424,
     "longitude": -3.181549994
   },
   {
     "3alpha": "HHY",
-    "station_name": "Highbury & Islington Rail Station",
+    "station_name": "Highbury & Islington",
     "latitude": 51.5461777019,
     "longitude": -0.103737426
   },
   {
     "3alpha": "HIA",
-    "station_name": "Hampton-in-Arden Rail Station",
+    "station_name": "Hampton-in-Arden",
     "latitude": 52.4290462911,
     "longitude": -1.69992295
   },
   {
     "3alpha": "HIB",
-    "station_name": "High Brooms Rail Station",
+    "station_name": "High Brooms",
     "latitude": 51.1494010314,
     "longitude": 0.2773589795
   },
   {
     "3alpha": "HID",
-    "station_name": "Hall i' th' Wood Rail Station",
+    "station_name": "Hall i' th' Wood",
     "latitude": 53.5974371057,
     "longitude": -2.413107867
   },
   {
     "3alpha": "HIG",
-    "station_name": "Highbridge & Burnham-on-Sea Rail Station",
+    "station_name": "Highbridge & Burnham-on-Sea",
     "latitude": 51.2181503748,
     "longitude": -2.9721630499
   },
   {
     "3alpha": "HII",
-    "station_name": "Highbury & Islington Rail Station",
+    "station_name": "Highbury & Islington",
     "latitude": 51.5460878363,
     "longitude": -0.1037411643
   },
   {
     "3alpha": "HIL",
-    "station_name": "Hillside Rail Station",
+    "station_name": "Hillside",
     "latitude": 53.6221202826,
     "longitude": -3.0247137204
   },
   {
     "3alpha": "HIN",
-    "station_name": "Hindley Rail Station",
+    "station_name": "Hindley",
     "latitude": 53.5422508577,
     "longitude": -2.575501122
   },
   {
     "3alpha": "HIP",
-    "station_name": "Highams Park Rail Station",
+    "station_name": "Highams Park",
     "latitude": 51.6083496344,
     "longitude": -0.000196266
   },
   {
     "3alpha": "HIR",
-    "station_name": "Horton-in-Ribblesdale Rail Station",
+    "station_name": "Horton-in-Ribblesdale",
     "latitude": 54.149396209,
     "longitude": -2.3020360937
   },
   {
     "3alpha": "HIT",
-    "station_name": "Hitchin Rail Station",
+    "station_name": "Hitchin",
     "latitude": 51.9532881959,
     "longitude": -0.2634564466
   },
   {
     "3alpha": "HKC",
-    "station_name": "Hackney Central Rail Station",
+    "station_name": "Hackney Central",
     "latitude": 51.5471044422,
     "longitude": -0.0560308162
   },
   {
     "3alpha": "HKH",
-    "station_name": "Hawkhead Rail Station",
+    "station_name": "Hawkhead",
     "latitude": 55.8421839094,
     "longitude": -4.3988362292
   },
   {
     "3alpha": "HKM",
-    "station_name": "Hykeham Rail Station",
+    "station_name": "Hykeham",
     "latitude": 53.1950249324,
     "longitude": -0.6001954228
   },
   {
     "3alpha": "HKN",
-    "station_name": "Hucknall Rail Station",
+    "station_name": "Hucknall",
     "latitude": 53.0383014288,
     "longitude": -1.1958079305
   },
   {
     "3alpha": "HKW",
-    "station_name": "Hackney Wick Rail Station",
+    "station_name": "Hackney Wick",
     "latitude": 51.5434103591,
     "longitude": -0.0248923154
   },
   {
     "3alpha": "HLB",
-    "station_name": "Hildenborough Rail Station",
+    "station_name": "Hildenborough",
     "latitude": 51.2144822954,
     "longitude": 0.227617147
   },
   {
     "3alpha": "HLC",
-    "station_name": "Helensburgh Central Rail Station",
+    "station_name": "Helensburgh Central",
     "latitude": 56.0041995399,
     "longitude": -4.7327385924
   },
   {
     "3alpha": "HLD",
-    "station_name": "Hellifield Rail Station",
+    "station_name": "Hellifield",
     "latitude": 54.0108742019,
     "longitude": -2.2278480504
   },
   {
     "3alpha": "HLE",
-    "station_name": "Hillington East Rail Station",
+    "station_name": "Hillington East",
     "latitude": 55.8541758548,
     "longitude": -4.3549953963
   },
   {
     "3alpha": "HLF",
-    "station_name": "Hillfoot Rail Station",
+    "station_name": "Hillfoot",
     "latitude": 55.9200849636,
     "longitude": -4.3202587624
   },
   {
     "3alpha": "HLG",
-    "station_name": "Hall Green Rail Station",
+    "station_name": "Hall Green",
     "latitude": 52.4369222096,
     "longitude": -1.8456449276
   },
   {
     "3alpha": "HLI",
-    "station_name": "Healing Rail Station",
+    "station_name": "Healing",
     "latitude": 53.5818205021,
     "longitude": -0.1606345765
   },
   {
     "3alpha": "HLL",
-    "station_name": "Heath Low Level Rail Station",
+    "station_name": "Heath Low Level",
     "latitude": 51.5156612205,
     "longitude": -3.1819768215
   },
   {
     "3alpha": "HLM",
-    "station_name": "Holmwood Rail Station",
+    "station_name": "Holmwood",
     "latitude": 51.1811903162,
     "longitude": -0.3207835997
   },
   {
     "3alpha": "HLN",
-    "station_name": "Harlington (Beds) Rail Station",
+    "station_name": "Harlington (Beds)",
     "latitude": 51.9620697513,
     "longitude": -0.4956650065
   },
   {
     "3alpha": "HLR",
-    "station_name": "Hall Road Rail Station",
+    "station_name": "Hall Road",
     "latitude": 53.4975007979,
     "longitude": -3.049624671
   },
   {
     "3alpha": "HLS",
-    "station_name": "Hilsea Rail Station",
+    "station_name": "Hilsea",
     "latitude": 50.828264455,
     "longitude": -1.0587831528
   },
   {
     "3alpha": "HLU",
-    "station_name": "Helensburgh Upper Rail Station",
+    "station_name": "Helensburgh Upper",
     "latitude": 56.0123545737,
     "longitude": -4.7297849071
   },
   {
     "3alpha": "HLW",
-    "station_name": "Hillington West Rail Station",
+    "station_name": "Hillington West",
     "latitude": 55.8560145655,
     "longitude": -4.3715655801
   },
   {
     "3alpha": "HLY",
-    "station_name": "Holytown Rail Station",
+    "station_name": "Holytown",
     "latitude": 55.8128931888,
     "longitude": -3.9739183285
   },
   {
     "3alpha": "HMC",
-    "station_name": "Hampton Court Rail Station",
+    "station_name": "Hampton Court",
     "latitude": 51.402553453,
     "longitude": -0.3427264701
   },
   {
     "3alpha": "HMD",
-    "station_name": "Hampden Park (Sussex) Rail Station",
+    "station_name": "Hampden Park (Sussex)",
     "latitude": 50.7963992867,
     "longitude": 0.2793840646
   },
   {
     "3alpha": "HME",
-    "station_name": "Hamble Rail Station",
+    "station_name": "Hamble",
     "latitude": 50.8713629565,
     "longitude": -1.3291521514
   },
   {
     "3alpha": "HML",
-    "station_name": "Hemel Hempstead Rail Station",
+    "station_name": "Hemel Hempstead",
     "latitude": 51.7423380827,
     "longitude": -0.4907522249
   },
   {
     "3alpha": "HMM",
-    "station_name": "Hammerton Rail Station",
+    "station_name": "Hammerton",
     "latitude": 53.9963447909,
     "longitude": -1.2841021471
   },
   {
     "3alpha": "HMN",
-    "station_name": "Homerton Rail Station",
+    "station_name": "Homerton",
     "latitude": 51.547011697,
     "longitude": -0.0423325837
   },
   {
     "3alpha": "HMP",
-    "station_name": "Hampton (London) Rail Station",
+    "station_name": "Hampton (London)",
     "latitude": 51.415932868,
     "longitude": -0.3720976323
   },
   {
     "3alpha": "HMS",
-    "station_name": "Helmsdale Rail Station",
+    "station_name": "Helmsdale",
     "latitude": 58.1174231841,
     "longitude": -3.6586930118
   },
   {
     "3alpha": "HMT",
-    "station_name": "Ham Street Rail Station",
+    "station_name": "Ham Street",
     "latitude": 51.0683758331,
     "longitude": 0.8545396144
   },
   {
     "3alpha": "HMW",
-    "station_name": "Hampton Wick Rail Station",
+    "station_name": "Hampton Wick",
     "latitude": 51.414522516,
     "longitude": -0.3124680243
   },
   {
     "3alpha": "HMY",
-    "station_name": "Hairmyres Rail Station",
+    "station_name": "Hairmyres",
     "latitude": 55.761959437,
     "longitude": -4.2199969848
   },
   {
     "3alpha": "HNA",
-    "station_name": "Hinton Admiral Rail Station",
+    "station_name": "Hinton Admiral",
     "latitude": 50.7526280082,
     "longitude": -1.7141197084
   },
   {
     "3alpha": "HNB",
-    "station_name": "Herne Bay Rail Station",
+    "station_name": "Herne Bay",
     "latitude": 51.364595492,
     "longitude": 1.1177553962
   },
   {
     "3alpha": "HNC",
-    "station_name": "Hamilton Central Rail Station",
+    "station_name": "Hamilton Central",
     "latitude": 55.7731886703,
     "longitude": -4.0388743726
   },
   {
     "3alpha": "HND",
-    "station_name": "Hanborough Rail Station",
+    "station_name": "Hanborough",
     "latitude": 51.8251625822,
     "longitude": -1.3735084455
   },
   {
     "3alpha": "HNF",
-    "station_name": "Hednesford Rail Station",
+    "station_name": "Hednesford",
     "latitude": 52.7101262196,
     "longitude": -2.0017747098
   },
   {
     "3alpha": "HNG",
-    "station_name": "Hengoed Rail Station",
+    "station_name": "Hengoed",
     "latitude": 51.6474099206,
     "longitude": -3.2241373274
   },
   {
     "3alpha": "HNH",
-    "station_name": "Herne Hill Rail Station",
+    "station_name": "Herne Hill",
     "latitude": 51.4533037255,
     "longitude": -0.102263463
   },
   {
     "3alpha": "HNK",
-    "station_name": "Hinckley Rail Station",
+    "station_name": "Hinckley",
     "latitude": 52.5350144159,
     "longitude": -1.3719130606
   },
   {
     "3alpha": "HNL",
-    "station_name": "Henley-in-Arden Rail Station",
+    "station_name": "Henley-in-Arden",
     "latitude": 52.2915002317,
     "longitude": -1.7839820888
   },
   {
     "3alpha": "HNT",
-    "station_name": "Huntly Rail Station",
+    "station_name": "Huntly",
     "latitude": 57.4444716353,
     "longitude": -2.7757412945
   },
   {
     "3alpha": "HNW",
-    "station_name": "Hamilton West Rail Station",
+    "station_name": "Hamilton West",
     "latitude": 55.7788548735,
     "longitude": -4.0547968763
   },
   {
     "3alpha": "HNX",
-    "station_name": "Hunts Cross Rail Station",
+    "station_name": "Hunts Cross",
     "latitude": 53.3607253407,
     "longitude": -2.8558609579
   },
   {
     "3alpha": "HOC",
-    "station_name": "Hockley Rail Station",
+    "station_name": "Hockley",
     "latitude": 51.6035599652,
     "longitude": 0.6590284828
   },
   {
     "3alpha": "HOH",
-    "station_name": "Harrow-on-the-Hill Rail Station",
+    "station_name": "Harrow-on-the-Hill",
     "latitude": 51.5791855381,
     "longitude": -0.3372032129
   },
   {
     "3alpha": "HOK",
-    "station_name": "Hook Rail Station",
+    "station_name": "Hook",
     "latitude": 51.279996325,
     "longitude": -0.9616187573
   },
   {
     "3alpha": "HOL",
-    "station_name": "Holton Heath Rail Station",
+    "station_name": "Holton Heath",
     "latitude": 50.7113964673,
     "longitude": -2.0778391092
   },
   {
     "3alpha": "HON",
-    "station_name": "Honiton Rail Station",
+    "station_name": "Honiton",
     "latitude": 50.7965702123,
     "longitude": -3.1867284121
   },
   {
     "3alpha": "HOO",
-    "station_name": "Hooton Rail Station",
+    "station_name": "Hooton",
     "latitude": 53.2972130919,
     "longitude": -2.9770090629
   },
   {
     "3alpha": "HOP",
-    "station_name": "Hope (Derbyshire) Rail Station",
+    "station_name": "Hope (Derbyshire)",
     "latitude": 53.3461251048,
     "longitude": -1.7298854225
   },
   {
     "3alpha": "HOR",
-    "station_name": "Horley Rail Station",
+    "station_name": "Horley",
     "latitude": 51.1687701925,
     "longitude": -0.1610261883
   },
   {
     "3alpha": "HOT",
-    "station_name": "Henley-on-Thames Rail Station",
+    "station_name": "Henley-on-Thames",
     "latitude": 51.5341810915,
     "longitude": -0.9001927563
   },
   {
     "3alpha": "HOU",
-    "station_name": "Hounslow Rail Station",
+    "station_name": "Hounslow",
     "latitude": 51.4619441377,
     "longitude": -0.3622557388
   },
   {
     "3alpha": "HOV",
-    "station_name": "Hove Rail Station",
+    "station_name": "Hove",
     "latitude": 50.8352085815,
     "longitude": -0.1706597369
   },
   {
     "3alpha": "HOW",
-    "station_name": "Howden Rail Station",
+    "station_name": "Howden",
     "latitude": 53.7647299348,
     "longitude": -0.8604679516
   },
   {
     "3alpha": "HOX",
-    "station_name": "Hoxton Rail Station",
+    "station_name": "Hoxton",
     "latitude": 51.5315115893,
     "longitude": -0.075655026
   },
   {
     "3alpha": "HOY",
-    "station_name": "Honley Rail Station",
+    "station_name": "Honley",
     "latitude": 53.6082419978,
     "longitude": -1.7809663313
   },
   {
     "3alpha": "HOZ",
-    "station_name": "Howwood (Renfrewshire) Rail Station",
+    "station_name": "Howwood (Renfrewshire)",
     "latitude": 55.8105581084,
     "longitude": -4.5630406539
   },
   {
     "3alpha": "HPA",
-    "station_name": "Honor Oak Park Rail Station",
+    "station_name": "Honor Oak Park",
     "latitude": 51.4499871094,
     "longitude": -0.0454798264
   },
   {
     "3alpha": "HPD",
-    "station_name": "Harpenden Rail Station",
+    "station_name": "Harpenden",
     "latitude": 51.8146501449,
     "longitude": -0.3514563418
   },
   {
     "3alpha": "HPE",
-    "station_name": "Hope (Flintshire) Rail Station",
+    "station_name": "Hope (Flintshire)",
     "latitude": 53.117371815,
     "longitude": -3.03687622
   },
   {
     "3alpha": "HPL",
-    "station_name": "Hartlepool Rail Station",
+    "station_name": "Hartlepool",
     "latitude": 54.6867644231,
     "longitude": -1.2073308234
   },
   {
     "3alpha": "HPN",
-    "station_name": "Hapton Rail Station",
+    "station_name": "Hapton",
     "latitude": 53.7816268971,
     "longitude": -2.3169116789
   },
   {
     "3alpha": "HPQ",
-    "station_name": "Harwich International Rail Station",
+    "station_name": "Harwich International",
     "latitude": 51.9473012514,
     "longitude": 1.2551547397
   },
   {
     "3alpha": "HPT",
-    "station_name": "Hopton Heath Rail Station",
+    "station_name": "Hopton Heath",
     "latitude": 52.3914278931,
     "longitude": -2.9120578549
   },
   {
     "3alpha": "HRD",
-    "station_name": "Harling Road Rail Station",
+    "station_name": "Harling Road",
     "latitude": 52.4537084708,
     "longitude": 0.9091672143
   },
   {
+    "3alpha":"HRE",
+    "station_name":"Horden",
+    "latitude": 54.763879,
+    "longitude":-1.307347
+  },
+  {
     "3alpha": "HRH",
-    "station_name": "Horsham Rail Station",
+    "station_name": "Horsham",
     "latitude": 51.0660592013,
     "longitude": -0.3192431154
   },
   {
     "3alpha": "HRL",
-    "station_name": "Harlech Rail Station",
+    "station_name": "Harlech",
     "latitude": 52.8613425321,
     "longitude": -4.1091973982
   },
   {
     "3alpha": "HRM",
-    "station_name": "Harrietsham Rail Station",
+    "station_name": "Harrietsham",
     "latitude": 51.2448308208,
     "longitude": 0.6724297963
   },
   {
     "3alpha": "HRN",
-    "station_name": "Hornsey Rail Station",
+    "station_name": "Hornsey",
     "latitude": 51.5864618559,
     "longitude": -0.1119495944
   },
   {
     "3alpha": "HRO",
-    "station_name": "Harold Wood Rail Station",
+    "station_name": "Harold Wood",
     "latitude": 51.592766307,
     "longitude": 0.2331539888
   },
   {
     "3alpha": "HRR",
-    "station_name": "Harrington Rail Station",
+    "station_name": "Harrington",
     "latitude": 54.6134911874,
     "longitude": -3.5655149544
   },
   {
     "3alpha": "HRS",
-    "station_name": "Horsforth Rail Station",
+    "station_name": "Horsforth",
     "latitude": 53.8477194776,
     "longitude": -1.6302327899
   },
   {
     "3alpha": "HRW",
-    "station_name": "Harrow & Wealdstone Rail Station",
+    "station_name": "Harrow & Wealdstone",
     "latitude": 51.5921690735,
     "longitude": -0.3345489082
   },
   {
     "3alpha": "HRY",
-    "station_name": "Harringay Green Lanes Rail Station",
+    "station_name": "Harringay Green Lanes",
     "latitude": 51.5771828877,
     "longitude": -0.0981182196
   },
   {
     "3alpha": "HSB",
-    "station_name": "Helsby Rail Station",
+    "station_name": "Helsby",
     "latitude": 53.2752149638,
     "longitude": -2.7712062956
   },
   {
     "3alpha": "HSC",
-    "station_name": "Hoscar Rail Station",
+    "station_name": "Hoscar",
     "latitude": 53.5977824276,
     "longitude": -2.8044204789
   },
   {
     "3alpha": "HSD",
-    "station_name": "Hamstead (Birmingham) Rail Station",
+    "station_name": "Hamstead (Birmingham)",
     "latitude": 52.5310822389,
     "longitude": -1.9289728746
   },
   {
     "3alpha": "HSG",
-    "station_name": "Hathersage Rail Station",
+    "station_name": "Hathersage",
     "latitude": 53.3257885551,
     "longitude": -1.6517174825
   },
   {
     "3alpha": "HSK",
-    "station_name": "Hassocks Rail Station",
+    "station_name": "Hassocks",
     "latitude": 50.9246090606,
     "longitude": -0.1459258012
   },
   {
     "3alpha": "HSL",
-    "station_name": "Haslemere Rail Station",
+    "station_name": "Haslemere",
     "latitude": 51.0886414366,
     "longitude": -0.7191423803
   },
   {
     "3alpha": "HST",
-    "station_name": "High Street (Glasgow) Rail Station",
+    "station_name": "High Street (Glasgow)",
     "latitude": 55.8595578077,
     "longitude": -4.2401039264
   },
   {
     "3alpha": "HSW",
-    "station_name": "Heswall Rail Station",
+    "station_name": "Heswall",
     "latitude": 53.329731232,
     "longitude": -3.073702346
   },
   {
     "3alpha": "HSY",
-    "station_name": "Horsley Rail Station",
+    "station_name": "Horsley",
     "latitude": 51.2793430837,
     "longitude": -0.4353859424
   },
   {
     "3alpha": "HTC",
-    "station_name": "Heaton Chapel Rail Station",
+    "station_name": "Heaton Chapel",
     "latitude": 53.4255745892,
     "longitude": -2.1790400211
   },
   {
     "3alpha": "HTE",
-    "station_name": "Hatch End Rail Station",
+    "station_name": "Hatch End",
     "latitude": 51.609418318,
     "longitude": -0.3685792009
   },
   {
     "3alpha": "HTF",
-    "station_name": "Hartford Rail Station",
+    "station_name": "Hartford",
     "latitude": 53.2417720752,
     "longitude": -2.5536278419
   },
   {
     "3alpha": "HTH",
-    "station_name": "Handforth Rail Station",
+    "station_name": "Handforth",
     "latitude": 53.3465081231,
     "longitude": -2.2136326157
   },
   {
     "3alpha": "HTN",
-    "station_name": "Hatton (Warks) Rail Station",
+    "station_name": "Hatton (Warks)",
     "latitude": 52.2952909349,
     "longitude": -1.6729642026
   },
   {
     "3alpha": "HTO",
-    "station_name": "Hightown Rail Station",
+    "station_name": "Hightown",
     "latitude": 53.5251206717,
     "longitude": -3.0570655927
   },
@@ -7129,91 +7171,91 @@
   },
   {
     "3alpha": "HTW",
-    "station_name": "Hartwood Rail Station",
+    "station_name": "Hartwood",
     "latitude": 55.8114760965,
     "longitude": -3.8393119766
   },
   {
     "3alpha": "HTY",
-    "station_name": "Hattersley Rail Station",
+    "station_name": "Hattersley",
     "latitude": 53.4452970666,
     "longitude": -2.0403099081
   },
   {
     "3alpha": "HUB",
-    "station_name": "Hunmanby Rail Station",
+    "station_name": "Hunmanby",
     "latitude": 54.1739432859,
     "longitude": -0.3145719426
   },
   {
     "3alpha": "HUD",
-    "station_name": "Huddersfield Rail Station",
+    "station_name": "Huddersfield",
     "latitude": 53.6485157907,
     "longitude": -1.7846917017
   },
   {
     "3alpha": "HUL",
-    "station_name": "Hull Rail Station",
+    "station_name": "Hull",
     "latitude": 53.7441695387,
     "longitude": -0.3456862671
   },
   {
     "3alpha": "HUN",
-    "station_name": "Huntingdon Rail Station",
+    "station_name": "Huntingdon",
     "latitude": 52.3286615315,
     "longitude": -0.1920472657
   },
   {
     "3alpha": "HUP",
-    "station_name": "Humphrey Park Rail Station",
+    "station_name": "Humphrey Park",
     "latitude": 53.4522431612,
     "longitude": -2.3275376643
   },
   {
     "3alpha": "HUR",
-    "station_name": "Hurst Green Rail Station",
+    "station_name": "Hurst Green",
     "latitude": 51.2444268856,
     "longitude": 0.0039654468
   },
   {
     "3alpha": "HUT",
-    "station_name": "Hutton Cranswick Rail Station",
+    "station_name": "Hutton Cranswick",
     "latitude": 53.9558737241,
     "longitude": -0.433871592
   },
   {
     "3alpha": "HUY",
-    "station_name": "Huyton Rail Station",
+    "station_name": "Huyton",
     "latitude": 53.4096981525,
     "longitude": -2.8429886413
   },
   {
     "3alpha": "HVF",
-    "station_name": "Haverfordwest Rail Station",
+    "station_name": "Haverfordwest",
     "latitude": 51.8026432765,
     "longitude": -4.960235795
   },
   {
     "3alpha": "HVN",
-    "station_name": "Havenhouse Rail Station",
+    "station_name": "Havenhouse",
     "latitude": 53.1144941819,
     "longitude": 0.2731698815
   },
   {
     "3alpha": "HWB",
-    "station_name": "Hawarden Bridge Rail Station",
+    "station_name": "Hawarden Bridge",
     "latitude": 53.2180881941,
     "longitude": -3.0327167308
   },
   {
     "3alpha": "HWC",
-    "station_name": "Harwich Town Rail Station",
+    "station_name": "Harwich Town",
     "latitude": 51.9441574404,
     "longitude": 1.2867119437
   },
   {
     "3alpha": "HWD",
-    "station_name": "Hawarden Rail Station",
+    "station_name": "Hawarden",
     "latitude": 53.1853727789,
     "longitude": -3.0320807812
   },
@@ -7225,37 +7267,37 @@
   },
   {
     "3alpha": "HWH",
-    "station_name": "Haltwhistle Rail Station",
+    "station_name": "Haltwhistle",
     "latitude": 54.9678535356,
     "longitude": -2.4635724781
   },
   {
     "3alpha": "HWI",
-    "station_name": "Horwich Parkway Rail Station",
+    "station_name": "Horwich Parkway",
     "latitude": 53.5781205097,
     "longitude": -2.5396661144
   },
   {
     "3alpha": "HWM",
-    "station_name": "Harlow Mill Rail Station",
+    "station_name": "Harlow Mill",
     "latitude": 51.7903700355,
     "longitude": 0.1323343315
   },
   {
     "3alpha": "HWN",
-    "station_name": "Harlow Town Rail Station",
+    "station_name": "Harlow Town",
     "latitude": 51.7810744782,
     "longitude": 0.0951587231
   },
   {
     "3alpha": "HWV",
-    "station_name": "Heathrow Terminal 5 Rail Station",
+    "station_name": "Heathrow Terminal 5",
     "latitude": 51.4700517143,
     "longitude": -0.490569702
   },
   {
     "3alpha": "HWW",
-    "station_name": "How Wood (Herts) Rail Station",
+    "station_name": "How Wood (Herts)",
     "latitude": 51.7177454662,
     "longitude": -0.344647203
   },
@@ -7267,1939 +7309,1957 @@
   },
   {
     "3alpha": "HWY",
-    "station_name": "High Wycombe Rail Station",
+    "station_name": "High Wycombe",
     "latitude": 51.6295875603,
     "longitude": -0.7453905204
   },
   {
     "3alpha": "HXM",
-    "station_name": "Hoveton & Wroxham Rail Station",
+    "station_name": "Hoveton & Wroxham",
     "latitude": 52.715595961,
     "longitude": 1.4080190978
   },
   {
     "3alpha": "HYB",
-    "station_name": "Honeybourne Rail Station",
+    "station_name": "Honeybourne",
     "latitude": 52.1016109574,
     "longitude": -1.8337328413
   },
   {
     "3alpha": "HYC",
-    "station_name": "Hyde Central Rail Station",
+    "station_name": "Hyde Central",
     "latitude": 53.451897881,
     "longitude": -2.0852494833
   },
   {
     "3alpha": "HYD",
-    "station_name": "Heyford Rail Station",
+    "station_name": "Heyford",
     "latitude": 51.9191971629,
     "longitude": -1.2992524985
   },
   {
     "3alpha": "HYH",
-    "station_name": "Hythe (Essex) Rail Station",
+    "station_name": "Hythe (Essex)",
     "latitude": 51.885649004,
     "longitude": 0.9275572674
   },
   {
     "3alpha": "HYK",
-    "station_name": "Hoylake Rail Station",
+    "station_name": "Hoylake",
     "latitude": 53.3902262538,
     "longitude": -3.1788295823
   },
   {
     "3alpha": "HYL",
-    "station_name": "Hayle Rail Station",
+    "station_name": "Hayle",
     "latitude": 50.1855516133,
     "longitude": -5.4198876444
   },
   {
     "3alpha": "HYM",
-    "station_name": "Haymarket Rail Station",
+    "station_name": "Haymarket",
     "latitude": 55.9458020856,
     "longitude": -3.2184499798
   },
   {
     "3alpha": "HYN",
-    "station_name": "Hyndland Rail Station",
+    "station_name": "Hyndland",
     "latitude": 55.8797471979,
     "longitude": -4.314653649
   },
   {
     "3alpha": "HYR",
-    "station_name": "Haydons Road Rail Station",
+    "station_name": "Haydons Road",
     "latitude": 51.4254457568,
     "longitude": -0.188790104
   },
   {
     "3alpha": "HYS",
-    "station_name": "Hayes (Kent) Rail Station",
+    "station_name": "Hayes (Kent)",
     "latitude": 51.376332397,
     "longitude": 0.0105837729
   },
   {
     "3alpha": "HYT",
-    "station_name": "Hyde North Rail Station",
+    "station_name": "Hyde North",
     "latitude": 53.4648142912,
     "longitude": -2.0854568359
   },
   {
     "3alpha": "HYW",
-    "station_name": "Hinchley Wood Rail Station",
+    "station_name": "Hinchley Wood",
     "latitude": 51.3749950976,
     "longitude": -0.3405015776
   },
   {
     "3alpha": "IBM",
-    "station_name": "IBM (Greenock) Rail Station",
+    "station_name": "IBM (Greenock)",
     "latitude": 55.9294397123,
     "longitude": -4.8272199389
   },
   {
     "3alpha": "IFD",
-    "station_name": "Ilford Rail Station",
+    "station_name": "Ilford",
     "latitude": 51.5591169252,
     "longitude": 0.0697060332
   },
   {
     "3alpha": "IFI",
-    "station_name": "Ifield Rail Station",
+    "station_name": "Ifield",
     "latitude": 51.115616552,
     "longitude": -0.214744158
   },
   {
     "3alpha": "IGD",
-    "station_name": "Invergordon Rail Station",
+    "station_name": "Invergordon",
     "latitude": 57.6890013885,
     "longitude": -4.1748401883
   },
   {
     "3alpha": "ILK",
-    "station_name": "Ilkley Rail Station",
+    "station_name": "Ilkley",
     "latitude": 53.9247771648,
     "longitude": -1.822030732
   },
   {
     "3alpha": "ILN",
-    "station_name": "Ilkeston Rail Station",
+    "station_name": "Ilkeston",
     "latitude": 52.9796097784,
     "longitude": -1.2949283917
   },
   {
     "3alpha": "IMW",
-    "station_name": "Imperial Wharf Rail Station",
+    "station_name": "Imperial Wharf",
     "latitude": 51.4749481734,
     "longitude": -0.1827985374
   },
   {
     "3alpha": "INC",
-    "station_name": "Ince (Manchester) Rail Station",
+    "station_name": "Ince (Manchester)",
     "latitude": 53.5389257232,
     "longitude": -2.6115187679
   },
   {
     "3alpha": "INE",
-    "station_name": "Ince & Elton Rail Station",
+    "station_name": "Ince & Elton",
     "latitude": 53.2766213459,
     "longitude": -2.8165221852
   },
   {
     "3alpha": "ING",
-    "station_name": "Invergowrie Rail Station",
+    "station_name": "Invergowrie",
     "latitude": 56.4564629346,
     "longitude": -3.0574006479
   },
   {
     "3alpha": "INH",
-    "station_name": "Invershin Rail Station",
+    "station_name": "Invershin",
     "latitude": 57.9248506817,
     "longitude": -4.3994794892
   },
   {
     "3alpha": "INK",
-    "station_name": "Inverkeithing Rail Station",
+    "station_name": "Inverkeithing",
     "latitude": 56.0346707647,
     "longitude": -3.3961851331
   },
   {
     "3alpha": "INP",
-    "station_name": "Inverkip Rail Station",
+    "station_name": "Inverkip",
     "latitude": 55.906097486,
     "longitude": -4.8725658517
   },
   {
     "3alpha": "INR",
-    "station_name": "Inverurie Rail Station",
+    "station_name": "Inverurie",
     "latitude": 57.2862510473,
     "longitude": -2.3735646839
   },
   {
     "3alpha": "INS",
-    "station_name": "Insch Rail Station",
+    "station_name": "Insch",
     "latitude": 57.3374826347,
     "longitude": -2.6171148112
   },
   {
     "3alpha": "INT",
-    "station_name": "Ingatestone Rail Station",
+    "station_name": "Ingatestone",
     "latitude": 51.6670448119,
     "longitude": 0.3842732713
   },
   {
     "3alpha": "INV",
-    "station_name": "Inverness Rail Station",
+    "station_name": "Inverness",
     "latitude": 57.4798523576,
     "longitude": -4.2233591954
   },
   {
     "3alpha": "IPS",
-    "station_name": "Ipswich Rail Station",
+    "station_name": "Ipswich",
     "latitude": 52.050605185,
     "longitude": 1.1444561195
   },
   {
     "3alpha": "IRL",
-    "station_name": "Irlam Rail Station",
+    "station_name": "Irlam",
     "latitude": 53.4343243953,
     "longitude": -2.4332290912
   },
   {
     "3alpha": "IRV",
-    "station_name": "Irvine Rail Station",
+    "station_name": "Irvine",
     "latitude": 55.610870787,
     "longitude": -4.6751248885
   },
   {
     "3alpha": "ISL",
-    "station_name": "Isleworth Rail Station",
+    "station_name": "Isleworth",
     "latitude": 51.4747609931,
     "longitude": -0.3368852384
   },
   {
     "3alpha": "ISP",
-    "station_name": "Islip Rail Station",
+    "station_name": "Islip",
     "latitude": 51.8257581652,
     "longitude": -1.2381632634
   },
   {
+    "3alpha": "IVA",
+    "station_name": "Inverness Airport",
+    "latitude": 57.5335,
+    "longitude": -4.0552
+  },
+  {
     "3alpha": "IVR",
-    "station_name": "Iver Rail Station",
+    "station_name": "Iver",
     "latitude": 51.5085027345,
     "longitude": -0.5067065231
   },
   {
     "3alpha": "IVY",
-    "station_name": "Ivybridge Rail Station",
+    "station_name": "Ivybridge",
     "latitude": 50.3933952288,
     "longitude": -3.9042285416
   },
   {
     "3alpha": "JCH",
-    "station_name": "James Cook University Hospital Rail Station",
+    "station_name": "James Cook University Hospital",
     "latitude": 54.552041983,
     "longitude": -1.2085837079
   },
   {
     "3alpha": "JEQ",
-    "station_name": "Jewellery Quarter Rail Station",
+    "station_name": "Jewellery Quarter",
     "latitude": 52.489447723,
     "longitude": -1.9132076451
   },
   {
     "3alpha": "JHN",
-    "station_name": "Johnstone Rail Station",
+    "station_name": "Johnstone",
     "latitude": 55.8347024844,
     "longitude": -4.5036207425
   },
   {
     "3alpha": "JOH",
-    "station_name": "Johnston (Pembrokeshire) Rail Station",
+    "station_name": "Johnston (Pembrokeshire)",
     "latitude": 51.7567579295,
     "longitude": -4.9963630908
   },
   {
     "3alpha": "JOR",
-    "station_name": "Jordanhill Rail Station",
+    "station_name": "Jordanhill",
     "latitude": 55.882699515,
     "longitude": -4.3249029293
   },
   {
     "3alpha": "KBC",
-    "station_name": "Kinbrace Rail Station",
+    "station_name": "Kinbrace",
     "latitude": 58.2582968272,
     "longitude": -3.9412133227
   },
   {
     "3alpha": "KBF",
-    "station_name": "Kirkby-in-Furness Rail Station",
+    "station_name": "Kirkby-in-Furness",
     "latitude": 54.2327161445,
     "longitude": -3.1873760397
   },
   {
     "3alpha": "KBK",
-    "station_name": "Kents Bank Rail Station",
+    "station_name": "Kents Bank",
     "latitude": 54.172910528,
     "longitude": -2.9252290041
   },
   {
     "3alpha": "KBN",
-    "station_name": "Kilburn High Road Rail Station",
+    "station_name": "Kilburn High Road",
     "latitude": 51.5372777601,
     "longitude": -0.1922126859
   },
   {
     "3alpha": "KBW",
-    "station_name": "Knebworth Rail Station",
+    "station_name": "Knebworth",
     "latitude": 51.8668603588,
     "longitude": -0.1872649131
   },
   {
     "3alpha": "KBX",
-    "station_name": "Kirby Cross Rail Station",
+    "station_name": "Kirby Cross",
     "latitude": 51.841408258,
     "longitude": 1.2150236403
   },
   {
     "3alpha": "KCK",
-    "station_name": "Knockholt Rail Station",
+    "station_name": "Knockholt",
     "latitude": 51.3457884371,
     "longitude": 0.1308739721
   },
   {
     "3alpha": "KDB",
-    "station_name": "Kidbrooke Rail Station",
+    "station_name": "Kidbrooke",
     "latitude": 51.4621199896,
     "longitude": 0.0275232797
   },
   {
     "3alpha": "KDG",
-    "station_name": "Kidsgrove Rail Station",
+    "station_name": "Kidsgrove",
     "latitude": 53.0865804703,
     "longitude": -2.2448159035
   },
   {
     "3alpha": "KDY",
-    "station_name": "Kirkcaldy Rail Station",
+    "station_name": "Kirkcaldy",
     "latitude": 56.1120505901,
     "longitude": -3.1670300049
   },
   {
     "3alpha": "KEH",
-    "station_name": "Keith Rail Station",
+    "station_name": "Keith",
     "latitude": 57.5508815659,
     "longitude": -2.9540692665
   },
   {
     "3alpha": "KEI",
-    "station_name": "Keighley Rail Station",
+    "station_name": "Keighley",
     "latitude": 53.8679755061,
     "longitude": -1.9016526329
   },
   {
     "3alpha": "KEL",
-    "station_name": "Kelvedon Rail Station",
+    "station_name": "Kelvedon",
     "latitude": 51.8407101631,
     "longitude": 0.7024132856
   },
   {
     "3alpha": "KEM",
-    "station_name": "Kemble Rail Station",
+    "station_name": "Kemble",
     "latitude": 51.6769974883,
     "longitude": -2.0228096226
   },
   {
     "3alpha": "KEN",
-    "station_name": "Kendal Rail Station",
+    "station_name": "Kendal",
     "latitude": 54.3321036266,
     "longitude": -2.7396488466
   },
   {
     "3alpha": "KET",
-    "station_name": "Kettering Rail Station",
+    "station_name": "Kettering",
     "latitude": 52.3935680461,
     "longitude": -0.7315471328
   },
   {
     "3alpha": "KEY",
-    "station_name": "Keyham Rail Station",
+    "station_name": "Keyham",
     "latitude": 50.3898643425,
     "longitude": -4.1796285768
   },
   {
     "3alpha": "KGE",
-    "station_name": "Kingsknowe Rail Station",
+    "station_name": "Kingsknowe",
     "latitude": 55.9188071296,
     "longitude": -3.2649651648
   },
   {
     "3alpha": "KGH",
-    "station_name": "Kinghorn Rail Station",
+    "station_name": "Kinghorn",
     "latitude": 56.0693308155,
     "longitude": -3.1741555055
   },
   {
     "3alpha": "KGL",
-    "station_name": "Kings Langley Rail Station",
+    "station_name": "Kings Langley",
     "latitude": 51.7063602029,
     "longitude": -0.4384002341
   },
   {
     "3alpha": "KGM",
-    "station_name": "Kingham Rail Station",
+    "station_name": "Kingham",
     "latitude": 51.9022564168,
     "longitude": -1.6287732881
   },
   {
     "3alpha": "KGN",
-    "station_name": "Kings Nympton Rail Station",
+    "station_name": "Kings Nympton",
     "latitude": 50.936065096,
     "longitude": -3.9054316221
   },
   {
     "3alpha": "KGP",
-    "station_name": "Kings Park Rail Station",
+    "station_name": "Kings Park",
     "latitude": 55.8195373532,
     "longitude": -4.2465028963
   },
   {
     "3alpha": "KGS",
-    "station_name": "Kings Sutton Rail Station",
+    "station_name": "Kings Sutton",
     "latitude": 52.021359878,
     "longitude": -1.2809139108
   },
   {
     "3alpha": "KGT",
-    "station_name": "Kilgetty Rail Station",
+    "station_name": "Kilgetty",
     "latitude": 51.7321146696,
     "longitude": -4.7151861813
   },
   {
     "3alpha": "KGX",
-    "station_name": "London Kings Cross Rail Station",
+    "station_name": "London Kings Cross",
     "latitude": 51.5308836375,
     "longitude": -0.1229002946
   },
   {
     "3alpha": "KID",
-    "station_name": "Kidderminster Rail Station",
+    "station_name": "Kidderminster",
     "latitude": 52.3844946608,
     "longitude": -2.2384665613
   },
   {
     "3alpha": "KIL",
-    "station_name": "Kildonan Rail Station",
+    "station_name": "Kildonan",
     "latitude": 58.1707935283,
     "longitude": -3.8691107621
   },
   {
     "3alpha": "KIN",
-    "station_name": "Kingussie Rail Station",
+    "station_name": "Kingussie",
     "latitude": 57.0777663698,
     "longitude": -4.0521889967
   },
   {
     "3alpha": "KIR",
-    "station_name": "Kirkby Rail Station",
+    "station_name": "Kirkby",
     "latitude": 53.4862048537,
     "longitude": -2.9028281809
   },
   {
     "3alpha": "KIT",
-    "station_name": "Kintbury Rail Station",
+    "station_name": "Kintbury",
     "latitude": 51.4025186724,
     "longitude": -1.4459730106
   },
   {
     "3alpha": "KIV",
-    "station_name": "Kiveton Bridge Rail Station",
+    "station_name": "Kiveton Bridge",
     "latitude": 53.3409764694,
     "longitude": -1.2671800273
   },
   {
     "3alpha": "KKB",
-    "station_name": "Kirkby in Ashfield Rail Station",
+    "station_name": "Kirkby in Ashfield",
     "latitude": 53.1001156743,
     "longitude": -1.2530543087
   },
   {
     "3alpha": "KKD",
-    "station_name": "Kirkdale Rail Station",
+    "station_name": "Kirkdale",
     "latitude": 53.4409136231,
     "longitude": -2.9811163636
   },
   {
     "3alpha": "KKH",
-    "station_name": "Kirkhill Rail Station",
+    "station_name": "Kirkhill",
     "latitude": 55.8139079243,
     "longitude": -4.1670911014
   },
   {
     "3alpha": "KKM",
-    "station_name": "Kirkham & Wesham Rail Station",
+    "station_name": "Kirkham & Wesham",
     "latitude": 53.7869285701,
     "longitude": -2.8829376626
   },
   {
     "3alpha": "KKN",
-    "station_name": "Kirknewton Rail Station",
+    "station_name": "Kirknewton",
     "latitude": 55.8886849182,
     "longitude": -3.4325077075
   },
   {
     "3alpha": "KKS",
-    "station_name": "Kirk Sandall Rail Station",
+    "station_name": "Kirk Sandall",
     "latitude": 53.5638967616,
     "longitude": -1.074065509
   },
   {
     "3alpha": "KLD",
-    "station_name": "Kildale Rail Station",
+    "station_name": "Kildale",
     "latitude": 54.4777686824,
     "longitude": -1.0681580089
   },
   {
     "3alpha": "KLF",
-    "station_name": "Kirkstall Forge Rail Station",
+    "station_name": "Kirkstall Forge",
     "latitude": 53.8237339338,
     "longitude": -1.6224823291
   },
   {
     "3alpha": "KLM",
-    "station_name": "Kilmaurs Rail Station",
+    "station_name": "Kilmaurs",
     "latitude": 55.6372048041,
     "longitude": -4.530470324
   },
   {
     "3alpha": "KLN",
-    "station_name": "Kings Lynn Rail Station",
+    "station_name": "Kings Lynn",
     "latitude": 52.7539444878,
     "longitude": 0.4034623052
   },
   {
     "3alpha": "KLY",
-    "station_name": "Kenley Rail Station",
+    "station_name": "Kenley",
     "latitude": 51.3247744025,
     "longitude": -0.1008992757
   },
   {
     "3alpha": "KMH",
-    "station_name": "Kempston Hardwick Rail Station",
+    "station_name": "Kempston Hardwick",
     "latitude": 52.0922280746,
     "longitude": -0.503891956
   },
   {
     "3alpha": "KMK",
-    "station_name": "Kilmarnock Rail Station",
+    "station_name": "Kilmarnock",
     "latitude": 55.6121152355,
     "longitude": -4.4986646202
   },
   {
     "3alpha": "KML",
-    "station_name": "Kemsley Rail Station",
+    "station_name": "Kemsley",
     "latitude": 51.3624400702,
     "longitude": 0.7353874775
   },
   {
     "3alpha": "KMP",
-    "station_name": "Kempton Park Rail Station",
+    "station_name": "Kempton Park",
     "latitude": 51.4209818235,
     "longitude": -0.4097301104
   },
   {
     "3alpha": "KMS",
-    "station_name": "Kemsing Rail Station",
+    "station_name": "Kemsing",
     "latitude": 51.2971839907,
     "longitude": 0.2474553811
   },
   {
     "3alpha": "KNA",
-    "station_name": "Knaresborough Rail Station",
+    "station_name": "Knaresborough",
     "latitude": 54.0090375731,
     "longitude": -1.4704220018
   },
   {
     "3alpha": "KND",
-    "station_name": "Kingswood Rail Station",
+    "station_name": "Kingswood",
     "latitude": 51.2947217871,
     "longitude": -0.2112222297
   },
   {
     "3alpha": "KNE",
-    "station_name": "Kennett Rail Station",
+    "station_name": "Kennett",
     "latitude": 52.2772786496,
     "longitude": 0.490492211
   },
   {
     "3alpha": "KNF",
-    "station_name": "Knutsford Rail Station",
+    "station_name": "Knutsford",
     "latitude": 53.3018050357,
     "longitude": -2.3717892715
   },
   {
     "3alpha": "KNG",
-    "station_name": "Kingston Rail Station",
+    "station_name": "Kingston",
     "latitude": 51.412749207,
     "longitude": -0.3011440528
   },
   {
     "3alpha": "KNI",
-    "station_name": "Knighton Rail Station",
+    "station_name": "Knighton",
     "latitude": 52.3450836187,
     "longitude": -3.0421947541
   },
   {
     "3alpha": "KNL",
-    "station_name": "Kensal Green Rail Station",
+    "station_name": "Kensal Green",
     "latitude": 51.5305403206,
     "longitude": -0.225063468
   },
   {
     "3alpha": "KNN",
-    "station_name": "Kings Norton Rail Station",
+    "station_name": "Kings Norton",
     "latitude": 52.4143035181,
     "longitude": -1.9323192635
   },
   {
     "3alpha": "KNO",
-    "station_name": "Knottingley Rail Station",
+    "station_name": "Knottingley",
     "latitude": 53.7065538515,
     "longitude": -1.2591815208
   },
   {
     "3alpha": "KNR",
-    "station_name": "Kensal Rise Rail Station",
+    "station_name": "Kensal Rise",
     "latitude": 51.5345542153,
     "longitude": -0.2199327512
   },
   {
     "3alpha": "KNS",
-    "station_name": "Kennishead Rail Station",
+    "station_name": "Kennishead",
     "latitude": 55.813309436,
     "longitude": -4.3252321959
   },
   {
     "3alpha": "KNT",
-    "station_name": "Kenton Rail Station",
+    "station_name": "Kenton",
     "latitude": 51.581801686,
     "longitude": -0.3169583454
   },
   {
     "3alpha": "KNU",
-    "station_name": "Knucklas Rail Station",
+    "station_name": "Knucklas",
     "latitude": 52.3598728116,
     "longitude": -3.0968778892
   },
   {
     "3alpha": "KNW",
-    "station_name": "Kenilworth Rail Station",
+    "station_name": "Kenilworth",
     "latitude": 52.3427193518,
     "longitude": -1.5727265434
   },
   {
     "3alpha": "KPA",
-    "station_name": "Kensington (Olympia) Rail Station",
+    "station_name": "Kensington (Olympia)",
     "latitude": 51.4978982211,
     "longitude": -0.2103405047
   },
   {
     "3alpha": "KPT",
-    "station_name": "Kilpatrick Rail Station",
+    "station_name": "Kilpatrick",
     "latitude": 55.9246935335,
     "longitude": -4.4533967721
   },
   {
     "3alpha": "KRK",
-    "station_name": "Kirkconnel Rail Station",
+    "station_name": "Kirkconnel",
     "latitude": 55.3883045795,
     "longitude": -3.9984909836
   },
   {
     "3alpha": "KSL",
-    "station_name": "Kearsley Rail Station",
+    "station_name": "Kearsley",
     "latitude": 53.5441534939,
     "longitude": -2.3751177475
   },
   {
     "3alpha": "KSN",
-    "station_name": "Kearsney Rail Station",
+    "station_name": "Kearsney",
     "latitude": 51.1493801653,
     "longitude": 1.2720927524
   },
   {
     "3alpha": "KSW",
-    "station_name": "Kirkby Stephen Rail Station",
+    "station_name": "Kirkby Stephen",
     "latitude": 54.4548647986,
     "longitude": -2.3686012903
   },
   {
     "3alpha": "KTH",
-    "station_name": "Kent House Rail Station",
+    "station_name": "Kent House",
     "latitude": 51.4122125796,
     "longitude": -0.0452213855
   },
   {
     "3alpha": "KTL",
-    "station_name": "Kirton Lindsey Rail Station",
+    "station_name": "Kirton Lindsey",
     "latitude": 53.4848601103,
     "longitude": -0.5939161226
   },
   {
     "3alpha": "KTN",
-    "station_name": "Kentish Town Rail Station",
+    "station_name": "Kentish Town",
     "latitude": 51.550495644,
     "longitude": -0.1403392037
   },
   {
+    "3alpha":"KTR",
+    "station_name":"Kintore",
+    "latitude":57.243611,
+    "longitude": -2.350278
+  },
+  {
     "3alpha": "KTW",
-    "station_name": "Kentish Town West Rail Station",
+    "station_name": "Kentish Town West",
     "latitude": 51.546548457,
     "longitude": -0.1466298744
   },
   {
     "3alpha": "KVD",
-    "station_name": "Kelvindale Rail Station",
+    "station_name": "Kelvindale",
     "latitude": 55.8935487999,
     "longitude": -4.3095577512
   },
   {
     "3alpha": "KVP",
-    "station_name": "Kiveton Park Rail Station",
+    "station_name": "Kiveton Park",
     "latitude": 53.3367337933,
     "longitude": -1.2398447759
   },
   {
     "3alpha": "KWB",
-    "station_name": "Kew Bridge Rail Station",
+    "station_name": "Kew Bridge",
     "latitude": 51.489511729,
     "longitude": -0.287085417
   },
   {
     "3alpha": "KWD",
-    "station_name": "Kirkwood Rail Station",
+    "station_name": "Kirkwood",
     "latitude": 55.8541826133,
     "longitude": -4.0483868931
   },
   {
     "3alpha": "KWG",
-    "station_name": "Kew Gardens Rail Station",
+    "station_name": "Kew Gardens",
     "latitude": 51.4770717225,
     "longitude": -0.2850311799
   },
   {
     "3alpha": "KWL",
-    "station_name": "Kidwelly Rail Station",
+    "station_name": "Kidwelly",
     "latitude": 51.7343478013,
     "longitude": -4.3170097512
   },
   {
     "3alpha": "KWN",
-    "station_name": "Kilwinning Rail Station",
+    "station_name": "Kilwinning",
     "latitude": 55.6559470119,
     "longitude": -4.7099979638
   },
   {
     "3alpha": "KYL",
-    "station_name": "Kyle of Lochalsh Rail Station",
+    "station_name": "Kyle of Lochalsh",
     "latitude": 57.2797467149,
     "longitude": -5.7138003131
   },
   {
     "3alpha": "KYN",
-    "station_name": "Keynsham Rail Station",
+    "station_name": "Keynsham",
     "latitude": 51.4179728415,
     "longitude": -2.495628895
   },
   {
     "3alpha": "LAC",
-    "station_name": "Lancing Rail Station",
+    "station_name": "Lancing",
     "latitude": 50.8270743359,
     "longitude": -0.3230828778
   },
   {
     "3alpha": "LAD",
-    "station_name": "Ladywell Rail Station",
+    "station_name": "Ladywell",
     "latitude": 51.4562424895,
     "longitude": -0.0190151041
   },
   {
     "3alpha": "LAG",
-    "station_name": "Langwith - Whaley Thorns Rail Station",
+    "station_name": "Langwith - Whaley Thorns",
     "latitude": 53.2318581892,
     "longitude": -1.2093421054
   },
   {
     "3alpha": "LAI",
-    "station_name": "Laindon Rail Station",
+    "station_name": "Laindon",
     "latitude": 51.5675245473,
     "longitude": 0.4243193409
   },
   {
     "3alpha": "LAK",
-    "station_name": "Lakenheath Rail Station",
+    "station_name": "Lakenheath",
     "latitude": 52.4474170039,
     "longitude": 0.535221579
   },
   {
     "3alpha": "LAM",
-    "station_name": "Lamphey Rail Station",
+    "station_name": "Lamphey",
     "latitude": 51.6671952632,
     "longitude": -4.8732909776
   },
   {
     "3alpha": "LAN",
-    "station_name": "Lancaster Rail Station",
+    "station_name": "Lancaster",
     "latitude": 54.0487386625,
     "longitude": -2.8074539872
   },
   {
     "3alpha": "LAP",
-    "station_name": "Lapford Rail Station",
+    "station_name": "Lapford",
     "latitude": 50.8569928871,
     "longitude": -3.8106600905
   },
   {
     "3alpha": "LAR",
-    "station_name": "Largs Rail Station",
+    "station_name": "Largs",
     "latitude": 55.7927371132,
     "longitude": -4.8671774606
   },
   {
     "3alpha": "LAS",
-    "station_name": "Llansamlet Rail Station",
+    "station_name": "Llansamlet",
     "latitude": 51.661506083,
     "longitude": -3.8847019198
   },
   {
     "3alpha": "LAU",
-    "station_name": "Laurencekirk Rail Station",
+    "station_name": "Laurencekirk",
     "latitude": 56.8363340087,
     "longitude": -2.4659318685
   },
   {
     "3alpha": "LAW",
-    "station_name": "Landywood Rail Station",
+    "station_name": "Landywood",
     "latitude": 52.656554762,
     "longitude": -2.0207214262
   },
   {
     "3alpha": "LAY",
-    "station_name": "Layton (Lancs) Rail Station",
+    "station_name": "Layton (Lancs)",
     "latitude": 53.8352807966,
     "longitude": -3.0299856202
   },
   {
     "3alpha": "LBG",
-    "station_name": "London Bridge Rail Station",
+    "station_name": "London Bridge",
     "latitude": 51.5050187718,
     "longitude": -0.0860663187
   },
   {
     "3alpha": "LBK",
-    "station_name": "Long Buckby Rail Station",
+    "station_name": "Long Buckby",
     "latitude": 52.2947305797,
     "longitude": -1.0864517232
   },
   {
     "3alpha": "LBO",
-    "station_name": "Loughborough (Leics) Rail Station",
+    "station_name": "Loughborough (Leics)",
     "latitude": 52.7789730706,
     "longitude": -1.1959223029
   },
   {
     "3alpha": "LBR",
-    "station_name": "Llanbedr Rail Station",
+    "station_name": "Llanbedr",
     "latitude": 52.8208652563,
     "longitude": -4.1102042575
   },
   {
     "3alpha": "LBT",
-    "station_name": "Larbert Rail Station",
+    "station_name": "Larbert",
     "latitude": 56.0226975731,
     "longitude": -3.8305736309
   },
   {
     "3alpha": "LBZ",
-    "station_name": "Leighton Buzzard Rail Station",
+    "station_name": "Leighton Buzzard",
     "latitude": 51.9163138347,
     "longitude": -0.6769823167
   },
   {
     "3alpha": "LCC",
-    "station_name": "Lochluichart Rail Station",
+    "station_name": "Lochluichart",
     "latitude": 57.621737692,
     "longitude": -4.8090441141
   },
   {
     "3alpha": "LCG",
-    "station_name": "Lochgelly Rail Station",
+    "station_name": "Lochgelly",
     "latitude": 56.1353217097,
     "longitude": -3.312938865
   },
   {
     "3alpha": "LCK",
-    "station_name": "Lockwood Rail Station",
+    "station_name": "Lockwood",
     "latitude": 53.634746673,
     "longitude": -1.8007918923
   },
   {
     "3alpha": "LCL",
-    "station_name": "Lochailort Rail Station",
+    "station_name": "Lochailort",
     "latitude": 56.8809423369,
     "longitude": -5.6633772414
   },
   {
     "3alpha": "LCN",
-    "station_name": "Lincoln Central Rail Station",
+    "station_name": "Lincoln Central",
     "latitude": 53.2261072888,
     "longitude": -0.5399222885
   },
   {
     "3alpha": "LCS",
-    "station_name": "Locheilside Rail Station",
+    "station_name": "Locheilside",
     "latitude": 56.8553882734,
     "longitude": -5.2900225827
   },
   {
     "3alpha": "LDN",
-    "station_name": "Llandanwg Rail Station",
+    "station_name": "Llandanwg",
     "latitude": 52.8361759873,
     "longitude": -4.1238635913
   },
   {
     "3alpha": "LDS",
-    "station_name": "Leeds Rail Station",
+    "station_name": "Leeds",
     "latitude": 53.7956409037,
     "longitude": -1.5480300934
   },
   {
     "3alpha": "LDY",
-    "station_name": "Ladybank Rail Station",
+    "station_name": "Ladybank",
     "latitude": 56.2737723207,
     "longitude": -3.1222761516
   },
   {
     "3alpha": "LEA",
-    "station_name": "Leagrave Rail Station",
+    "station_name": "Leagrave",
     "latitude": 51.9051657736,
     "longitude": -0.4584767531
   },
   {
     "3alpha": "LEB",
-    "station_name": "Lea Bridge Rail Station",
+    "station_name": "Lea Bridge",
     "latitude": 51.5665477908,
     "longitude": -0.0366456064
   },
   {
     "3alpha": "LED",
-    "station_name": "Ledbury Rail Station",
+    "station_name": "Ledbury",
     "latitude": 52.0452583249,
     "longitude": -2.4258582991
   },
   {
     "3alpha": "LEE",
-    "station_name": "Lee Rail Station",
+    "station_name": "Lee",
     "latitude": 51.4497532361,
     "longitude": 0.0135186891
   },
   {
     "3alpha": "LEG",
-    "station_name": "Lea Green Rail Station",
+    "station_name": "Lea Green",
     "latitude": 53.4268240445,
     "longitude": -2.7249767465
   },
   {
     "3alpha": "LEH",
-    "station_name": "Lea Hall Rail Station",
+    "station_name": "Lea Hall",
     "latitude": 52.480655776,
     "longitude": -1.7860055303
   },
   {
     "3alpha": "LEI",
-    "station_name": "Leicester Rail Station",
+    "station_name": "Leicester",
     "latitude": 52.6314416999,
     "longitude": -1.1252675699
   },
   {
     "3alpha": "LEL",
-    "station_name": "Lelant Rail Station",
+    "station_name": "Lelant",
     "latitude": 50.1841132154,
     "longitude": -5.4365983681
   },
   {
     "3alpha": "LEM",
-    "station_name": "Leyton Midland Road Rail Station",
+    "station_name": "Leyton Midland Road",
     "latitude": 51.5697256477,
     "longitude": -0.0080229844
   },
   {
     "3alpha": "LEN",
-    "station_name": "Lenham Rail Station",
+    "station_name": "Lenham",
     "latitude": 51.2344839559,
     "longitude": 0.7077894244
   },
   {
     "3alpha": "LEO",
-    "station_name": "Leominster Rail Station",
+    "station_name": "Leominster",
     "latitude": 52.2256915912,
     "longitude": -2.730340766
   },
   {
     "3alpha": "LER",
-    "station_name": "Leytonstone High Road Rail Station",
+    "station_name": "Leytonstone High Road",
     "latitude": 51.5635545296,
     "longitude": 0.0084437379
   },
   {
     "3alpha": "LES",
-    "station_name": "Leigh-on-Sea Rail Station",
+    "station_name": "Leigh-on-Sea",
     "latitude": 51.5412752344,
     "longitude": 0.6404394965
   },
   {
     "3alpha": "LET",
-    "station_name": "Letchworth Rail Station",
+    "station_name": "Letchworth",
     "latitude": 51.9799709665,
     "longitude": -0.2292371062
   },
   {
     "3alpha": "LEU",
-    "station_name": "Leuchars Rail Station",
+    "station_name": "Leuchars",
     "latitude": 56.3750925172,
     "longitude": -2.8937163252
   },
   {
     "3alpha": "LEW",
-    "station_name": "Lewisham Rail Station",
+    "station_name": "Lewisham",
     "latitude": 51.4656900464,
     "longitude": -0.0139988836
   },
   {
     "3alpha": "LEY",
-    "station_name": "Leyland Rail Station",
+    "station_name": "Leyland",
     "latitude": 53.6988690686,
     "longitude": -2.6871416367
   },
   {
     "3alpha": "LFD",
-    "station_name": "Lingfield Rail Station",
+    "station_name": "Lingfield",
     "latitude": 51.1764479512,
     "longitude": -0.0071377353
   },
   {
     "3alpha": "LGB",
-    "station_name": "Langbank Rail Station",
+    "station_name": "Langbank",
     "latitude": 55.9245116809,
     "longitude": -4.5852569156
   },
   {
     "3alpha": "LGD",
-    "station_name": "Lingwood Rail Station",
+    "station_name": "Lingwood",
     "latitude": 52.6221259547,
     "longitude": 1.4899676829
   },
   {
     "3alpha": "LGE",
-    "station_name": "Long Eaton Rail Station",
+    "station_name": "Long Eaton",
     "latitude": 52.8850051381,
     "longitude": -1.287515035
   },
   {
     "3alpha": "LGF",
-    "station_name": "Longfield Rail Station",
+    "station_name": "Longfield",
     "latitude": 51.3961528278,
     "longitude": 0.3003927726
   },
   {
     "3alpha": "LGG",
-    "station_name": "Langley Green Rail Station",
+    "station_name": "Langley Green",
     "latitude": 52.4938847738,
     "longitude": -2.0049580874
   },
   {
     "3alpha": "LGJ",
-    "station_name": "Loughborough Junction Rail Station",
+    "station_name": "Loughborough Junction",
     "latitude": 51.4662966456,
     "longitude": -0.1021564205
   },
   {
     "3alpha": "LGK",
-    "station_name": "Longbeck Rail Station",
+    "station_name": "Longbeck",
     "latitude": 54.5892295098,
     "longitude": -1.0304881067
   },
   {
     "3alpha": "LGM",
-    "station_name": "Langley Mill Rail Station",
+    "station_name": "Langley Mill",
     "latitude": 53.0180775906,
     "longitude": -1.3312416884
   },
   {
     "3alpha": "LGN",
-    "station_name": "Longton Rail Station",
+    "station_name": "Longton",
     "latitude": 52.9899681856,
     "longitude": -2.1370099565
   },
   {
     "3alpha": "LGO",
-    "station_name": "Llangynllo Rail Station",
+    "station_name": "Llangynllo",
     "latitude": 52.3496362697,
     "longitude": -3.1613704736
   },
   {
     "3alpha": "LGS",
-    "station_name": "Langside Rail Station",
+    "station_name": "Langside",
     "latitude": 55.8211269753,
     "longitude": -4.2773259977
   },
   {
     "3alpha": "LGW",
-    "station_name": "Langwathby Rail Station",
+    "station_name": "Langwathby",
     "latitude": 54.6943634202,
     "longitude": -2.6636891905
   },
   {
     "3alpha": "LHA",
-    "station_name": "Loch Awe Rail Station",
+    "station_name": "Loch Awe",
     "latitude": 56.4020023455,
     "longitude": -5.0419541347
   },
   {
     "3alpha": "LHD",
-    "station_name": "Leatherhead Rail Station",
+    "station_name": "Leatherhead",
     "latitude": 51.2988144436,
     "longitude": -0.3332088593
   },
   {
     "3alpha": "LHE",
-    "station_name": "Loch Eil Outward Bound Rail Station",
+    "station_name": "Loch Eil Outward Bound",
     "latitude": 56.8552494299,
     "longitude": -5.1915632271
   },
   {
     "3alpha": "LHM",
-    "station_name": "Lealholm Rail Station",
+    "station_name": "Lealholm",
     "latitude": 54.4606042623,
     "longitude": -0.8257310498
   },
   {
     "3alpha": "LHO",
-    "station_name": "Langho Rail Station",
+    "station_name": "Langho",
     "latitude": 53.8048444025,
     "longitude": -2.4486582114
   },
   {
     "3alpha": "LHR",
-    "station_name": "Heathrow Terminals 1-3 Rail Station",
+    "station_name": "Heathrow Terminals 1-3",
     "latitude": 51.4714046459,
     "longitude": -0.4543126778
   },
   {
     "3alpha": "LHS",
-    "station_name": "Limehouse Rail Station",
+    "station_name": "Limehouse",
     "latitude": 51.5125361684,
     "longitude": -0.0397760782
   },
   {
     "3alpha": "LHW",
-    "station_name": "Lochwinnoch Rail Station",
+    "station_name": "Lochwinnoch",
     "latitude": 55.7871497964,
     "longitude": -4.6160573245
   },
   {
     "3alpha": "LIC",
-    "station_name": "Lichfield City Rail Station",
+    "station_name": "Lichfield City",
     "latitude": 52.6801615881,
     "longitude": -1.8254127247
   },
   {
     "3alpha": "LID",
-    "station_name": "Lidlington Rail Station",
+    "station_name": "Lidlington",
     "latitude": 52.0415453254,
     "longitude": -0.5589061726
   },
   {
     "3alpha": "LIF",
-    "station_name": "Lichfield Trent Valley High Level Rail Station",
+    "station_name": "Lichfield Trent Valley High Level",
     "latitude": 52.6869091229,
     "longitude": -1.8002367619
   },
   {
     "3alpha": "LIH",
-    "station_name": "Leigh (Kent) Rail Station",
+    "station_name": "Leigh (Kent)",
     "latitude": 51.1938967547,
     "longitude": 0.2105218236
   },
   {
     "3alpha": "LIN",
-    "station_name": "Linlithgow Rail Station",
+    "station_name": "Linlithgow",
     "latitude": 55.9764464658,
     "longitude": -3.5958472904
   },
   {
     "3alpha": "LIP",
-    "station_name": "Liphook Rail Station",
+    "station_name": "Liphook",
     "latitude": 51.0713092222,
     "longitude": -0.8002098038
   },
   {
     "3alpha": "LIS",
-    "station_name": "Liss Rail Station",
+    "station_name": "Liss",
     "latitude": 51.0435640733,
     "longitude": -0.8928497986
   },
   {
     "3alpha": "LIT",
-    "station_name": "Littlehampton Rail Station",
+    "station_name": "Littlehampton",
     "latitude": 50.8100978499,
     "longitude": -0.5459719624
   },
   {
     "3alpha": "LIV",
-    "station_name": "Liverpool Lime Street Rail Station",
+    "station_name": "Liverpool Lime Street",
     "latitude": 53.4073236407,
     "longitude": -2.977726082
   },
   {
     "3alpha": "LKE",
-    "station_name": "Lake (Isle of Wight) Rail Station",
+    "station_name": "Lake (Isle of Wight)",
     "latitude": 50.6464632785,
     "longitude": -1.1663386012
   },
   {
     "3alpha": "LLA",
-    "station_name": "Llanaber Rail Station",
+    "station_name": "Llanaber",
     "latitude": 52.7415174068,
     "longitude": -4.0771833809
   },
   {
     "3alpha": "LLC",
-    "station_name": "Llandecwyn Rail Station",
+    "station_name": "Llandecwyn",
     "latitude": 52.9206985859,
     "longitude": -4.0570419611
   },
   {
     "3alpha": "LLD",
-    "station_name": "Llandudno Rail Station",
+    "station_name": "Llandudno",
     "latitude": 53.320931375,
     "longitude": -3.8270045937
   },
   {
     "3alpha": "LLE",
-    "station_name": "Llanelli Rail Station",
+    "station_name": "Llanelli",
     "latitude": 51.6738710202,
     "longitude": -4.1613259947
   },
   {
     "3alpha": "LLF",
-    "station_name": "Llanfairfechan Rail Station",
+    "station_name": "Llanfairfechan",
     "latitude": 53.2573026611,
     "longitude": -3.9832073298
   },
   {
     "3alpha": "LLG",
-    "station_name": "Llangadog Rail Station",
+    "station_name": "Llangadog",
     "latitude": 51.9402195807,
     "longitude": -3.8931635456
   },
   {
     "3alpha": "LLH",
-    "station_name": "Llangennech Rail Station",
+    "station_name": "Llangennech",
     "latitude": 51.6911401855,
     "longitude": -4.0789505342
   },
   {
     "3alpha": "LLI",
-    "station_name": "Llandybie Rail Station",
+    "station_name": "Llandybie",
     "latitude": 51.8210413519,
     "longitude": -4.0036670781
   },
   {
     "3alpha": "LLJ",
-    "station_name": "Llandudno Junction Rail Station",
+    "station_name": "Llandudno Junction",
     "latitude": 53.283958434,
     "longitude": -3.8091060573
   },
   {
     "3alpha": "LLL",
-    "station_name": "Llandeilo Rail Station",
+    "station_name": "Llandeilo",
     "latitude": 51.8853508121,
     "longitude": -3.9869089385
   },
   {
     "3alpha": "LLM",
-    "station_name": "Llangammarch Rail Station",
+    "station_name": "Llangammarch",
     "latitude": 52.1143061939,
     "longitude": -3.5548258245
   },
   {
     "3alpha": "LLN",
-    "station_name": "Llandaf Rail Station",
+    "station_name": "Llandaf",
     "latitude": 51.5084380797,
     "longitude": -3.2286220121
   },
   {
     "3alpha": "LLO",
-    "station_name": "Llandrindod Rail Station",
+    "station_name": "Llandrindod",
     "latitude": 52.2423682996,
     "longitude": -3.3791453356
   },
   {
     "3alpha": "LLR",
-    "station_name": "Llanharan Rail Station",
+    "station_name": "Llanharan",
     "latitude": 51.5375863272,
     "longitude": -3.4407911115
   },
   {
     "3alpha": "LLS",
-    "station_name": "Llanishen Rail Station",
+    "station_name": "Llanishen",
     "latitude": 51.532745927,
     "longitude": -3.1819878738
   },
   {
     "3alpha": "LLT",
-    "station_name": "Llanbister Road Rail Station",
+    "station_name": "Llanbister Road",
     "latitude": 52.3364359032,
     "longitude": -3.2134226095
   },
   {
     "3alpha": "LLV",
-    "station_name": "Llandovery Rail Station",
+    "station_name": "Llandovery",
     "latitude": 51.995319454,
     "longitude": -3.8028430574
   },
   {
     "3alpha": "LLW",
-    "station_name": "Llwyngwril Rail Station",
+    "station_name": "Llwyngwril",
     "latitude": 52.6667959978,
     "longitude": -4.0876869996
   },
   {
     "3alpha": "LLY",
-    "station_name": "Llwynypia Rail Station",
+    "station_name": "Llwynypia",
     "latitude": 51.6340038599,
     "longitude": -3.4535242203
   },
   {
     "3alpha": "LMR",
-    "station_name": "Low Moor Rail Station",
+    "station_name": "Low Moor",
     "latitude": 53.7499403782,
     "longitude": -1.7534074129
   },
   {
     "3alpha": "LMS",
-    "station_name": "Leamington Spa Rail Station",
+    "station_name": "Leamington Spa",
     "latitude": 52.284503537,
     "longitude": -1.5361991242
   },
   {
     "3alpha": "LNB",
-    "station_name": "Llanbradach Rail Station",
+    "station_name": "Llanbradach",
     "latitude": 51.6032561222,
     "longitude": -3.2330580594
   },
   {
     "3alpha": "LND",
-    "station_name": "Longniddry Rail Station",
+    "station_name": "Longniddry",
     "latitude": 55.9764783228,
     "longitude": -2.8883472596
   },
   {
     "3alpha": "LNG",
-    "station_name": "Longcross Rail Station",
+    "station_name": "Longcross",
     "latitude": 51.3851709311,
     "longitude": -0.5945509208
   },
   {
     "3alpha": "LNK",
-    "station_name": "Lanark Rail Station",
+    "station_name": "Lanark",
     "latitude": 55.673604759,
     "longitude": -3.7732799051
   },
   {
     "3alpha": "LNR",
-    "station_name": "Llanwrda Rail Station",
+    "station_name": "Llanwrda",
     "latitude": 51.9625935234,
     "longitude": -3.8716896629
   },
   {
     "3alpha": "LNW",
-    "station_name": "Llanwrtyd Rail Station",
+    "station_name": "Llanwrtyd",
     "latitude": 52.1047187961,
     "longitude": -3.632173997
   },
   {
     "3alpha": "LNY",
-    "station_name": "Langley (Berks) Rail Station",
+    "station_name": "Langley (Berks)",
     "latitude": 51.5080622586,
     "longitude": -0.5417374982
   },
   {
     "3alpha": "LNZ",
-    "station_name": "Lenzie Rail Station",
+    "station_name": "Lenzie",
     "latitude": 55.9213119495,
     "longitude": -4.1538778824
   },
   {
     "3alpha": "LOB",
-    "station_name": "Longbridge Rail Station",
+    "station_name": "Longbridge",
     "latitude": 52.3964311105,
     "longitude": -1.981283672
   },
   {
     "3alpha": "LOC",
-    "station_name": "Lockerbie Rail Station",
+    "station_name": "Lockerbie",
     "latitude": 55.1230561909,
     "longitude": -3.353531624
   },
   {
     "3alpha": "LOF",
-    "station_name": "London Fields Rail Station",
+    "station_name": "London Fields",
     "latitude": 51.5411524205,
     "longitude": -0.0577263865
   },
   {
     "3alpha": "LOH",
-    "station_name": "Lostock Hall Rail Station",
+    "station_name": "Lostock Hall",
     "latitude": 53.7242588593,
     "longitude": -2.6874800806
   },
   {
     "3alpha": "LOO",
-    "station_name": "Looe Rail Station",
+    "station_name": "Looe",
     "latitude": 50.3592096258,
     "longitude": -4.4561992266
   },
   {
     "3alpha": "LOS",
-    "station_name": "Lostwithiel Rail Station",
+    "station_name": "Lostwithiel",
     "latitude": 50.4071639994,
     "longitude": -4.6660056695
   },
   {
     "3alpha": "LOT",
-    "station_name": "Lostock Rail Station",
+    "station_name": "Lostock",
     "latitude": 53.572942054,
     "longitude": -2.4942651922
   },
   {
     "3alpha": "LOW",
-    "station_name": "Lowdham Rail Station",
+    "station_name": "Lowdham",
     "latitude": 53.0063029264,
     "longitude": -0.9984155088
   },
   {
     "3alpha": "LPG",
-    "station_name": "Llanfairpwll Rail Station",
+    "station_name": "Llanfairpwll",
     "latitude": 53.2209605021,
     "longitude": -4.2092216486
   },
   {
     "3alpha": "LPR",
-    "station_name": "Long Preston Rail Station",
+    "station_name": "Long Preston",
     "latitude": 54.0168488895,
     "longitude": -2.255595159
   },
   {
     "3alpha": "LPT",
-    "station_name": "Longport Rail Station",
+    "station_name": "Longport",
     "latitude": 53.0418973325,
     "longitude": -2.2164483623
   },
   {
     "3alpha": "LPW",
-    "station_name": "Lapworth Rail Station",
+    "station_name": "Lapworth",
     "latitude": 52.3422646161,
     "longitude": -1.7256819125
   },
   {
     "3alpha": "LPY",
-    "station_name": "Liverpool South Parkway Rail Station",
+    "station_name": "Liverpool South Parkway",
     "latitude": 53.3577585374,
     "longitude": -2.8891427297
   },
   {
     "3alpha": "LRB",
-    "station_name": "London Road (Brighton) Rail Station",
+    "station_name": "London Road (Brighton)",
     "latitude": 50.8366553421,
     "longitude": -0.1364746723
   },
   {
     "3alpha": "LRD",
-    "station_name": "London Road (Guildford) Rail Station",
+    "station_name": "London Road (Guildford)",
     "latitude": 51.2406441935,
     "longitude": -0.565047885
   },
   {
     "3alpha": "LRG",
-    "station_name": "Lairg Rail Station",
+    "station_name": "Lairg",
     "latitude": 58.0018108151,
     "longitude": -4.3998916637
   },
   {
     "3alpha": "LRH",
-    "station_name": "Larkhall Rail Station",
+    "station_name": "Larkhall",
     "latitude": 55.7385910664,
     "longitude": -3.9754997252
   },
   {
     "3alpha": "LSK",
-    "station_name": "Liskeard Rail Station",
+    "station_name": "Liskeard",
     "latitude": 50.4468508005,
     "longitude": -4.4696103937
   },
   {
     "3alpha": "LSN",
-    "station_name": "Livingston North Rail Station",
+    "station_name": "Livingston North",
     "latitude": 55.9013777549,
     "longitude": -3.5443460776
   },
   {
     "3alpha": "LST",
-    "station_name": "London Liverpool Street Rail Station",
+    "station_name": "London Liverpool Street",
     "latitude": 51.5179909029,
     "longitude": -0.0813998966
   },
   {
     "3alpha": "LSW",
-    "station_name": "Leasowe Rail Station",
+    "station_name": "Leasowe",
     "latitude": 53.4080616471,
     "longitude": -3.0995918732
   },
   {
     "3alpha": "LSY",
-    "station_name": "Lower Sydenham Rail Station",
+    "station_name": "Lower Sydenham",
     "latitude": 51.4248284049,
     "longitude": -0.0333195275
   },
   {
     "3alpha": "LTG",
-    "station_name": "Lostock Gralam Rail Station",
+    "station_name": "Lostock Gralam",
     "latitude": 53.2676790034,
     "longitude": -2.4652014465
   },
   {
     "3alpha": "LTH",
-    "station_name": "Llanhilleth Rail Station",
+    "station_name": "Llanhilleth",
     "latitude": 51.7003015567,
     "longitude": -3.1351956439
   },
   {
     "3alpha": "LTK",
-    "station_name": "Little Kimble Rail Station",
+    "station_name": "Little Kimble",
     "latitude": 51.7522355985,
     "longitude": -0.8084296111
   },
   {
     "3alpha": "LTL",
-    "station_name": "Littleborough Rail Station",
+    "station_name": "Littleborough",
     "latitude": 53.6430095698,
     "longitude": -2.0946505145
   },
   {
     "3alpha": "LTM",
-    "station_name": "Lytham Rail Station",
+    "station_name": "Lytham",
     "latitude": 53.7392940824,
     "longitude": -2.9640373329
   },
   {
     "3alpha": "LTN",
-    "station_name": "Luton Airport Parkway Rail Station",
+    "station_name": "Luton Airport Parkway",
     "latitude": 51.8724440314,
     "longitude": -0.3958564573
   },
   {
     "3alpha": "LTP",
-    "station_name": "Littleport Rail Station",
+    "station_name": "Littleport",
     "latitude": 52.4623961349,
     "longitude": 0.3165814324
   },
   {
     "3alpha": "LTS",
-    "station_name": "Lelant Saltings Rail Station",
+    "station_name": "Lelant Saltings",
     "latitude": 50.1787654627,
     "longitude": -5.4409776419
   },
   {
     "3alpha": "LTT",
-    "station_name": "Little Sutton Rail Station",
+    "station_name": "Little Sutton",
     "latitude": 53.2855291567,
     "longitude": -2.9432922123
   },
   {
     "3alpha": "LTV",
-    "station_name": "Lichfield Trent Valley Rail Station",
+    "station_name": "Lichfield Trent Valley",
     "latitude": 52.686909098,
     "longitude": -1.8002219684
   },
   {
     "3alpha": "LUD",
-    "station_name": "Ludlow Rail Station",
+    "station_name": "Ludlow",
     "latitude": 52.3712898598,
     "longitude": -2.7162155608
   },
   {
     "3alpha": "LUT",
-    "station_name": "Luton Rail Station",
+    "station_name": "Luton",
     "latitude": 51.882311449,
     "longitude": -0.4140156557
   },
   {
     "3alpha": "LUX",
-    "station_name": "Luxulyan Rail Station",
+    "station_name": "Luxulyan",
     "latitude": 50.3900215765,
     "longitude": -4.7474248225
   },
   {
     "3alpha": "LVC",
-    "station_name": "Liverpool Central Rail Station",
+    "station_name": "Liverpool Central",
     "latitude": 53.4046152032,
     "longitude": -2.9791681938
   },
   {
     "3alpha": "LVG",
-    "station_name": "Livingston South Rail Station",
+    "station_name": "Livingston South",
     "latitude": 55.8716872521,
     "longitude": -3.5015651841
   },
   {
     "3alpha": "LVJ",
-    "station_name": "Liverpool James Street Rail Station",
+    "station_name": "Liverpool James Street",
     "latitude": 53.4047793126,
     "longitude": -2.9919576763
   },
   {
     "3alpha": "LVL",
-    "station_name": "Liverpool Lime Street Low Level Rail Station",
+    "station_name": "Liverpool Lime Street Low Level",
     "latitude": 53.4082223458,
     "longitude": -2.9777466846
   },
   {
     "3alpha": "LVM",
-    "station_name": "Levenshulme Rail Station",
+    "station_name": "Levenshulme",
     "latitude": 53.44417758,
     "longitude": -2.1926682497
   },
   {
     "3alpha": "LVN",
-    "station_name": "Littlehaven Rail Station",
+    "station_name": "Littlehaven",
     "latitude": 51.0797455182,
     "longitude": -0.3079538284
   },
   {
     "3alpha": "LVT",
-    "station_name": "Lisvane & Thornhill Rail Station",
+    "station_name": "Lisvane & Thornhill",
     "latitude": 51.5445785441,
     "longitude": -3.1856117371
   },
   {
     "3alpha": "LWH",
-    "station_name": "Lawrence Hill Rail Station",
+    "station_name": "Lawrence Hill",
     "latitude": 51.4580082791,
     "longitude": -2.5644309056
   },
   {
     "3alpha": "LWM",
-    "station_name": "Llantwit Major Rail Station",
+    "station_name": "Llantwit Major",
     "latitude": 51.4097453635,
     "longitude": -3.4816304262
   },
   {
     "3alpha": "LWR",
-    "station_name": "Llanrwst Rail Station",
+    "station_name": "Llanrwst",
     "latitude": 53.1388647884,
     "longitude": -3.7944055622
   },
   {
     "3alpha": "LWS",
-    "station_name": "Lewes Rail Station",
+    "station_name": "Lewes",
     "latitude": 50.8706247466,
     "longitude": 0.0113583341
   },
   {
     "3alpha": "LWT",
-    "station_name": "Lowestoft Rail Station",
+    "station_name": "Lowestoft",
     "latitude": 52.4744616279,
     "longitude": 1.7497332362
   },
   {
     "3alpha": "LYC",
-    "station_name": "Lympstone Commando Rail Station",
+    "station_name": "Lympstone Commando",
     "latitude": 50.6622243505,
     "longitude": -3.4408532407
   },
   {
     "3alpha": "LYD",
-    "station_name": "Lydney Rail Station",
+    "station_name": "Lydney",
     "latitude": 51.7141382304,
     "longitude": -2.5308648278
   },
   {
     "3alpha": "LYE",
-    "station_name": "Lye (West Midlands) Rail Station",
+    "station_name": "Lye (West Midlands)",
     "latitude": 52.4599348586,
     "longitude": -2.1159231742
   },
   {
     "3alpha": "LYM",
-    "station_name": "Lympstone Village Rail Station",
+    "station_name": "Lympstone Village",
     "latitude": 50.6482800194,
     "longitude": -3.4310201406
   },
   {
     "3alpha": "LYP",
-    "station_name": "Lymington Pier Rail Station",
+    "station_name": "Lymington Pier",
     "latitude": 50.7582891862,
     "longitude": -1.5294384152
   },
   {
     "3alpha": "LYT",
-    "station_name": "Lymington Town Rail Station",
+    "station_name": "Lymington Town",
     "latitude": 50.7609009488,
     "longitude": -1.5371535429
   },
   {
     "3alpha": "LZB",
-    "station_name": "Lazonby & Kirkoswald Rail Station",
+    "station_name": "Lazonby & Kirkoswald",
     "latitude": 54.7504423613,
     "longitude": -2.7032136037
   },
   {
     "3alpha": "MAC",
-    "station_name": "Macclesfield Rail Station",
+    "station_name": "Macclesfield",
     "latitude": 53.2593576131,
     "longitude": -2.1219791655
   },
   {
     "3alpha": "MAG",
-    "station_name": "Maghull Rail Station",
+    "station_name": "Maghull",
     "latitude": 53.5064842654,
     "longitude": -2.930851711
   },
   {
     "3alpha": "MAI",
-    "station_name": "Maidenhead Rail Station",
+    "station_name": "Maidenhead",
     "latitude": 51.5186697833,
     "longitude": -0.7226423149
   },
   {
     "3alpha": "MAL",
-    "station_name": "Malden Manor Rail Station",
+    "station_name": "Malden Manor",
     "latitude": 51.3847271859,
     "longitude": -0.2612506017
   },
   {
     "3alpha": "MAN",
-    "station_name": "Manchester Piccadilly Rail Station",
+    "station_name": "Manchester Piccadilly",
     "latitude": 53.4773757207,
     "longitude": -2.2309078024
   },
   {
     "3alpha": "MAO",
-    "station_name": "Martins Heron Rail Station",
+    "station_name": "Martins Heron",
     "latitude": 51.4074107796,
     "longitude": -0.7243793482
   },
   {
     "3alpha": "MAR",
-    "station_name": "Margate Rail Station",
+    "station_name": "Margate",
     "latitude": 51.385433445,
     "longitude": 1.37202976
   },
   {
     "3alpha": "MAS",
-    "station_name": "Manors Rail Station",
+    "station_name": "Manors",
     "latitude": 54.9727702733,
     "longitude": -1.6047541665
   },
   {
     "3alpha": "MAT",
-    "station_name": "Matlock Rail Station",
+    "station_name": "Matlock",
     "latitude": 53.1384242777,
     "longitude": -1.5589084294
   },
   {
     "3alpha": "MAU",
-    "station_name": "Mauldeth Road Rail Station",
+    "station_name": "Mauldeth Road",
     "latitude": 53.4330757412,
     "longitude": -2.2092498987
   },
   {
     "3alpha": "MAX",
-    "station_name": "Maxwell Park Rail Station",
+    "station_name": "Maxwell Park",
     "latitude": 55.8377227182,
     "longitude": -4.2886774595
   },
   {
     "3alpha": "MAY",
-    "station_name": "Maybole Rail Station",
+    "station_name": "Maybole",
     "latitude": 55.3547389681,
     "longitude": -4.6852666045
   },
   {
     "3alpha": "MBK",
-    "station_name": "Millbrook (Hants) Rail Station",
+    "station_name": "Millbrook (Hants)",
     "latitude": 50.9114857016,
     "longitude": -1.433834394
   },
   {
+    "3alpha": "MBT",
+    "station_name": "Marsh Barton",
+    "latitude": 50.704,
+    "longitude": -3.521
+  },
+  {
     "3alpha": "MBR",
-    "station_name": "Middlesbrough Rail Station",
+    "station_name": "Middlesbrough",
     "latitude": 54.5791171412,
     "longitude": -1.2347318713
   },
   {
     "3alpha": "MCB",
-    "station_name": "Moulsecoomb Rail Station",
+    "station_name": "Moulsecoomb",
     "latitude": 50.846714382,
     "longitude": -0.1188141333
   },
   {
     "3alpha": "MCE",
-    "station_name": "Metrocentre Rail Station",
+    "station_name": "Metrocentre",
     "latitude": 54.9587542761,
     "longitude": -1.6656377117
   },
   {
     "3alpha": "MCH",
-    "station_name": "March Rail Station",
+    "station_name": "March",
     "latitude": 52.5599099766,
     "longitude": 0.0912162426
   },
   {
     "3alpha": "MCM",
-    "station_name": "Morecambe Rail Station",
+    "station_name": "Morecambe",
     "latitude": 54.0703284997,
     "longitude": -2.8693058453
   },
   {
     "3alpha": "MCN",
-    "station_name": "Machynlleth Rail Station",
+    "station_name": "Machynlleth",
     "latitude": 52.5951498424,
     "longitude": -3.8545361215
   },
   {
     "3alpha": "MCO",
-    "station_name": "Manchester Oxford Road Rail Station",
+    "station_name": "Manchester Oxford Road",
     "latitude": 53.4740463537,
     "longitude": -2.2419934877
   },
   {
     "3alpha": "MCV",
-    "station_name": "Manchester Victoria Rail Station",
+    "station_name": "Manchester Victoria",
     "latitude": 53.4874823915,
     "longitude": -2.2425968806
   },
   {
     "3alpha": "MDB",
-    "station_name": "Maidstone Barracks Rail Station",
+    "station_name": "Maidstone Barracks",
     "latitude": 51.27716692,
     "longitude": 0.5139899352
   },
   {
     "3alpha": "MDE",
-    "station_name": "Maidstone East Rail Station",
+    "station_name": "Maidstone East",
     "latitude": 51.2778275358,
     "longitude": 0.5213244253
   },
   {
     "3alpha": "MDG",
-    "station_name": "Midgham Rail Station",
+    "station_name": "Midgham",
     "latitude": 51.3959731964,
     "longitude": -1.1776918335
   },
   {
     "3alpha": "MDL",
-    "station_name": "Middlewood Rail Station",
+    "station_name": "Middlewood",
     "latitude": 53.3599736747,
     "longitude": -2.083352764
   },
   {
     "3alpha": "MDN",
-    "station_name": "Maiden Newton Rail Station",
+    "station_name": "Maiden Newton",
     "latitude": 50.7799951951,
     "longitude": -2.5694292738
   },
   {
     "3alpha": "MDS",
-    "station_name": "Morden South Rail Station",
+    "station_name": "Morden South",
     "latitude": 51.3961136271,
     "longitude": -0.1994364409
   },
   {
     "3alpha": "MDW",
-    "station_name": "Maidstone West Rail Station",
+    "station_name": "Maidstone West",
     "latitude": 51.2704636478,
     "longitude": 0.515803579
   },
   {
     "3alpha": "MEC",
-    "station_name": "Meols Cop Rail Station",
+    "station_name": "Meols Cop",
     "latitude": 53.6462862013,
     "longitude": -2.9758023054
   },
   {
     "3alpha": "MEL",
-    "station_name": "Meldreth Rail Station",
+    "station_name": "Meldreth",
     "latitude": 52.0907259969,
     "longitude": 0.0089697848
   },
   {
     "3alpha": "MEN",
-    "station_name": "Menheniot Rail Station",
+    "station_name": "Menheniot",
     "latitude": 50.4262142257,
     "longitude": -4.4092572868
   },
   {
     "3alpha": "MEO",
-    "station_name": "Meols Rail Station",
+    "station_name": "Meols",
     "latitude": 53.3994554549,
     "longitude": -3.1542676173
   },
   {
     "3alpha": "MEP",
-    "station_name": "Meopham Rail Station",
+    "station_name": "Meopham",
     "latitude": 51.3864213569,
     "longitude": 0.3569805515
   },
   {
     "3alpha": "MER",
-    "station_name": "Merthyr Tydfil Rail Station",
+    "station_name": "Merthyr Tydfil",
     "latitude": 51.7446246906,
     "longitude": -3.3772616186
   },
   {
     "3alpha": "MES",
-    "station_name": "Melton (Suffolk) Rail Station",
+    "station_name": "Melton (Suffolk)",
     "latitude": 52.1044529456,
     "longitude": 1.3382667481
   },
   {
     "3alpha": "MEV",
-    "station_name": "Merthyr Vale Rail Station",
+    "station_name": "Merthyr Vale",
     "latitude": 51.6866484889,
     "longitude": -3.3365879829
   },
   {
     "3alpha": "MEW",
-    "station_name": "Maesteg (Ewenny Road) Rail Station",
+    "station_name": "Maesteg (Ewenny Road)",
     "latitude": 51.6053431085,
     "longitude": -3.6490064767
   },
   {
     "3alpha": "MEX",
-    "station_name": "Mexborough Rail Station",
+    "station_name": "Mexborough",
     "latitude": 53.4910099658,
     "longitude": -1.2885625776
   },
   {
     "3alpha": "MEY",
-    "station_name": "Merryton Rail Station",
+    "station_name": "Merryton",
     "latitude": 55.7487021227,
     "longitude": -3.9782420669
   },
   {
     "3alpha": "MFA",
-    "station_name": "Morfa Mawddach Rail Station",
+    "station_name": "Morfa Mawddach",
     "latitude": 52.7071419715,
     "longitude": -4.032178053
   },
@@ -9211,1561 +9271,1573 @@
   },
   {
     "3alpha": "MFF",
-    "station_name": "Minffordd Rail Station",
+    "station_name": "Minffordd",
     "latitude": 52.926145345,
     "longitude": -4.0849726521
   },
   {
     "3alpha": "MFH",
-    "station_name": "Milford Haven Rail Station",
+    "station_name": "Milford Haven",
     "latitude": 51.7149845991,
     "longitude": -5.0410051649
   },
   {
     "3alpha": "MFL",
-    "station_name": "Mount Florida Rail Station",
+    "station_name": "Mount Florida",
     "latitude": 55.8265491352,
     "longitude": -4.2611173526
   },
   {
     "3alpha": "MFT",
-    "station_name": "Mansfield Rail Station",
+    "station_name": "Mansfield",
     "latitude": 53.1421177161,
     "longitude": -1.1984319382
   },
   {
     "3alpha": "MGM",
-    "station_name": "Metheringham Rail Station",
+    "station_name": "Metheringham",
     "latitude": 53.1389012206,
     "longitude": -0.3914492699
   },
   {
     "3alpha": "MGN",
-    "station_name": "Marston Green Rail Station",
+    "station_name": "Marston Green",
     "latitude": 52.4672018911,
     "longitude": -1.7556002472
   },
   {
     "3alpha": "MHM",
-    "station_name": "Merstham Rail Station",
+    "station_name": "Merstham",
     "latitude": 51.2641512942,
     "longitude": -0.1502004055
   },
   {
     "3alpha": "MHR",
-    "station_name": "Market Harborough Rail Station",
+    "station_name": "Market Harborough",
     "latitude": 52.4797370398,
     "longitude": -0.9093194703
   },
   {
     "3alpha": "MHS",
-    "station_name": "Meadowhall Rail Station",
+    "station_name": "Meadowhall",
     "latitude": 53.4174828257,
     "longitude": -1.4128516936
   },
   {
     "3alpha": "MIA",
-    "station_name": "Manchester Airport Rail Station",
+    "station_name": "Manchester Airport",
     "latitude": 53.365056148,
     "longitude": -2.2729784791
   },
   {
     "3alpha": "MIC",
-    "station_name": "Micheldever Rail Station",
+    "station_name": "Micheldever",
     "latitude": 51.1823883025,
     "longitude": -1.260662184
   },
   {
     "3alpha": "MIH",
-    "station_name": "Mills Hill (Manchester) Rail Station",
+    "station_name": "Mills Hill (Manchester)",
     "latitude": 53.5513245844,
     "longitude": -2.1715108069
   },
   {
     "3alpha": "MIJ",
-    "station_name": "Mitcham Junction Rail Station",
+    "station_name": "Mitcham Junction",
     "latitude": 51.392947391,
     "longitude": -0.1577313094
   },
   {
     "3alpha": "MIK",
-    "station_name": "Micklefield Rail Station",
+    "station_name": "Micklefield",
     "latitude": 53.7888521389,
     "longitude": -1.3267968915
   },
   {
     "3alpha": "MIL",
-    "station_name": "Mill Hill Broadway Rail Station",
+    "station_name": "Mill Hill Broadway",
     "latitude": 51.6130940209,
     "longitude": -0.2492158407
   },
   {
     "3alpha": "MIM",
-    "station_name": "Moreton-in-Marsh Rail Station",
+    "station_name": "Moreton-in-Marsh",
     "latitude": 51.9922896467,
     "longitude": -1.700369111
   },
   {
     "3alpha": "MIN",
-    "station_name": "Milliken Park Rail Station",
+    "station_name": "Milliken Park",
     "latitude": 55.8251055368,
     "longitude": -4.5333409179
   },
   {
     "3alpha": "MIR",
-    "station_name": "Mirfield Rail Station",
+    "station_name": "Mirfield",
     "latitude": 53.6714142168,
     "longitude": -1.6925478902
   },
   {
     "3alpha": "MIS",
-    "station_name": "Mistley Rail Station",
+    "station_name": "Mistley",
     "latitude": 51.9436415764,
     "longitude": 1.081430084
   },
   {
     "3alpha": "MKC",
-    "station_name": "Milton Keynes Central Rail Station",
+    "station_name": "Milton Keynes Central",
     "latitude": 52.0342970583,
     "longitude": -0.7741256561
   },
   {
     "3alpha": "MKM",
-    "station_name": "Melksham Rail Station",
+    "station_name": "Melksham",
     "latitude": 51.3798186441,
     "longitude": -2.1444920323
   },
   {
     "3alpha": "MKR",
-    "station_name": "Market Rasen Rail Station",
+    "station_name": "Market Rasen",
     "latitude": 53.3839344671,
     "longitude": -0.3369000957
   },
   {
     "3alpha": "MKT",
-    "station_name": "Marks Tey Rail Station",
+    "station_name": "Marks Tey",
     "latitude": 51.8809486375,
     "longitude": 0.7833551606
   },
   {
     "3alpha": "MLB",
-    "station_name": "Millbrook (Beds) Rail Station",
+    "station_name": "Millbrook (Beds)",
     "latitude": 52.0538457297,
     "longitude": -0.5326807632
   },
   {
     "3alpha": "MLD",
-    "station_name": "Mouldsworth Rail Station",
+    "station_name": "Mouldsworth",
     "latitude": 53.2318188478,
     "longitude": -2.7322232144
   },
   {
     "3alpha": "MLF",
-    "station_name": "Milford (Surrey) Rail Station",
+    "station_name": "Milford (Surrey)",
     "latitude": 51.1633133767,
     "longitude": -0.6369282874
   },
   {
     "3alpha": "MLG",
-    "station_name": "Mallaig Rail Station",
+    "station_name": "Mallaig",
     "latitude": 57.005965587,
     "longitude": -5.8295792296
   },
   {
     "3alpha": "MLH",
-    "station_name": "Mill Hill (Lancs) Rail Station",
+    "station_name": "Mill Hill (Lancs)",
     "latitude": 53.7354717311,
     "longitude": -2.5017331794
   },
   {
     "3alpha": "MLM",
-    "station_name": "Millom Rail Station",
+    "station_name": "Millom",
     "latitude": 54.2108302797,
     "longitude": -3.2710839419
   },
   {
     "3alpha": "MLN",
-    "station_name": "Milngavie Rail Station",
+    "station_name": "Milngavie",
     "latitude": 55.9413575022,
     "longitude": -4.3145648876
   },
   {
     "3alpha": "MLT",
-    "station_name": "Malton Rail Station",
+    "station_name": "Malton",
     "latitude": 54.1320917413,
     "longitude": -0.7972330574
   },
   {
     "3alpha": "MLW",
-    "station_name": "Marlow Rail Station",
+    "station_name": "Marlow",
     "latitude": 51.5709950142,
     "longitude": -0.7664123608
   },
   {
     "3alpha": "MLY",
-    "station_name": "Morley Rail Station",
+    "station_name": "Morley",
     "latitude": 53.7499375883,
     "longitude": -1.5909802981
   },
   {
     "3alpha": "MMO",
-    "station_name": "Melton Mowbray Rail Station",
+    "station_name": "Melton Mowbray",
     "latitude": 52.7610494909,
     "longitude": -0.8858623625
   },
   {
     "3alpha": "MNC",
-    "station_name": "Markinch Rail Station",
+    "station_name": "Markinch",
     "latitude": 56.201006454,
     "longitude": -3.1307887208
   },
   {
     "3alpha": "MNE",
-    "station_name": "Manea Rail Station",
+    "station_name": "Manea",
     "latitude": 52.4978548877,
     "longitude": 0.1777139789
   },
   {
     "3alpha": "MNG",
-    "station_name": "Manningtree Rail Station",
+    "station_name": "Manningtree",
     "latitude": 51.9490620543,
     "longitude": 1.0452697914
   },
   {
     "3alpha": "MNN",
-    "station_name": "Menston Rail Station",
+    "station_name": "Menston",
     "latitude": 53.8923520984,
     "longitude": -1.7355135499
   },
   {
+    "3alpha": "MNS",
+    "station_name": "Maghull North",
+    "latitude": 53.5167,
+    "longitude": -2.9213
+  },
+  {
     "3alpha": "MNP",
-    "station_name": "Manor Park Rail Station",
+    "station_name": "Manor Park",
     "latitude": 51.5524760236,
     "longitude": 0.0463682122
   },
   {
     "3alpha": "MNR",
-    "station_name": "Manor Road Rail Station",
+    "station_name": "Manor Road",
     "latitude": 53.394793603,
     "longitude": -3.1714362959
   },
   {
     "3alpha": "MOB",
-    "station_name": "Mobberley Rail Station",
+    "station_name": "Mobberley",
     "latitude": 53.3291537972,
     "longitude": -2.3336642593
   },
   {
     "3alpha": "MOG",
-    "station_name": "Moorgate Rail Station",
+    "station_name": "Moorgate",
     "latitude": 51.5184914149,
     "longitude": -0.0889174169
   },
   {
     "3alpha": "MON",
-    "station_name": "Monifieth Rail Station",
+    "station_name": "Monifieth",
     "latitude": 56.4801011269,
     "longitude": -2.8182514848
   },
   {
     "3alpha": "MOO",
-    "station_name": "Muir of Ord Rail Station",
+    "station_name": "Muir of Ord",
     "latitude": 57.5178284795,
     "longitude": -4.460230876
   },
   {
     "3alpha": "MOR",
-    "station_name": "Mortimer Rail Station",
+    "station_name": "Mortimer",
     "latitude": 51.3720775119,
     "longitude": -1.0354903866
   },
   {
     "3alpha": "MOS",
-    "station_name": "Moss Side Rail Station",
+    "station_name": "Moss Side",
     "latitude": 53.764988776,
     "longitude": -2.9429318748
   },
   {
     "3alpha": "MOT",
-    "station_name": "Motspur Park Rail Station",
+    "station_name": "Motspur Park",
     "latitude": 51.3951937788,
     "longitude": -0.2395071447
   },
   {
     "3alpha": "MPK",
-    "station_name": "Mosspark Rail Station",
+    "station_name": "Mosspark",
     "latitude": 55.8408228806,
     "longitude": -4.3482777791
   },
   {
     "3alpha": "MPL",
-    "station_name": "Marple Rail Station",
+    "station_name": "Marple",
     "latitude": 53.4007069655,
     "longitude": -2.0572623816
   },
   {
     "3alpha": "MPT",
-    "station_name": "Morpeth Rail Station",
+    "station_name": "Morpeth",
     "latitude": 55.1623793108,
     "longitude": -1.6830875765
   },
   {
     "3alpha": "MRB",
-    "station_name": "Manorbier Rail Station",
+    "station_name": "Manorbier",
     "latitude": 51.6601657701,
     "longitude": -4.7918631589
   },
   {
     "3alpha": "MRD",
-    "station_name": "Morchard Road Rail Station",
+    "station_name": "Morchard Road",
     "latitude": 50.831888433,
     "longitude": -3.7763856573
   },
   {
     "3alpha": "MRF",
-    "station_name": "Moorfields Rail Station",
+    "station_name": "Moorfields",
     "latitude": 53.408577563,
     "longitude": -2.9891877739
   },
   {
     "3alpha": "MRN",
-    "station_name": "Marden Rail Station",
+    "station_name": "Marden",
     "latitude": 51.1751727189,
     "longitude": 0.4931989357
   },
   {
     "3alpha": "MRP",
-    "station_name": "Moorthorpe Rail Station",
+    "station_name": "Moorthorpe",
     "latitude": 53.5950120583,
     "longitude": -1.3049494779
   },
   {
     "3alpha": "MRR",
-    "station_name": "Morar Rail Station",
+    "station_name": "Morar",
     "latitude": 56.9696962652,
     "longitude": -5.8218995718
   },
   {
     "3alpha": "MRS",
-    "station_name": "Monks Risborough Rail Station",
+    "station_name": "Monks Risborough",
     "latitude": 51.7357654911,
     "longitude": -0.8293110058
   },
   {
     "3alpha": "MRT",
-    "station_name": "Moreton (Merseyside) Rail Station",
+    "station_name": "Moreton (Merseyside)",
     "latitude": 53.4072225806,
     "longitude": -3.1134999967
   },
   {
+    "3alpha":"MRW",
+    "station_name":"Meridian Water",
+    "latitude": 51.61,
+    "longitude": -0.0501
+  },
+  {
     "3alpha": "MRY",
-    "station_name": "Maryport Rail Station",
+    "station_name": "Maryport",
     "latitude": 54.71132475,
     "longitude": -3.4940750264
   },
   {
     "3alpha": "MSD",
-    "station_name": "Moorside Rail Station",
+    "station_name": "Moorside",
     "latitude": 53.516289171,
     "longitude": -2.351797693
   },
   {
     "3alpha": "MSH",
-    "station_name": "Mossley Hill Rail Station",
+    "station_name": "Mossley Hill",
     "latitude": 53.3790525198,
     "longitude": -2.9154430601
   },
   {
     "3alpha": "MSK",
-    "station_name": "Marske Rail Station",
+    "station_name": "Marske",
     "latitude": 54.5874288395,
     "longitude": -1.0189249961
   },
   {
     "3alpha": "MSL",
-    "station_name": "Mossley (Manchester) Rail Station",
+    "station_name": "Mossley (Manchester)",
     "latitude": 53.5149938702,
     "longitude": -2.0412799663
   },
   {
     "3alpha": "MSN",
-    "station_name": "Marsden Rail Station",
+    "station_name": "Marsden",
     "latitude": 53.6031989506,
     "longitude": -1.9307489058
   },
   {
     "3alpha": "MSO",
-    "station_name": "Moston Rail Station",
+    "station_name": "Moston",
     "latitude": 53.5234344757,
     "longitude": -2.1710210757
   },
   {
     "3alpha": "MSR",
-    "station_name": "Minster Rail Station",
+    "station_name": "Minster",
     "latitude": 51.3291791939,
     "longitude": 1.3172443102
   },
   {
     "3alpha": "MSS",
-    "station_name": "Moses Gate Rail Station",
+    "station_name": "Moses Gate",
     "latitude": 53.5559962598,
     "longitude": -2.4011861486
   },
   {
     "3alpha": "MST",
-    "station_name": "Maesteg Rail Station",
+    "station_name": "Maesteg",
     "latitude": 51.6099392672,
     "longitude": -3.6546614792
   },
   {
     "3alpha": "MSW",
-    "station_name": "Mansfield Woodhouse Rail Station",
+    "station_name": "Mansfield Woodhouse",
     "latitude": 53.1635798405,
     "longitude": -1.201846595
   },
   {
     "3alpha": "MTA",
-    "station_name": "Mountain Ash Rail Station",
+    "station_name": "Mountain Ash",
     "latitude": 51.6813336784,
     "longitude": -3.3763534667
   },
   {
     "3alpha": "MTB",
-    "station_name": "Matlock Bath Rail Station",
+    "station_name": "Matlock Bath",
     "latitude": 53.1223708532,
     "longitude": -1.5567564386
   },
   {
     "3alpha": "MTC",
-    "station_name": "Mitcham Eastfields Rail Station",
+    "station_name": "Mitcham Eastfields",
     "latitude": 51.4077364814,
     "longitude": -0.1546204515
   },
   {
     "3alpha": "MTG",
-    "station_name": "Mottingham Rail Station",
+    "station_name": "Mottingham",
     "latitude": 51.4402167384,
     "longitude": 0.0500802261
   },
   {
     "3alpha": "MTH",
-    "station_name": "Motherwell Rail Station",
+    "station_name": "Motherwell",
     "latitude": 55.7916692892,
     "longitude": -3.9943169398
   },
   {
     "3alpha": "MTL",
-    "station_name": "Mortlake Rail Station",
+    "station_name": "Mortlake",
     "latitude": 51.468085138,
     "longitude": -0.2670827547
   },
   {
     "3alpha": "MTM",
-    "station_name": "Martin Mill Rail Station",
+    "station_name": "Martin Mill",
     "latitude": 51.1706839505,
     "longitude": 1.3482479873
   },
   {
     "3alpha": "MTN",
-    "station_name": "Moreton (Dorset) Rail Station",
+    "station_name": "Moreton (Dorset)",
     "latitude": 50.7010195625,
     "longitude": -2.3134461541
   },
   {
     "3alpha": "MTO",
-    "station_name": "Marton Rail Station",
+    "station_name": "Marton",
     "latitude": 54.5443541756,
     "longitude": -1.1984988205
   },
   {
     "3alpha": "MTP",
-    "station_name": "Montpelier Rail Station",
+    "station_name": "Montpelier",
     "latitude": 51.4683464285,
     "longitude": -2.5886872075
   },
   {
     "3alpha": "MTS",
-    "station_name": "Montrose Rail Station",
+    "station_name": "Montrose",
     "latitude": 56.7127857624,
     "longitude": -2.4720806987
   },
   {
     "3alpha": "MTV",
-    "station_name": "Mount Vernon Rail Station",
+    "station_name": "Mount Vernon",
     "latitude": 55.84019612,
     "longitude": -4.133656173
   },
   {
     "3alpha": "MUB",
-    "station_name": "Musselburgh Rail Station",
+    "station_name": "Musselburgh",
     "latitude": 55.9335850009,
     "longitude": -3.0732054363
   },
   {
     "3alpha": "MUF",
-    "station_name": "Manchester United FC Rail Station",
+    "station_name": "Manchester United FC",
     "latitude": 53.4622084856,
     "longitude": -2.290652901
   },
   {
     "3alpha": "MUI",
-    "station_name": "Muirend Rail Station",
+    "station_name": "Muirend",
     "latitude": 55.8094528886,
     "longitude": -4.274377937
   },
   {
     "3alpha": "MVL",
-    "station_name": "Malvern Link Rail Station",
+    "station_name": "Malvern Link",
     "latitude": 52.1254773107,
     "longitude": -2.3195074315
   },
   {
     "3alpha": "MYB",
-    "station_name": "London Marylebone Rail Station",
+    "station_name": "London Marylebone",
     "latitude": 51.522523885,
     "longitude": -0.1628859644
   },
   {
     "3alpha": "MYH",
-    "station_name": "Maryhill Rail Station",
+    "station_name": "Maryhill",
     "latitude": 55.8976237197,
     "longitude": -4.3007303486
   },
   {
     "3alpha": "MYL",
-    "station_name": "Maryland Rail Station",
+    "station_name": "Maryland",
     "latitude": 51.5460813657,
     "longitude": 0.005842588
   },
   {
     "3alpha": "MYT",
-    "station_name": "Mytholmroyd Rail Station",
+    "station_name": "Mytholmroyd",
     "latitude": 53.7290162532,
     "longitude": -1.9814271564
   },
   {
     "3alpha": "MZH",
-    "station_name": "Maze Hill Rail Station",
+    "station_name": "Maze Hill",
     "latitude": 51.4826233713,
     "longitude": 0.0029400062
   },
   {
     "3alpha": "NAN",
-    "station_name": "Nantwich Rail Station",
+    "station_name": "Nantwich",
     "latitude": 53.0635867383,
     "longitude": -2.5189592102
   },
   {
     "3alpha": "NAR",
-    "station_name": "Narberth Rail Station",
+    "station_name": "Narberth",
     "latitude": 51.7993779002,
     "longitude": -4.7272043319
   },
   {
     "3alpha": "NAY",
-    "station_name": "Newton Aycliffe Rail Station",
+    "station_name": "Newton Aycliffe",
     "latitude": 54.6137111141,
     "longitude": -1.5896555578
   },
   {
     "3alpha": "NBA",
-    "station_name": "New Barnet Rail Station",
+    "station_name": "New Barnet",
     "latitude": 51.6485757882,
     "longitude": -0.1729714788
   },
   {
     "3alpha": "NBC",
-    "station_name": "New Beckenham Rail Station",
+    "station_name": "New Beckenham",
     "latitude": 51.416767136,
     "longitude": -0.0352474454
   },
   {
     "3alpha": "NBE",
-    "station_name": "Newbridge Rail Station",
+    "station_name": "Newbridge",
     "latitude": 51.665815285,
     "longitude": -3.1428939856
   },
   {
     "3alpha": "NBN",
-    "station_name": "New Brighton Rail Station",
+    "station_name": "New Brighton",
     "latitude": 53.437415844,
     "longitude": -3.0479632359
   },
   {
     "3alpha": "NBR",
-    "station_name": "Narborough Rail Station",
+    "station_name": "Narborough",
     "latitude": 52.5713097683,
     "longitude": -1.2033367857
   },
   {
     "3alpha": "NBT",
-    "station_name": "Norbiton Rail Station",
+    "station_name": "Norbiton",
     "latitude": 51.4123555216,
     "longitude": -0.2840028162
   },
   {
     "3alpha": "NBW",
-    "station_name": "North Berwick Rail Station",
+    "station_name": "North Berwick",
     "latitude": 56.0570302209,
     "longitude": -2.7307472989
   },
   {
     "3alpha": "NBY",
-    "station_name": "Newbury Rail Station",
+    "station_name": "Newbury",
     "latitude": 51.397647103,
     "longitude": -1.3228424921
   },
   {
     "3alpha": "NCE",
-    "station_name": "New Clee Rail Station",
+    "station_name": "New Clee",
     "latitude": 53.5744020885,
     "longitude": -0.0608183009
   },
   {
     "3alpha": "NCK",
-    "station_name": "New Cumnock Rail Station",
+    "station_name": "New Cumnock",
     "latitude": 55.4027409338,
     "longitude": -4.1843292426
   },
   {
     "3alpha": "NCL",
-    "station_name": "Newcastle Rail Station",
+    "station_name": "Newcastle",
     "latitude": 54.9684070401,
     "longitude": -1.6172925574
   },
   {
     "3alpha": "NCM",
-    "station_name": "North Camp Rail Station",
+    "station_name": "North Camp",
     "latitude": 51.2757921453,
     "longitude": -0.731181183
   },
   {
     "3alpha": "NCO",
-    "station_name": "Newcourt Rail Station",
+    "station_name": "Newcourt",
     "latitude": 50.7050286867,
     "longitude": -3.4727977721
   },
   {
     "3alpha": "NCT",
-    "station_name": "Newark Castle Rail Station",
+    "station_name": "Newark Castle",
     "latitude": 53.080022402,
     "longitude": -0.8131567694
   },
   {
     "3alpha": "NDL",
-    "station_name": "North Dulwich Rail Station",
+    "station_name": "North Dulwich",
     "latitude": 51.4545089621,
     "longitude": -0.0878918236
   },
   {
     "3alpha": "NEG",
-    "station_name": "Newtongrange Rail Station",
+    "station_name": "Newtongrange",
     "latitude": 55.8669914004,
     "longitude": -3.0693694316
   },
   {
     "3alpha": "NEH",
-    "station_name": "New Eltham Rail Station",
+    "station_name": "New Eltham",
     "latitude": 51.4380580221,
     "longitude": 0.0705593927
   },
   {
     "3alpha": "NEI",
-    "station_name": "Neilston Rail Station",
+    "station_name": "Neilston",
     "latitude": 55.7830319543,
     "longitude": -4.4269370486
   },
   {
     "3alpha": "NEL",
-    "station_name": "Nelson Rail Station",
+    "station_name": "Nelson",
     "latitude": 53.8350188567,
     "longitude": -2.2137611849
   },
   {
     "3alpha": "NEM",
-    "station_name": "New Malden Rail Station",
+    "station_name": "New Malden",
     "latitude": 51.4040722425,
     "longitude": -0.2559166562
   },
   {
     "3alpha": "NES",
-    "station_name": "Neston Rail Station",
+    "station_name": "Neston",
     "latitude": 53.2918652932,
     "longitude": -3.0630755474
   },
   {
     "3alpha": "NET",
-    "station_name": "Netherfield Rail Station",
+    "station_name": "Netherfield",
     "latitude": 52.9614294437,
     "longitude": -1.0798460669
   },
   {
     "3alpha": "NEW",
-    "station_name": "Newcraighall Rail Station",
+    "station_name": "Newcraighall",
     "latitude": 55.9331154017,
     "longitude": -3.0908472906
   },
   {
     "3alpha": "NFA",
-    "station_name": "North Fambridge Rail Station",
+    "station_name": "North Fambridge",
     "latitude": 51.6485874442,
     "longitude": 0.6816868594
   },
   {
     "3alpha": "NFD",
-    "station_name": "Northfield Rail Station",
+    "station_name": "Northfield",
     "latitude": 52.408205022,
     "longitude": -1.9658445265
   },
   {
     "3alpha": "NFL",
-    "station_name": "Northfleet Rail Station",
+    "station_name": "Northfleet",
     "latitude": 51.4458444738,
     "longitude": 0.3243627291
   },
   {
     "3alpha": "NFN",
-    "station_name": "Nafferton Rail Station",
+    "station_name": "Nafferton",
     "latitude": 54.0112409619,
     "longitude": -0.3860877568
   },
   {
     "3alpha": "NGT",
-    "station_name": "Newington Rail Station",
+    "station_name": "Newington",
     "latitude": 51.3533404814,
     "longitude": 0.6686002778
   },
   {
     "3alpha": "NHD",
-    "station_name": "Nunhead Rail Station",
+    "station_name": "Nunhead",
     "latitude": 51.4668266219,
     "longitude": -0.0522470725
   },
   {
     "3alpha": "NHE",
-    "station_name": "New Hythe Rail Station",
+    "station_name": "New Hythe",
     "latitude": 51.3130005132,
     "longitude": 0.4549583652
   },
   {
     "3alpha": "NHL",
-    "station_name": "New Holland Rail Station",
+    "station_name": "New Holland",
     "latitude": 53.7019404883,
     "longitude": -0.3602195506
   },
   {
     "3alpha": "NIT",
-    "station_name": "Nitshill Rail Station",
+    "station_name": "Nitshill",
     "latitude": 55.8119290151,
     "longitude": -4.3599440893
   },
   {
     "3alpha": "NLN",
-    "station_name": "New Lane Rail Station",
+    "station_name": "New Lane",
     "latitude": 53.611676421,
     "longitude": -2.8677150822
   },
   {
     "3alpha": "NLR",
-    "station_name": "North Llanrwst Rail Station",
+    "station_name": "North Llanrwst",
     "latitude": 53.1438364668,
     "longitude": -3.8027318185
   },
   {
     "3alpha": "NLS",
-    "station_name": "Nailsea & Backwell Rail Station",
+    "station_name": "Nailsea & Backwell",
     "latitude": 51.4194043932,
     "longitude": -2.750638165
   },
   {
     "3alpha": "NLT",
-    "station_name": "Northolt Park Rail Station",
+    "station_name": "Northolt Park",
     "latitude": 51.5575391716,
     "longitude": -0.3594445305
   },
   {
     "3alpha": "NLW",
-    "station_name": "Newton-le-Willows Rail Station",
+    "station_name": "Newton-le-Willows",
     "latitude": 53.4530749987,
     "longitude": -2.6135973334
   },
   {
     "3alpha": "NMC",
-    "station_name": "New Mills Central Rail Station",
+    "station_name": "New Mills Central",
     "latitude": 53.3648560934,
     "longitude": -2.0056703312
   },
   {
     "3alpha": "NMK",
-    "station_name": "Newmarket Rail Station",
+    "station_name": "Newmarket",
     "latitude": 52.2379580874,
     "longitude": 0.4062358785
   },
   {
     "3alpha": "NMN",
-    "station_name": "New Mills Newtown Rail Station",
+    "station_name": "New Mills Newtown",
     "latitude": 53.3596424903,
     "longitude": -2.0085245142
   },
   {
     "3alpha": "NMP",
-    "station_name": "Northampton Rail Station",
+    "station_name": "Northampton",
     "latitude": 52.2375139145,
     "longitude": -0.906638854
   },
   {
     "3alpha": "NMT",
-    "station_name": "Needham Market Rail Station",
+    "station_name": "Needham Market",
     "latitude": 52.1526036565,
     "longitude": 1.0552904861
   },
   {
     "3alpha": "NNG",
-    "station_name": "Newark North Gate Rail Station",
+    "station_name": "Newark North Gate",
     "latitude": 53.0817767766,
     "longitude": -0.7998511914
   },
   {
     "3alpha": "NNP",
-    "station_name": "Ninian Park Rail Station",
+    "station_name": "Ninian Park",
     "latitude": 51.4766151237,
     "longitude": -3.2017026277
   },
   {
     "3alpha": "NNT",
-    "station_name": "Nunthorpe Rail Station",
+    "station_name": "Nunthorpe",
     "latitude": 54.5278916561,
     "longitude": -1.1694623307
   },
   {
     "3alpha": "NOA",
-    "station_name": "Newton-on-Ayr Rail Station",
+    "station_name": "Newton-on-Ayr",
     "latitude": 55.4740529017,
     "longitude": -4.6258056575
   },
   {
     "3alpha": "NOR",
-    "station_name": "Normanton Rail Station",
+    "station_name": "Normanton",
     "latitude": 53.7005346086,
     "longitude": -1.4234040424
   },
   {
     "3alpha": "NOT",
-    "station_name": "Nottingham Rail Station",
+    "station_name": "Nottingham",
     "latitude": 52.9470929341,
     "longitude": -1.1463789462
   },
   {
     "3alpha": "NPD",
-    "station_name": "New Pudsey Rail Station",
+    "station_name": "New Pudsey",
     "latitude": 53.8044975251,
     "longitude": -1.6807968849
   },
   {
     "3alpha": "NQU",
-    "station_name": "North Queensferry Rail Station",
+    "station_name": "North Queensferry",
     "latitude": 56.0124941531,
     "longitude": -3.394582615
   },
   {
     "3alpha": "NQY",
-    "station_name": "Newquay Rail Station",
+    "station_name": "Newquay",
     "latitude": 50.415084133,
     "longitude": -5.0756989533
   },
   {
     "3alpha": "NRB",
-    "station_name": "Norbury Rail Station",
+    "station_name": "Norbury",
     "latitude": 51.4114439365,
     "longitude": -0.1219000953
   },
   {
     "3alpha": "NRC",
-    "station_name": "Newbury Racecourse Rail Station",
+    "station_name": "Newbury Racecourse",
     "latitude": 51.3984581516,
     "longitude": -1.3077799439
   },
   {
     "3alpha": "NRD",
-    "station_name": "North Road Rail Station",
+    "station_name": "North Road",
     "latitude": 54.5362092283,
     "longitude": -1.5539587211
   },
   {
     "3alpha": "NRN",
-    "station_name": "Nairn Rail Station",
+    "station_name": "Nairn",
     "latitude": 57.5802287419,
     "longitude": -3.871999953
   },
   {
     "3alpha": "NRT",
-    "station_name": "Nethertown Rail Station",
+    "station_name": "Nethertown",
     "latitude": 54.4564242911,
     "longitude": -3.5658366589
   },
   {
     "3alpha": "NRW",
-    "station_name": "Norwich Rail Station",
+    "station_name": "Norwich",
     "latitude": 52.6271764442,
     "longitude": 1.3068436175
   },
   {
     "3alpha": "NSB",
-    "station_name": "Normans Bay Rail Station",
+    "station_name": "Normans Bay",
     "latitude": 50.8260972868,
     "longitude": 0.3894907962
   },
   {
     "3alpha": "NSD",
-    "station_name": "Newstead Rail Station",
+    "station_name": "Newstead",
     "latitude": 53.0699991881,
     "longitude": -1.221784818
   },
   {
     "3alpha": "NSG",
-    "station_name": "New Southgate Rail Station",
+    "station_name": "New Southgate",
     "latitude": 51.6141146074,
     "longitude": -0.1430125641
   },
   {
     "3alpha": "NSH",
-    "station_name": "North Sheen Rail Station",
+    "station_name": "North Sheen",
     "latitude": 51.4651527407,
     "longitude": -0.2878532427
   },
   {
     "3alpha": "NTA",
-    "station_name": "Newton Abbot Rail Station",
+    "station_name": "Newton Abbot",
     "latitude": 50.5295709354,
     "longitude": -3.5991818536
   },
   {
     "3alpha": "NTB",
-    "station_name": "Norton Bridge Rail Station",
+    "station_name": "Norton Bridge",
     "latitude": 52.8667125875,
     "longitude": -2.1905418489
   },
   {
     "3alpha": "NTC",
-    "station_name": "Newton St Cyres Rail Station",
+    "station_name": "Newton St Cyres",
     "latitude": 50.7789165834,
     "longitude": -3.589404542
   },
   {
     "3alpha": "NTH",
-    "station_name": "Neath Rail Station",
+    "station_name": "Neath",
     "latitude": 51.6623638663,
     "longitude": -3.8072343482
   },
   {
     "3alpha": "NTL",
-    "station_name": "Netley Rail Station",
+    "station_name": "Netley",
     "latitude": 50.8748975168,
     "longitude": -1.3418931628
   },
   {
     "3alpha": "NTN",
-    "station_name": "Newton (S Lanarks) Rail Station",
+    "station_name": "Newton (S Lanarks)",
     "latitude": 55.8187724129,
     "longitude": -4.1330414607
   },
   {
     "3alpha": "NTR",
-    "station_name": "Northallerton Rail Station",
+    "station_name": "Northallerton",
     "latitude": 54.3330824604,
     "longitude": -1.4412825015
   },
   {
     "3alpha": "NUF",
-    "station_name": "Nutfield Rail Station",
+    "station_name": "Nutfield",
     "latitude": 51.2268096258,
     "longitude": -0.1325049602
   },
   {
     "3alpha": "NUM",
-    "station_name": "Northumberland Park Rail Station",
+    "station_name": "Northumberland Park",
     "latitude": 51.6019688995,
     "longitude": -0.0539069251
   },
   {
     "3alpha": "NUN",
-    "station_name": "Nuneaton Rail Station",
+    "station_name": "Nuneaton",
     "latitude": 52.5263860835,
     "longitude": -1.4638662754
   },
   {
     "3alpha": "NUT",
-    "station_name": "Nutbourne Rail Station",
+    "station_name": "Nutbourne",
     "latitude": 50.8460585998,
     "longitude": -0.8829282409
   },
   {
     "3alpha": "NVH",
-    "station_name": "Newhaven Harbour Rail Station",
+    "station_name": "Newhaven Harbour",
     "latitude": 50.7897843615,
     "longitude": 0.0550205943
   },
   {
     "3alpha": "NVN",
-    "station_name": "Newhaven Town Rail Station",
+    "station_name": "Newhaven Town",
     "latitude": 50.7948486315,
     "longitude": 0.0549731113
   },
   {
     "3alpha": "NVR",
-    "station_name": "Navigation Road Rail Station",
+    "station_name": "Navigation Road",
     "latitude": 53.3953905024,
     "longitude": -2.3434169235
   },
   {
     "3alpha": "NWA",
-    "station_name": "North Walsham Rail Station",
+    "station_name": "North Walsham",
     "latitude": 52.8169121918,
     "longitude": 1.3844751173
   },
   {
     "3alpha": "NWB",
-    "station_name": "North Wembley Rail Station",
+    "station_name": "North Wembley",
     "latitude": 51.5625961704,
     "longitude": -0.3039615425
   },
   {
     "3alpha": "NWD",
-    "station_name": "Norwood Junction Rail Station",
+    "station_name": "Norwood Junction",
     "latitude": 51.397016964,
     "longitude": -0.0751960155
   },
   {
     "3alpha": "NWE",
-    "station_name": "Newport (Essex) Rail Station",
+    "station_name": "Newport (Essex)",
     "latitude": 51.9798767674,
     "longitude": 0.2151664222
   },
   {
     "3alpha": "NWI",
-    "station_name": "Northwich Rail Station",
+    "station_name": "Northwich",
     "latitude": 53.2614653974,
     "longitude": -2.4969157221
   },
   {
     "3alpha": "NWM",
-    "station_name": "New Milton Rail Station",
+    "station_name": "New Milton",
     "latitude": 50.7557417759,
     "longitude": -1.657805844
   },
   {
     "3alpha": "NWN",
-    "station_name": "Newton for Hyde Rail Station",
+    "station_name": "Newton for Hyde",
     "latitude": 53.4563946328,
     "longitude": -2.0671424184
   },
   {
     "3alpha": "NWP",
-    "station_name": "Newport (S Wales) Rail Station",
+    "station_name": "Newport (S Wales)",
     "latitude": 51.5887891555,
     "longitude": -3.0005496511
   },
   {
     "3alpha": "NWR",
-    "station_name": "Newtonmore Rail Station",
+    "station_name": "Newtonmore",
     "latitude": 57.0591301765,
     "longitude": -4.1191037522
   },
   {
     "3alpha": "NWT",
-    "station_name": "Newtown (Powys) Rail Station",
+    "station_name": "Newtown (Powys)",
     "latitude": 52.5123270805,
     "longitude": -3.3113949158
   },
   {
     "3alpha": "NWX",
-    "station_name": "New Cross ELL Rail Station",
+    "station_name": "New Cross ELL",
     "latitude": 51.4763425048,
     "longitude": -0.0324150961
   },
   {
     "3alpha": "NXG",
-    "station_name": "New Cross Gate ELL Rail Station",
+    "station_name": "New Cross Gate ELL",
     "latitude": 51.4751271677,
     "longitude": -0.0403876579
   },
   {
     "3alpha": "OBN",
-    "station_name": "Oban Rail Station",
+    "station_name": "Oban",
     "latitude": 56.4124709629,
     "longitude": -5.4739093886
   },
   {
     "3alpha": "OCK",
-    "station_name": "Ockendon Rail Station",
+    "station_name": "Ockendon",
     "latitude": 51.5219914043,
     "longitude": 0.290497263
   },
   {
     "3alpha": "OHL",
-    "station_name": "Old Hill Rail Station",
+    "station_name": "Old Hill",
     "latitude": 52.470947074,
     "longitude": -2.0561848613
   },
   {
     "3alpha": "OKE",
-    "station_name": "Okehampton Rail Station",
+    "station_name": "Okehampton",
     "latitude": 50.7323709771,
     "longitude": -3.9962371646
   },
   {
     "3alpha": "OKL",
-    "station_name": "Oakleigh Park Rail Station",
+    "station_name": "Oakleigh Park",
     "latitude": 51.637679136,
     "longitude": -0.1661837043
   },
   {
     "3alpha": "OKM",
-    "station_name": "Oakham Rail Station",
+    "station_name": "Oakham",
     "latitude": 52.6722323623,
     "longitude": -0.7341607803
   },
   {
     "3alpha": "OKN",
-    "station_name": "Oakengates Rail Station",
+    "station_name": "Oakengates",
     "latitude": 52.6934109391,
     "longitude": -2.4501927064
   },
   {
     "3alpha": "OLD",
-    "station_name": "Old Street Rail Station",
+    "station_name": "Old Street",
     "latitude": 51.5258317895,
     "longitude": -0.0885090187
   },
   {
     "3alpha": "OLF",
-    "station_name": "Oldfield Park Rail Station",
+    "station_name": "Oldfield Park",
     "latitude": 51.3792256566,
     "longitude": -2.3805068483
   },
   {
     "3alpha": "OLT",
-    "station_name": "Olton Rail Station",
+    "station_name": "Olton",
     "latitude": 52.438524483,
     "longitude": -1.8043032158
   },
   {
     "3alpha": "OLY",
-    "station_name": "Ockley Rail Station",
+    "station_name": "Ockley",
     "latitude": 51.1515064148,
     "longitude": -0.3359877818
   },
   {
     "3alpha": "OMS",
-    "station_name": "Ormskirk Rail Station",
+    "station_name": "Ormskirk",
     "latitude": 53.56928696,
     "longitude": -2.8811915199
   },
   {
     "3alpha": "OPK",
-    "station_name": "Orrell Park Rail Station",
+    "station_name": "Orrell Park",
     "latitude": 53.4619123452,
     "longitude": -2.9633147359
   },
   {
     "3alpha": "OPY",
-    "station_name": "Oxford Parkway Rail Station",
+    "station_name": "Oxford Parkway",
     "latitude": 51.8040758686,
     "longitude": -1.2744681129
   },
   {
     "3alpha": "ORE",
-    "station_name": "Ore Rail Station",
+    "station_name": "Ore",
     "latitude": 50.8669427332,
     "longitude": 0.591596612
   },
   {
     "3alpha": "ORN",
-    "station_name": "Old Roan Rail Station",
+    "station_name": "Old Roan",
     "latitude": 53.4869093953,
     "longitude": -2.9510705094
   },
   {
     "3alpha": "ORP",
-    "station_name": "Orpington Rail Station",
+    "station_name": "Orpington",
     "latitude": 51.3732951318,
     "longitude": 0.0891167615
   },
   {
     "3alpha": "ORR",
-    "station_name": "Orrell Rail Station",
+    "station_name": "Orrell",
     "latitude": 53.530325904,
     "longitude": -2.7088376683
   },
   {
     "3alpha": "OTF",
-    "station_name": "Otford Rail Station",
+    "station_name": "Otford",
     "latitude": 51.313155145,
     "longitude": 0.1968058758
   },
   {
     "3alpha": "OUN",
-    "station_name": "Oulton Broad North Rail Station",
+    "station_name": "Oulton Broad North",
     "latitude": 52.4777844841,
     "longitude": 1.7157356055
   },
   {
     "3alpha": "OUS",
-    "station_name": "Oulton Broad South Rail Station",
+    "station_name": "Oulton Broad South",
     "latitude": 52.4696271149,
     "longitude": 1.7076837204
   },
   {
     "3alpha": "OUT",
-    "station_name": "Outwood Rail Station",
+    "station_name": "Outwood",
     "latitude": 53.7153018923,
     "longitude": -1.5104034645
   },
   {
     "3alpha": "OVE",
-    "station_name": "Overpool Rail Station",
+    "station_name": "Overpool",
     "latitude": 53.2840618342,
     "longitude": -2.9240604888
   },
   {
     "3alpha": "OVR",
-    "station_name": "Overton Rail Station",
+    "station_name": "Overton",
     "latitude": 51.2542901889,
     "longitude": -1.2592504239
   },
   {
     "3alpha": "OXF",
-    "station_name": "Oxford Rail Station",
+    "station_name": "Oxford",
     "latitude": 51.753499533,
     "longitude": -1.2701353856
   },
   {
     "3alpha": "OXN",
-    "station_name": "Oxenholme Lake District Rail Station",
+    "station_name": "Oxenholme Lake District",
     "latitude": 54.3049347745,
     "longitude": -2.7218718643
   },
   {
     "3alpha": "OXS",
-    "station_name": "Oxshott Rail Station",
+    "station_name": "Oxshott",
     "latitude": 51.3363929984,
     "longitude": -0.3623961961
   },
   {
     "3alpha": "OXT",
-    "station_name": "Oxted Rail Station",
+    "station_name": "Oxted",
     "latitude": 51.2579045834,
     "longitude": -0.0048073736
   },
   {
     "3alpha": "PAD",
-    "station_name": "London Paddington Rail Station",
+    "station_name": "London Paddington",
     "latitude": 51.515995347,
     "longitude": -0.1761493939
   },
   {
     "3alpha": "PAL",
-    "station_name": "Palmers Green Rail Station",
+    "station_name": "Palmers Green",
     "latitude": 51.6183152407,
     "longitude": -0.1104116731
   },
   {
     "3alpha": "PAN",
-    "station_name": "Pangbourne Rail Station",
+    "station_name": "Pangbourne",
     "latitude": 51.4854011729,
     "longitude": -1.0904500754
   },
   {
     "3alpha": "PAR",
-    "station_name": "Par Rail Station",
+    "station_name": "Par",
     "latitude": 50.3553115511,
     "longitude": -4.7047163536
   },
   {
     "3alpha": "PAT",
-    "station_name": "Patricroft Rail Station",
+    "station_name": "Patricroft",
     "latitude": 53.4847921621,
     "longitude": -2.3582432532
   },
   {
     "3alpha": "PBL",
-    "station_name": "Parbold Rail Station",
+    "station_name": "Parbold",
     "latitude": 53.5907686118,
     "longitude": -2.7707477548
   },
   {
     "3alpha": "PBO",
-    "station_name": "Peterborough Rail Station",
+    "station_name": "Peterborough",
     "latitude": 52.5749924034,
     "longitude": -0.2498227798
   },
   {
     "3alpha": "PBR",
-    "station_name": "Potters Bar Rail Station",
+    "station_name": "Potters Bar",
     "latitude": 51.6970695641,
     "longitude": -0.1925817236
   },
   {
     "3alpha": "PBY",
-    "station_name": "Pembrey & Burry Port Rail Station",
+    "station_name": "Pembrey & Burry Port",
     "latitude": 51.6835326809,
     "longitude": -4.2478649262
   },
   {
     "3alpha": "PCD",
-    "station_name": "Pencoed Rail Station",
+    "station_name": "Pencoed",
     "latitude": 51.5246083186,
     "longitude": -3.5004926045
   },
   {
     "3alpha": "PCN",
-    "station_name": "Paisley Canal Rail Station",
+    "station_name": "Paisley Canal",
     "latitude": 55.8400708211,
     "longitude": -4.4241022116
   },
   {
     "3alpha": "PDG",
-    "station_name": "Padgate Rail Station",
+    "station_name": "Padgate",
     "latitude": 53.4058038948,
     "longitude": -2.5568110117
   },
   {
     "3alpha": "PDW",
-    "station_name": "Paddock Wood Rail Station",
+    "station_name": "Paddock Wood",
     "latitude": 51.1822633724,
     "longitude": 0.3891775302
   },
   {
     "3alpha": "PEA",
-    "station_name": "Peartree Rail Station",
+    "station_name": "Peartree",
     "latitude": 52.8970116224,
     "longitude": -1.4732098615
   },
   {
     "3alpha": "PEB",
-    "station_name": "Pevensey Bay Rail Station",
+    "station_name": "Pevensey Bay",
     "latitude": 50.8174539615,
     "longitude": 0.3429353987
   },
   {
     "3alpha": "PEG",
-    "station_name": "Pegswood Rail Station",
+    "station_name": "Pegswood",
     "latitude": 55.1781320707,
     "longitude": -1.6441787746
   },
   {
     "3alpha": "PEM",
-    "station_name": "Pemberton Rail Station",
+    "station_name": "Pemberton",
     "latitude": 53.5304214463,
     "longitude": -2.6703543304
   },
   {
     "3alpha": "PEN",
-    "station_name": "Penarth Rail Station",
+    "station_name": "Penarth",
     "latitude": 51.4358873168,
     "longitude": -3.1744496863
   },
   {
     "3alpha": "PER",
-    "station_name": "Penrhiwceiber Rail Station",
+    "station_name": "Penrhiwceiber",
     "latitude": 51.6699251561,
     "longitude": -3.3599562105
   },
   {
     "3alpha": "PES",
-    "station_name": "Pensarn (Gwynedd) Rail Station",
+    "station_name": "Pensarn (Gwynedd)",
     "latitude": 52.8307204357,
     "longitude": -4.1121665744
   },
   {
     "3alpha": "PET",
-    "station_name": "Petts Wood Rail Station",
+    "station_name": "Petts Wood",
     "latitude": 51.3886176381,
     "longitude": 0.0745066346
   },
   {
     "3alpha": "PEV",
-    "station_name": "Pevensey & Westham Rail Station",
+    "station_name": "Pevensey & Westham",
     "latitude": 50.8157924588,
     "longitude": 0.3248360436
   },
   {
     "3alpha": "PEW",
-    "station_name": "Pewsey Rail Station",
+    "station_name": "Pewsey",
     "latitude": 51.342188386,
     "longitude": -1.7706654384
   },
   {
     "3alpha": "PFL",
-    "station_name": "Purfleet Rail Station",
+    "station_name": "Purfleet",
     "latitude": 51.4810119817,
     "longitude": 0.2367953506
   },
   {
     "3alpha": "PFM",
-    "station_name": "Pontefract Monkhill Rail Station",
+    "station_name": "Pontefract Monkhill",
     "latitude": 53.6990008028,
     "longitude": -1.3036919442
   },
   {
     "3alpha": "PFR",
-    "station_name": "Pontefract Baghill Rail Station",
+    "station_name": "Pontefract Baghill",
     "latitude": 53.6918982987,
     "longitude": -1.3033551435
   },
   {
     "3alpha": "PFY",
-    "station_name": "Poulton-le-Fylde Rail Station",
+    "station_name": "Poulton-le-Fylde",
     "latitude": 53.8484388445,
     "longitude": -2.9906188413
   },
   {
     "3alpha": "PGM",
-    "station_name": "Pengam Rail Station",
+    "station_name": "Pengam",
     "latitude": 51.6704563039,
     "longitude": -3.2301095675
   },
   {
     "3alpha": "PGN",
-    "station_name": "Paignton Rail Station",
+    "station_name": "Paignton",
     "latitude": 50.4347023859,
     "longitude": -3.5648917612
   },
   {
     "3alpha": "PHG",
-    "station_name": "Penhelig Rail Station",
+    "station_name": "Penhelig",
     "latitude": 52.5457006306,
     "longitude": -4.0350346008
   },
   {
     "3alpha": "PHR",
-    "station_name": "Penshurst Rail Station",
+    "station_name": "Penshurst",
     "latitude": 51.1973335413,
     "longitude": 0.1734986012
   },
   {
     "3alpha": "PIL",
-    "station_name": "Pilning Rail Station",
+    "station_name": "Pilning",
     "latitude": 51.5566244695,
     "longitude": -2.6271165239
   },
   {
     "3alpha": "PIN",
-    "station_name": "Pinhoe Rail Station",
+    "station_name": "Pinhoe",
     "latitude": 50.7377726757,
     "longitude": -3.469346888
   },
   {
     "3alpha": "PIT",
-    "station_name": "Pitlochry Rail Station",
+    "station_name": "Pitlochry",
     "latitude": 56.7024883256,
     "longitude": -3.7355677144
   },
   {
     "3alpha": "PKG",
-    "station_name": "Penkridge Rail Station",
+    "station_name": "Penkridge",
     "latitude": 52.723513524,
     "longitude": -2.1192894969
   },
   {
     "3alpha": "PKS",
-    "station_name": "Parkstone (Dorset) Rail Station",
+    "station_name": "Parkstone (Dorset)",
     "latitude": 50.7229662137,
     "longitude": -1.9479483493
   },
   {
     "3alpha": "PKT",
-    "station_name": "Park Street Rail Station",
+    "station_name": "Park Street",
     "latitude": 51.7254616475,
     "longitude": -0.3402531493
   },
   {
     "3alpha": "PLC",
-    "station_name": "Pluckley Rail Station",
+    "station_name": "Pluckley",
     "latitude": 51.1564699354,
     "longitude": 0.7474262223
   },
   {
     "3alpha": "PLD",
-    "station_name": "Portslade Rail Station",
+    "station_name": "Portslade",
     "latitude": 50.8356743968,
     "longitude": -0.2053088577
   },
   {
     "3alpha": "PLE",
-    "station_name": "Pollokshields East Rail Station",
+    "station_name": "Pollokshields East",
     "latitude": 55.8410609323,
     "longitude": -4.2685885077
   },
   {
     "3alpha": "PLG",
-    "station_name": "Polegate Rail Station",
+    "station_name": "Polegate",
     "latitude": 50.8212387544,
     "longitude": 0.2451683916
   },
   {
     "3alpha": "PLK",
-    "station_name": "Plockton Rail Station",
+    "station_name": "Plockton",
     "latitude": 57.333539976,
     "longitude": -5.6659881238
   },
   {
     "3alpha": "PLM",
-    "station_name": "Plumley Rail Station",
+    "station_name": "Plumley",
     "latitude": 53.2746886444,
     "longitude": -2.419660194
   },
   {
     "3alpha": "PLN",
-    "station_name": "Portlethen Rail Station",
+    "station_name": "Portlethen",
     "latitude": 57.0613593651,
     "longitude": -2.1266196251
   },
   {
     "3alpha": "PLS",
-    "station_name": "Pleasington Rail Station",
+    "station_name": "Pleasington",
     "latitude": 53.7309724834,
     "longitude": -2.5441212488
   },
   {
     "3alpha": "PLT",
-    "station_name": "Pontlottyn Rail Station",
+    "station_name": "Pontlottyn",
     "latitude": 51.7466343204,
     "longitude": -3.2789665322
   },
   {
     "3alpha": "PLU",
-    "station_name": "Plumstead Rail Station",
+    "station_name": "Plumstead",
     "latitude": 51.4897937032,
     "longitude": 0.0842834892
   },
   {
     "3alpha": "PLW",
-    "station_name": "Pollokshields West Rail Station",
+    "station_name": "Pollokshields West",
     "latitude": 55.8376933127,
     "longitude": -4.2757390394
   },
   {
     "3alpha": "PLY",
-    "station_name": "Plymouth Rail Station",
+    "station_name": "Plymouth",
     "latitude": 50.3778114758,
     "longitude": -4.1433494979
   },
   {
     "3alpha": "PMA",
-    "station_name": "Portsmouth Arms Rail Station",
+    "station_name": "Portsmouth Arms",
     "latitude": 50.9569944809,
     "longitude": -3.9506012138
   },
   {
     "3alpha": "PMB",
-    "station_name": "Pembroke Rail Station",
+    "station_name": "Pembroke",
     "latitude": 51.6729545258,
     "longitude": -4.9060582576
   },
   {
     "3alpha": "PMD",
-    "station_name": "Pembroke Dock Rail Station",
+    "station_name": "Pembroke Dock",
     "latitude": 51.693923213,
     "longitude": -4.9380817217
   },
@@ -10777,1645 +10849,1657 @@
   },
   {
     "3alpha": "PMH",
-    "station_name": "Portsmouth Harbour Rail Station",
+    "station_name": "Portsmouth Harbour",
     "latitude": 50.7969498727,
     "longitude": -1.1078273211
   },
   {
     "3alpha": "PMP",
-    "station_name": "Plumpton Rail Station",
+    "station_name": "Plumpton",
     "latitude": 50.9286565684,
     "longitude": -0.0601544007
   },
   {
     "3alpha": "PMR",
-    "station_name": "Peckham Rye Rail Station",
+    "station_name": "Peckham Rye",
     "latitude": 51.470033016,
     "longitude": -0.0693887302
   },
   {
     "3alpha": "PMS",
-    "station_name": "Portsmouth & Southsea Rail Station",
+    "station_name": "Portsmouth & Southsea",
     "latitude": 50.7984827623,
     "longitude": -1.0908977098
   },
   {
     "3alpha": "PMT",
-    "station_name": "Polmont Rail Station",
+    "station_name": "Polmont",
     "latitude": 55.9847314785,
     "longitude": -3.7149654171
   },
   {
     "3alpha": "PMW",
-    "station_name": "Penmaenmawr Rail Station",
+    "station_name": "Penmaenmawr",
     "latitude": 53.2704805077,
     "longitude": -3.9235150995
   },
   {
     "3alpha": "PNA",
-    "station_name": "Penally Rail Station",
+    "station_name": "Penally",
     "latitude": 51.6589262669,
     "longitude": -4.7220868534
   },
   {
     "3alpha": "PNE",
-    "station_name": "Penge East Rail Station",
+    "station_name": "Penge East",
     "latitude": 51.4193314862,
     "longitude": -0.0541945966
   },
   {
     "3alpha": "PNF",
-    "station_name": "Penyffordd Rail Station",
+    "station_name": "Penyffordd",
     "latitude": 53.1431032633,
     "longitude": -3.0548384851
   },
   {
     "3alpha": "PNL",
-    "station_name": "Pannal Rail Station",
+    "station_name": "Pannal",
     "latitude": 53.9583379183,
     "longitude": -1.5334728227
   },
   {
     "3alpha": "PNM",
-    "station_name": "Penmere Rail Station",
+    "station_name": "Penmere",
     "latitude": 50.1503163602,
     "longitude": -5.0832395818
   },
   {
     "3alpha": "PNR",
-    "station_name": "Penrith North Lakes Rail Station",
+    "station_name": "Penrith North Lakes",
     "latitude": 54.6618111812,
     "longitude": -2.7588851525
   },
   {
     "3alpha": "PNS",
-    "station_name": "Penistone Rail Station",
+    "station_name": "Penistone",
     "latitude": 53.5255620634,
     "longitude": -1.6227817865
   },
   {
     "3alpha": "PNW",
-    "station_name": "Penge West Rail Station",
+    "station_name": "Penge West",
     "latitude": 51.4175527378,
     "longitude": -0.060813969
   },
   {
     "3alpha": "PNY",
-    "station_name": "Pen-y-Bont Rail Station",
+    "station_name": "Pen-y-Bont",
     "latitude": 52.2739523227,
     "longitude": -3.3219364345
   },
   {
     "3alpha": "PNZ",
-    "station_name": "Penzance Rail Station",
+    "station_name": "Penzance",
     "latitude": 50.1216622978,
     "longitude": -5.5326194274
   },
   {
     "3alpha": "POK",
-    "station_name": "Pokesdown Rail Station",
+    "station_name": "Pokesdown",
     "latitude": 50.7310753298,
     "longitude": -1.8250944808
   },
   {
     "3alpha": "POL",
-    "station_name": "Polsloe Bridge Rail Station",
+    "station_name": "Polsloe Bridge",
     "latitude": 50.7312683809,
     "longitude": -3.5019615191
   },
   {
     "3alpha": "PON",
-    "station_name": "Ponders End Rail Station",
+    "station_name": "Ponders End",
     "latitude": 51.642255947,
     "longitude": -0.0350543162
   },
   {
     "3alpha": "POO",
-    "station_name": "Poole Rail Station",
+    "station_name": "Poole",
     "latitude": 50.7194165218,
     "longitude": -1.9833107381
   },
   {
     "3alpha": "POP",
-    "station_name": "Poppleton Rail Station",
+    "station_name": "Poppleton",
     "latitude": 53.9759137087,
     "longitude": -1.1486052224
   },
   {
     "3alpha": "POR",
-    "station_name": "Porth Rail Station",
+    "station_name": "Porth",
     "latitude": 51.6125376458,
     "longitude": -3.4071988908
   },
   {
     "3alpha": "POT",
-    "station_name": "Pontefract Tanshelf Rail Station",
+    "station_name": "Pontefract Tanshelf",
     "latitude": 53.6941449221,
     "longitude": -1.3189173719
   },
   {
     "3alpha": "PPD",
-    "station_name": "Pontypridd Rail Station",
+    "station_name": "Pontypridd",
     "latitude": 51.5993702973,
     "longitude": -3.3413865323
   },
   {
     "3alpha": "PPK",
-    "station_name": "Possilpark & Parkhouse Rail Station",
+    "station_name": "Possilpark & Parkhouse",
     "latitude": 55.8901379173,
     "longitude": -4.2584986291
   },
   {
     "3alpha": "PPL",
-    "station_name": "Pontypool & New Inn Rail Station",
+    "station_name": "Pontypool & New Inn",
     "latitude": 51.6979651222,
     "longitude": -3.0142431288
   },
   {
     "3alpha": "PRA",
-    "station_name": "Prestwick Intl Airport Rail Station",
+    "station_name": "Prestwick Intl Airport",
     "latitude": 55.5090345152,
     "longitude": -4.6141499438
   },
   {
     "3alpha": "PRB",
-    "station_name": "Prestbury Rail Station",
+    "station_name": "Prestbury",
     "latitude": 53.2933984529,
     "longitude": -2.1454808763
   },
   {
     "3alpha": "PRE",
-    "station_name": "Preston Rail Station",
+    "station_name": "Preston",
     "latitude": 53.7568736745,
     "longitude": -2.7081248286
   },
   {
     "3alpha": "PRH",
-    "station_name": "Penrhyndeudraeth Rail Station",
+    "station_name": "Penrhyndeudraeth",
     "latitude": 52.9288395107,
     "longitude": -4.0645697821
   },
   {
     "3alpha": "PRL",
-    "station_name": "Prittlewell Rail Station",
+    "station_name": "Prittlewell",
     "latitude": 51.5506897273,
     "longitude": 0.7107053733
   },
   {
     "3alpha": "PRN",
-    "station_name": "Parton Rail Station",
+    "station_name": "Parton",
     "latitude": 54.5703745223,
     "longitude": -3.5808010214
   },
   {
     "3alpha": "PRP",
-    "station_name": "Preston Park Rail Station",
+    "station_name": "Preston Park",
     "latitude": 50.8459365038,
     "longitude": -0.1551401939
   },
   {
     "3alpha": "PRR",
-    "station_name": "Princes Risborough Rail Station",
+    "station_name": "Princes Risborough",
     "latitude": 51.717862811,
     "longitude": -0.8438584339
   },
   {
     "3alpha": "PRS",
-    "station_name": "Prees Rail Station",
+    "station_name": "Prees",
     "latitude": 52.8993178144,
     "longitude": -2.6896604773
   },
   {
     "3alpha": "PRT",
-    "station_name": "Prestatyn Rail Station",
+    "station_name": "Prestatyn",
     "latitude": 53.3365131812,
     "longitude": -3.4071329997
   },
   {
     "3alpha": "PRU",
-    "station_name": "Prudhoe Rail Station",
+    "station_name": "Prudhoe",
     "latitude": 54.9658336963,
     "longitude": -1.8648762701
   },
   {
     "3alpha": "PRW",
-    "station_name": "Perranwell Rail Station",
+    "station_name": "Perranwell",
     "latitude": 50.2165660708,
     "longitude": -5.1121161477
   },
   {
     "3alpha": "PRY",
-    "station_name": "Perry Barr Rail Station",
+    "station_name": "Perry Barr",
     "latitude": 52.5164989542,
     "longitude": -1.9019553886
   },
   {
     "3alpha": "PSC",
-    "station_name": "Prescot Rail Station",
+    "station_name": "Prescot",
     "latitude": 53.4235727522,
     "longitude": -2.7991706418
   },
   {
     "3alpha": "PSE",
-    "station_name": "Pitsea Rail Station",
+    "station_name": "Pitsea",
     "latitude": 51.5603607427,
     "longitude": 0.5063210544
   },
   {
     "3alpha": "PSH",
-    "station_name": "Pershore Rail Station",
+    "station_name": "Pershore",
     "latitude": 52.1305654583,
     "longitude": -2.071529789
   },
   {
     "3alpha": "PSL",
-    "station_name": "Port Sunlight Rail Station",
+    "station_name": "Port Sunlight",
     "latitude": 53.3492661166,
     "longitude": -2.9980290994
   },
   {
     "3alpha": "PSN",
-    "station_name": "Parson Street Rail Station",
+    "station_name": "Parson Street",
     "latitude": 51.4333162228,
     "longitude": -2.6077452159
   },
   {
     "3alpha": "PST",
-    "station_name": "Prestonpans Rail Station",
+    "station_name": "Prestonpans",
     "latitude": 55.9530925088,
     "longitude": -2.9747721637
   },
   {
     "3alpha": "PSW",
-    "station_name": "Polesworth Rail Station",
+    "station_name": "Polesworth",
     "latitude": 52.6258478025,
     "longitude": -1.6105322867
   },
   {
     "3alpha": "PTA",
-    "station_name": "Port Talbot Parkway Rail Station",
+    "station_name": "Port Talbot Parkway",
     "latitude": 51.5917198989,
     "longitude": -3.7813309651
   },
   {
     "3alpha": "PTB",
-    "station_name": "Pentre-Bach Rail Station",
+    "station_name": "Pentre-Bach",
     "latitude": 51.7250170652,
     "longitude": -3.3623321925
   },
   {
     "3alpha": "PTC",
-    "station_name": "Portchester Rail Station",
+    "station_name": "Portchester",
     "latitude": 50.8487383979,
     "longitude": -1.1242258208
   },
   {
     "3alpha": "PTD",
-    "station_name": "Pontarddulais Rail Station",
+    "station_name": "Pontarddulais",
     "latitude": 51.717625303,
     "longitude": -4.0455653141
   },
   {
     "3alpha": "PTF",
-    "station_name": "Pantyffynnon Rail Station",
+    "station_name": "Pantyffynnon",
     "latitude": 51.7788828692,
     "longitude": -3.997449154
   },
   {
     "3alpha": "PTG",
-    "station_name": "Port Glasgow Rail Station",
+    "station_name": "Port Glasgow",
     "latitude": 55.9335070293,
     "longitude": -4.6898064686
   },
   {
     "3alpha": "PTH",
-    "station_name": "Perth Rail Station",
+    "station_name": "Perth",
     "latitude": 56.3920836665,
     "longitude": -3.439696225
   },
   {
     "3alpha": "PTK",
-    "station_name": "Partick Rail Station",
+    "station_name": "Partick",
     "latitude": 55.8698812708,
     "longitude": -4.3087915388
   },
   {
     "3alpha": "PTL",
-    "station_name": "Priesthill & Darnley Rail Station",
+    "station_name": "Priesthill & Darnley",
     "latitude": 55.8121655063,
     "longitude": -4.3428803656
   },
   {
     "3alpha": "PTM",
-    "station_name": "Porthmadog Rail Station",
+    "station_name": "Porthmadog",
     "latitude": 52.9309305535,
     "longitude": -4.1344534631
   },
   {
     "3alpha": "PTR",
-    "station_name": "Petersfield Rail Station",
+    "station_name": "Petersfield",
     "latitude": 51.0067187319,
     "longitude": -0.941119933
   },
   {
     "3alpha": "PTT",
-    "station_name": "Patterton Rail Station",
+    "station_name": "Patterton",
     "latitude": 55.7906049425,
     "longitude": -4.335284571
   },
   {
     "3alpha": "PTW",
-    "station_name": "Prestwick Rail Station",
+    "station_name": "Prestwick",
     "latitude": 55.5016967612,
     "longitude": -4.6151361015
   },
   {
     "3alpha": "PUL",
-    "station_name": "Pulborough Rail Station",
+    "station_name": "Pulborough",
     "latitude": 50.957350444,
     "longitude": -0.5165342741
   },
   {
     "3alpha": "PUO",
-    "station_name": "Purley Oaks Rail Station",
+    "station_name": "Purley Oaks",
     "latitude": 51.347043203,
     "longitude": -0.0988301854
   },
   {
     "3alpha": "PUR",
-    "station_name": "Purley Rail Station",
+    "station_name": "Purley",
     "latitude": 51.3375762777,
     "longitude": -0.1140096477
   },
   {
     "3alpha": "PUT",
-    "station_name": "Putney Rail Station",
+    "station_name": "Putney",
     "latitude": 51.4613011865,
     "longitude": -0.2164509784
   },
   {
     "3alpha": "PWE",
-    "station_name": "Pollokshaws East Rail Station",
+    "station_name": "Pollokshaws East",
     "latitude": 55.8246345854,
     "longitude": -4.2868710374
   },
   {
     "3alpha": "PWL",
-    "station_name": "Pwllheli Rail Station",
+    "station_name": "Pwllheli",
     "latitude": 52.8878498612,
     "longitude": -4.4167062643
   },
   {
     "3alpha": "PWW",
-    "station_name": "Pollokshaws West Rail Station",
+    "station_name": "Pollokshaws West",
     "latitude": 55.8238204955,
     "longitude": -4.3015915299
   },
   {
     "3alpha": "PWY",
-    "station_name": "Patchway Rail Station",
+    "station_name": "Patchway",
     "latitude": 51.5259301005,
     "longitude": -2.5626913928
   },
   {
     "3alpha": "PYC",
-    "station_name": "Pontyclun Rail Station",
+    "station_name": "Pontyclun",
     "latitude": 51.523767301,
     "longitude": -3.3929297459
   },
   {
     "3alpha": "PYE",
-    "station_name": "Pye Corner Rail Station",
+    "station_name": "Pye Corner",
     "latitude": 51.581475726,
     "longitude": -3.0412190166
   },
   {
     "3alpha": "PYG",
-    "station_name": "Paisley Gilmour Street Rail Station",
+    "station_name": "Paisley Gilmour Street",
     "latitude": 55.8473432284,
     "longitude": -4.4244912616
   },
   {
     "3alpha": "PYJ",
-    "station_name": "Paisley St James Rail Station",
+    "station_name": "Paisley St James",
     "latitude": 55.8521114555,
     "longitude": -4.4424274654
   },
   {
     "3alpha": "PYL",
-    "station_name": "Pyle Rail Station",
+    "station_name": "Pyle",
     "latitude": 51.5257356235,
     "longitude": -3.6980690341
   },
   {
     "3alpha": "PYN",
-    "station_name": "Penryn Rail Station",
+    "station_name": "Penryn",
     "latitude": 50.1706984329,
     "longitude": -5.111654776
   },
   {
     "3alpha": "PYP",
-    "station_name": "Pont-y-Pant Rail Station",
+    "station_name": "Pont-y-Pant",
     "latitude": 53.0651459792,
     "longitude": -3.8627254729
   },
   {
     "3alpha": "PYT",
-    "station_name": "Poynton Rail Station",
+    "station_name": "Poynton",
     "latitude": 53.350399608,
     "longitude": -2.1344099238
   },
   {
     "3alpha": "QBR",
-    "station_name": "Queenborough Rail Station",
+    "station_name": "Queenborough",
     "latitude": 51.4156380311,
     "longitude": 0.7496958334
   },
   {
     "3alpha": "QPK",
-    "station_name": "Queens Park (Glasgow) Rail Station",
+    "station_name": "Queens Park (Glasgow)",
     "latitude": 55.8352982505,
     "longitude": -4.26673566
   },
   {
     "3alpha": "QPW",
-    "station_name": "Queens Park (London) Rail Station",
+    "station_name": "Queens Park (London)",
     "latitude": 51.5339663794,
     "longitude": -0.2049603036
   },
   {
     "3alpha": "QRB",
-    "station_name": "Queenstown Road (Battersea) Rail Station",
+    "station_name": "Queenstown Road (Battersea)",
     "latitude": 51.4749670081,
     "longitude": -0.146653366
   },
   {
     "3alpha": "QRP",
-    "station_name": "Queens Road Peckham Rail Station",
+    "station_name": "Queens Road Peckham",
     "latitude": 51.4735650429,
     "longitude": -0.057287956
   },
   {
     "3alpha": "QUI",
-    "station_name": "Quintrell Downs Rail Station",
+    "station_name": "Quintrell Downs",
     "latitude": 50.404043309,
     "longitude": -5.0285359493
   },
   {
     "3alpha": "QYD",
-    "station_name": "Quakers Yard Rail Station",
+    "station_name": "Quakers Yard",
     "latitude": 51.6607282285,
     "longitude": -3.3228133757
   },
   {
     "3alpha": "RAD",
-    "station_name": "Radley Rail Station",
+    "station_name": "Radley",
     "latitude": 51.6862085244,
     "longitude": -1.2404640226
   },
   {
     "3alpha": "RAI",
-    "station_name": "Rainham (Kent) Rail Station",
+    "station_name": "Rainham (Kent)",
     "latitude": 51.3663043788,
     "longitude": 0.6113657109
   },
   {
     "3alpha": "RAM",
-    "station_name": "Ramsgate Rail Station",
+    "station_name": "Ramsgate",
     "latitude": 51.3408101248,
     "longitude": 1.4064935542
   },
   {
     "3alpha": "RAN",
-    "station_name": "Rannoch Rail Station",
+    "station_name": "Rannoch",
     "latitude": 56.6860287779,
     "longitude": -4.5768596363
   },
   {
     "3alpha": "RAU",
-    "station_name": "Rauceby Rail Station",
+    "station_name": "Rauceby",
     "latitude": 52.9852250505,
     "longitude": -0.4566002495
   },
   {
     "3alpha": "RAV",
-    "station_name": "Ravenglass Rail Station",
+    "station_name": "Ravenglass",
     "latitude": 54.355714451,
     "longitude": -3.4088152992
   },
   {
     "3alpha": "RAY",
-    "station_name": "Raynes Park Rail Station",
+    "station_name": "Raynes Park",
     "latitude": 51.4091709872,
     "longitude": -0.2301271492
   },
   {
     "3alpha": "RBR",
-    "station_name": "Robertsbridge Rail Station",
+    "station_name": "Robertsbridge",
     "latitude": 50.9849282663,
     "longitude": 0.468811527
   },
   {
     "3alpha": "RBS",
-    "station_name": "British Steel Redcar Rail Station",
+    "station_name": "British Steel Redcar",
     "latitude": 54.6099002966,
     "longitude": -1.1126759256
   },
   {
     "3alpha": "RBU",
-    "station_name": "Reading Rail Station",
+    "station_name": "Reading",
     "latitude": 51.4581455251,
     "longitude": -0.9716410129
   },
   {
     "3alpha": "RCA",
-    "station_name": "Risca & Pontymister Rail Station",
+    "station_name": "Risca & Pontymister",
     "latitude": 51.6058480469,
     "longitude": -3.0922175896
   },
   {
     "3alpha": "RCC",
-    "station_name": "Redcar Central Rail Station",
+    "station_name": "Redcar Central",
     "latitude": 54.6162371859,
     "longitude": -1.0708827236
   },
   {
     "3alpha": "RCD",
-    "station_name": "Rochdale Rail Station",
+    "station_name": "Rochdale",
     "latitude": 53.6103213876,
     "longitude": -2.1535226045
   },
   {
     "3alpha": "RCE",
-    "station_name": "Redcar East Rail Station",
+    "station_name": "Redcar East",
     "latitude": 54.6092632648,
     "longitude": -1.0523074152
   },
   {
     "3alpha": "RDA",
-    "station_name": "Redland Rail Station",
+    "station_name": "Redland",
     "latitude": 51.4683833784,
     "longitude": -2.5991255269
   },
   {
     "3alpha": "RDB",
-    "station_name": "Redbridge (Hants) Rail Station",
+    "station_name": "Redbridge (Hants)",
     "latitude": 50.919929763,
     "longitude": -1.4701514648
   },
   {
     "3alpha": "RDC",
-    "station_name": "Redditch Rail Station",
+    "station_name": "Redditch",
     "latitude": 52.3063386466,
     "longitude": -1.9452414363
   },
   {
     "3alpha": "RDD",
-    "station_name": "Riddlesdown Rail Station",
+    "station_name": "Riddlesdown",
     "latitude": 51.3324835004,
     "longitude": -0.0993606073
   },
   {
     "3alpha": "RDF",
-    "station_name": "Radcliffe (Notts) Rail Station",
+    "station_name": "Radcliffe (Notts)",
     "latitude": 52.948803948,
     "longitude": -1.0373248467
   },
   {
     "3alpha": "RDG",
-    "station_name": "Reading Rail Station",
+    "station_name": "Reading",
     "latitude": 51.4587857311,
     "longitude": -0.9718425502
   },
   {
     "3alpha": "RDH",
-    "station_name": "Redhill Rail Station",
+    "station_name": "Redhill",
     "latitude": 51.2401977624,
     "longitude": -0.1658743282
   },
   {
     "3alpha": "RDM",
-    "station_name": "Riding Mill Rail Station",
+    "station_name": "Riding Mill",
     "latitude": 54.9487414454,
     "longitude": -1.9715645429
   },
   {
     "3alpha": "RDN",
-    "station_name": "Reddish North Rail Station",
+    "station_name": "Reddish North",
     "latitude": 53.4494263145,
     "longitude": -2.1562533084
   },
   {
     "3alpha": "RDR",
-    "station_name": "Radyr Rail Station",
+    "station_name": "Radyr",
     "latitude": 51.5163222796,
     "longitude": -3.2483627755
   },
   {
     "3alpha": "RDS",
-    "station_name": "Reddish South Rail Station",
+    "station_name": "Reddish South",
     "latitude": 53.4359402108,
     "longitude": -2.15876271
   },
   {
     "3alpha": "RDT",
-    "station_name": "Radlett Rail Station",
+    "station_name": "Radlett",
     "latitude": 51.6851911564,
     "longitude": -0.3172197627
   },
   {
     "3alpha": "RDW",
-    "station_name": "Reading West Rail Station",
+    "station_name": "Reading West",
     "latitude": 51.4555007173,
     "longitude": -0.9901085456
   },
   {
     "3alpha": "REC",
-    "station_name": "Rectory Road Rail Station",
+    "station_name": "Rectory Road",
     "latitude": 51.5585021691,
     "longitude": -0.0682408077
   },
   {
     "3alpha": "RED",
-    "station_name": "Redruth Rail Station",
+    "station_name": "Redruth",
     "latitude": 50.2332412948,
     "longitude": -5.2259636066
   },
   {
     "3alpha": "REE",
-    "station_name": "Reedham (Norfolk) Rail Station",
+    "station_name": "Reedham (Norfolk)",
     "latitude": 52.5645273067,
     "longitude": 1.5596750305
   },
   {
     "3alpha": "REI",
-    "station_name": "Reigate Rail Station",
+    "station_name": "Reigate",
     "latitude": 51.241955247,
     "longitude": -0.2037998793
   },
   {
     "3alpha": "REL",
-    "station_name": "Retford Low Level Rail Station",
+    "station_name": "Retford Low Level",
     "latitude": 53.314084796,
     "longitude": -0.944772788
   },
   {
     "3alpha": "RET",
-    "station_name": "Retford Rail Station",
+    "station_name": "Retford",
     "latitude": 53.3151729691,
     "longitude": -0.9478832051
   },
   {
     "3alpha": "RFD",
-    "station_name": "Rochford Rail Station",
+    "station_name": "Rochford",
     "latitude": 51.5817322678,
     "longitude": 0.7023320206
   },
   {
     "3alpha": "RFY",
-    "station_name": "Rock Ferry Rail Station",
+    "station_name": "Rock Ferry",
     "latitude": 53.3726649286,
     "longitude": -3.0108263238
   },
   {
     "3alpha": "RGL",
-    "station_name": "Rugeley Trent Valley Rail Station",
+    "station_name": "Rugeley Trent Valley",
     "latitude": 52.7696708266,
     "longitude": -1.9298468285
   },
   {
     "3alpha": "RGT",
-    "station_name": "Rugeley Town Rail Station",
+    "station_name": "Rugeley Town",
     "latitude": 52.7543925458,
     "longitude": -1.9368345411
   },
   {
     "3alpha": "RGW",
-    "station_name": "Ramsgreave & Wilpshire Rail Station",
+    "station_name": "Ramsgreave & Wilpshire",
     "latitude": 53.7797887472,
     "longitude": -2.4781340362
   },
   {
     "3alpha": "RHD",
-    "station_name": "Ribblehead Rail Station",
+    "station_name": "Ribblehead",
     "latitude": 54.2058547832,
     "longitude": -2.3608596376
   },
   {
     "3alpha": "RHI",
-    "station_name": "Rhiwbina Rail Station",
+    "station_name": "Rhiwbina",
     "latitude": 51.5211795118,
     "longitude": -3.2139748912
   },
   {
     "3alpha": "RHL",
-    "station_name": "Rhyl Rail Station",
+    "station_name": "Rhyl",
     "latitude": 53.3184382534,
     "longitude": -3.4891071986
   },
   {
     "3alpha": "RHM",
-    "station_name": "Reedham (Surrey) Rail Station",
+    "station_name": "Reedham (Surrey)",
     "latitude": 51.3311168831,
     "longitude": -0.1233901081
   },
   {
     "3alpha": "RHO",
-    "station_name": "Rhosneigr Rail Station",
+    "station_name": "Rhosneigr",
     "latitude": 53.234853792,
     "longitude": -4.5066484672
   },
   {
     "3alpha": "RHY",
-    "station_name": "Rhymney Rail Station",
+    "station_name": "Rhymney",
     "latitude": 51.7588400163,
     "longitude": -3.2893087685
   },
   {
     "3alpha": "RIA",
-    "station_name": "Rhoose Rail Station",
+    "station_name": "Rhoose",
     "latitude": 51.3870636406,
     "longitude": -3.3493952024
   },
   {
     "3alpha": "RIC",
-    "station_name": "Rickmansworth Rail Station",
+    "station_name": "Rickmansworth",
     "latitude": 51.6402484957,
     "longitude": -0.4732613263
   },
   {
     "3alpha": "RID",
-    "station_name": "Ridgmont Rail Station",
+    "station_name": "Ridgmont",
     "latitude": 52.0264115351,
     "longitude": -0.5945346786
   },
   {
     "3alpha": "RIL",
-    "station_name": "Rice Lane Rail Station",
+    "station_name": "Rice Lane",
     "latitude": 53.4577855134,
     "longitude": -2.9623176912
   },
   {
     "3alpha": "RIS",
-    "station_name": "Rishton Rail Station",
+    "station_name": "Rishton",
     "latitude": 53.7638280488,
     "longitude": -2.4201573255
   },
   {
     "3alpha": "RKT",
-    "station_name": "Ruskington Rail Station",
+    "station_name": "Ruskington",
     "latitude": 53.0414843853,
     "longitude": -0.3807571306
   },
   {
     "3alpha": "RLG",
-    "station_name": "Rayleigh Rail Station",
+    "station_name": "Rayleigh",
     "latitude": 51.5892966358,
     "longitude": 0.6000099485
   },
   {
     "3alpha": "RLN",
-    "station_name": "Rowlands Castle Rail Station",
+    "station_name": "Rowlands Castle",
     "latitude": 50.8921618565,
     "longitude": -0.9574550113
   },
   {
     "3alpha": "RMB",
-    "station_name": "Roman Bridge Rail Station",
+    "station_name": "Roman Bridge",
     "latitude": 53.0444294912,
     "longitude": -3.9216535234
   },
   {
     "3alpha": "RMC",
-    "station_name": "Rotherham Central Rail Station",
+    "station_name": "Rotherham Central",
     "latitude": 53.4322702249,
     "longitude": -1.3604360441
   },
   {
     "3alpha": "RMD",
-    "station_name": "Richmond (London) Rail Station",
+    "station_name": "Richmond (London)",
     "latitude": 51.4630586084,
     "longitude": -0.3015359438
   },
   {
     "3alpha": "RMF",
-    "station_name": "Romford Rail Station",
+    "station_name": "Romford",
     "latitude": 51.5748295085,
     "longitude": 0.1832643102
   },
   {
     "3alpha": "RML",
-    "station_name": "Romiley Rail Station",
+    "station_name": "Romiley",
     "latitude": 53.4140264045,
     "longitude": -2.0893251906
   },
   {
     "3alpha": "RNF",
-    "station_name": "Rainford Rail Station",
+    "station_name": "Rainford",
     "latitude": 53.5171200074,
     "longitude": -2.7894686817
   },
   {
     "3alpha": "RNH",
-    "station_name": "Rainhill Rail Station",
+    "station_name": "Rainhill",
     "latitude": 53.4171359422,
     "longitude": -2.7663996705
   },
   {
     "3alpha": "RNM",
-    "station_name": "Rainham (London) Rail Station",
+    "station_name": "Rainham (London)",
     "latitude": 51.5167228766,
     "longitude": 0.1906626283
   },
   {
     "3alpha": "RNR",
-    "station_name": "Roughton Road Rail Station",
+    "station_name": "Roughton Road",
     "latitude": 52.9180468243,
     "longitude": 1.2998131699
   },
   {
     "3alpha": "ROB",
-    "station_name": "Roby Rail Station",
+    "station_name": "Roby",
     "latitude": 53.4100553223,
     "longitude": -2.8559333314
   },
   {
     "3alpha": "ROC",
-    "station_name": "Roche Rail Station",
+    "station_name": "Roche",
     "latitude": 50.4185298804,
     "longitude": -4.8302395116
   },
   {
     "3alpha": "ROE",
-    "station_name": "Rotherhithe Rail Station",
+    "station_name": "Rotherhithe",
     "latitude": 51.5008159021,
     "longitude": -0.0520222921
   },
   {
     "3alpha": "ROG",
-    "station_name": "Rogart Rail Station",
+    "station_name": "Rogart",
     "latitude": 57.9886951233,
     "longitude": -4.1581880614
   },
   {
     "3alpha": "ROL",
-    "station_name": "Rolleston Rail Station",
+    "station_name": "Rolleston",
     "latitude": 53.0653022003,
     "longitude": -0.8996705436
   },
   {
     "3alpha": "ROM",
-    "station_name": "Romsey Rail Station",
+    "station_name": "Romsey",
     "latitude": 50.992520078,
     "longitude": -1.4931337195
   },
   {
     "3alpha": "ROO",
-    "station_name": "Roose Rail Station",
+    "station_name": "Roose",
     "latitude": 54.115171803,
     "longitude": -3.1945656127
   },
   {
     "3alpha": "ROR",
-    "station_name": "Rogerstone Rail Station",
+    "station_name": "Rogerstone",
     "latitude": 51.595617413,
     "longitude": -3.0666186229
   },
   {
     "3alpha": "ROS",
-    "station_name": "Rosyth Rail Station",
+    "station_name": "Rosyth",
     "latitude": 56.0455112188,
     "longitude": -3.4273031727
   },
   {
     "3alpha": "ROW",
-    "station_name": "Rowley Regis Rail Station",
+    "station_name": "Rowley Regis",
     "latitude": 52.4773392229,
     "longitude": -2.0308690726
   },
   {
     "3alpha": "RRB",
-    "station_name": "Ryder Brow Rail Station",
+    "station_name": "Ryder Brow",
     "latitude": 53.4565936753,
     "longitude": -2.1730866723
   },
   {
+    "3alpha":"RRN",
+    "station_name":"Robroyston",
+    "latitude":55.887581,
+    "longitude": -4.172291
+  },
+  {
     "3alpha": "RSG",
-    "station_name": "Rose Grove Rail Station",
+    "station_name": "Rose Grove",
     "latitude": 53.786206105,
     "longitude": -2.2827968156
   },
   {
     "3alpha": "RSH",
-    "station_name": "Rose Hill Marple Rail Station",
+    "station_name": "Rose Hill Marple",
     "latitude": 53.3962378581,
     "longitude": -2.0765205539
   },
   {
+    "3alpha": "RSN",
+    "station_name": "Reston",
+    "latitude": 55.8506,
+    "longitude": -2.1972
+  },
+  {
     "3alpha": "RTN",
-    "station_name": "Renton Rail Station",
+    "station_name": "Renton",
     "latitude": 55.9704230841,
     "longitude": -4.5861084015
   },
   {
     "3alpha": "RTR",
-    "station_name": "Rochester Rail Station",
+    "station_name": "Rochester",
     "latitude": 51.385547102,
     "longitude": 0.5103102845
   },
   {
     "3alpha": "RUA",
-    "station_name": "Ruabon Rail Station",
+    "station_name": "Ruabon",
     "latitude": 52.9871483927,
     "longitude": -3.0431380968
   },
   {
     "3alpha": "RUE",
-    "station_name": "Runcorn East Rail Station",
+    "station_name": "Runcorn East",
     "latitude": 53.3275817336,
     "longitude": -2.6656977069
   },
   {
     "3alpha": "RUF",
-    "station_name": "Rufford Rail Station",
+    "station_name": "Rufford",
     "latitude": 53.6344771165,
     "longitude": -2.8078404066
   },
   {
     "3alpha": "RUG",
-    "station_name": "Rugby Rail Station",
+    "station_name": "Rugby",
     "latitude": 52.379109602,
     "longitude": -1.2504711992
   },
   {
     "3alpha": "RUN",
-    "station_name": "Runcorn Rail Station",
+    "station_name": "Runcorn",
     "latitude": 53.3387090613,
     "longitude": -2.7392524151
   },
   {
     "3alpha": "RUS",
-    "station_name": "Ruswarp Rail Station",
+    "station_name": "Ruswarp",
     "latitude": 54.4702038934,
     "longitude": -0.6277880896
   },
   {
     "3alpha": "RUT",
-    "station_name": "Rutherglen Rail Station",
+    "station_name": "Rutherglen",
     "latitude": 55.8305867225,
     "longitude": -4.2120903916
   },
   {
     "3alpha": "RVB",
-    "station_name": "Ravensbourne Rail Station",
+    "station_name": "Ravensbourne",
     "latitude": 51.4141860649,
     "longitude": -0.0075306056
   },
   {
     "3alpha": "RVN",
-    "station_name": "Ravensthorpe Rail Station",
+    "station_name": "Ravensthorpe",
     "latitude": 53.6755379752,
     "longitude": -1.6555824307
   },
   {
     "3alpha": "RWC",
-    "station_name": "Rawcliffe Rail Station",
+    "station_name": "Rawcliffe",
     "latitude": 53.689059382,
     "longitude": -0.9608672824
   },
   {
     "3alpha": "RYB",
-    "station_name": "Roy Bridge Rail Station",
+    "station_name": "Roy Bridge",
     "latitude": 56.8883464006,
     "longitude": -4.837231331
   },
   {
     "3alpha": "RYD",
-    "station_name": "Ryde Esplanade Rail Station",
+    "station_name": "Ryde Esplanade",
     "latitude": 50.732855472,
     "longitude": -1.1596052649
   },
   {
     "3alpha": "RYE",
-    "station_name": "Rye Rail Station",
+    "station_name": "Rye",
     "latitude": 50.9523651368,
     "longitude": 0.7307262415
   },
   {
     "3alpha": "RYH",
-    "station_name": "Rye House Rail Station",
+    "station_name": "Rye House",
     "latitude": 51.7694168549,
     "longitude": 0.0056554285
   },
   {
     "3alpha": "RYN",
-    "station_name": "Roydon Rail Station",
+    "station_name": "Roydon",
     "latitude": 51.7754907565,
     "longitude": 0.0362787847
   },
   {
     "3alpha": "RYP",
-    "station_name": "Ryde Pier Head Rail Station",
+    "station_name": "Ryde Pier Head",
     "latitude": 50.7391721946,
     "longitude": -1.160115731
   },
   {
     "3alpha": "RYR",
-    "station_name": "Ryde St Johns Road Rail Station",
+    "station_name": "Ryde St Johns Road",
     "latitude": 50.7243531538,
     "longitude": -1.1565554546
   },
   {
     "3alpha": "RYS",
-    "station_name": "Royston Rail Station",
+    "station_name": "Royston",
     "latitude": 52.0530886425,
     "longitude": -0.0268926227
   },
   {
     "3alpha": "SAA",
-    "station_name": "St Albans Abbey Rail Station",
+    "station_name": "St Albans Abbey",
     "latitude": 51.7447373797,
     "longitude": -0.3425457907
   },
   {
     "3alpha": "SAB",
-    "station_name": "Smallbrook Junction Rail Station",
+    "station_name": "Smallbrook Junction",
     "latitude": 50.7110892621,
     "longitude": -1.1541879058
   },
   {
     "3alpha": "SAC",
-    "station_name": "St Albans City Rail Station",
+    "station_name": "St Albans City",
     "latitude": 51.7504771115,
     "longitude": -0.3275149609
   },
   {
     "3alpha": "SAD",
-    "station_name": "Sandwell & Dudley Rail Station",
+    "station_name": "Sandwell & Dudley",
     "latitude": 52.508672806,
     "longitude": -2.0115900516
   },
   {
     "3alpha": "SAE",
-    "station_name": "Saltaire Rail Station",
+    "station_name": "Saltaire",
     "latitude": 53.8385061525,
     "longitude": -1.7904830974
   },
   {
     "3alpha": "SAF",
-    "station_name": "Salfords (Surrey) Rail Station",
+    "station_name": "Salfords (Surrey)",
     "latitude": 51.2017437324,
     "longitude": -0.1624625843
   },
   {
     "3alpha": "SAH",
-    "station_name": "Salhouse Rail Station",
+    "station_name": "Salhouse",
     "latitude": 52.6755989185,
     "longitude": 1.3914382836
   },
   {
     "3alpha": "SAJ",
-    "station_name": "St Johns (London) Rail Station",
+    "station_name": "St Johns (London)",
     "latitude": 51.4693892196,
     "longitude": -0.0226931111
   },
   {
     "3alpha": "SAL",
-    "station_name": "Salisbury Rail Station",
+    "station_name": "Salisbury",
     "latitude": 51.0705407298,
     "longitude": -1.8063773738
   },
   {
     "3alpha": "SAM",
-    "station_name": "Saltmarshe Rail Station",
+    "station_name": "Saltmarshe",
     "latitude": 53.721943052,
     "longitude": -0.8094903376
   },
   {
     "3alpha": "SAN",
-    "station_name": "Sandown Rail Station",
+    "station_name": "Sandown",
     "latitude": 50.6568577497,
     "longitude": -1.1623772447
   },
   {
     "3alpha": "SAR",
-    "station_name": "St Andrews Road Rail Station",
+    "station_name": "St Andrews Road",
     "latitude": 51.5127676823,
     "longitude": -2.6963176571
   },
   {
     "3alpha": "SAS",
-    "station_name": "St Annes-on-the-Sea Rail Station",
+    "station_name": "St Annes-on-the-Sea",
     "latitude": 53.7530450492,
     "longitude": -3.0290965047
   },
   {
     "3alpha": "SAT",
-    "station_name": "South Acton Rail Station",
+    "station_name": "South Acton",
     "latitude": 51.4996944038,
     "longitude": -0.2701346279
   },
   {
     "3alpha": "SAU",
-    "station_name": "St Austell Rail Station",
+    "station_name": "St Austell",
     "latitude": 50.3395021406,
     "longitude": -4.7894011447
   },
   {
     "3alpha": "SAV",
-    "station_name": "Stratford-upon-Avon Rail Station",
+    "station_name": "Stratford-upon-Avon",
     "latitude": 52.1942606452,
     "longitude": -1.7162794479
   },
   {
     "3alpha": "SAW",
-    "station_name": "Sawbridgeworth Rail Station",
+    "station_name": "Sawbridgeworth",
     "latitude": 51.8143528887,
     "longitude": 0.1604379052
   },
   {
     "3alpha": "SAX",
-    "station_name": "Saxmundham Rail Station",
+    "station_name": "Saxmundham",
     "latitude": 52.2149132591,
     "longitude": 1.4901964806
   },
   {
     "3alpha": "SAY",
-    "station_name": "Swanley Rail Station",
+    "station_name": "Swanley",
     "latitude": 51.3933848234,
     "longitude": 0.1692513064
   },
   {
     "3alpha": "SBE",
-    "station_name": "Starbeck Rail Station",
+    "station_name": "Starbeck",
     "latitude": 53.9990126023,
     "longitude": -1.5011353743
   },
   {
     "3alpha": "SBF",
-    "station_name": "St Budeaux Ferry Road Rail Station",
+    "station_name": "St Budeaux Ferry Road",
     "latitude": 50.4013767558,
     "longitude": -4.1868416838
   },
   {
     "3alpha": "SBJ",
-    "station_name": "Stourbridge Junction Rail Station",
+    "station_name": "Stourbridge Junction",
     "latitude": 52.4475544797,
     "longitude": -2.1338704963
   },
   {
     "3alpha": "SBK",
-    "station_name": "South Bank Rail Station",
+    "station_name": "South Bank",
     "latitude": 54.5838411607,
     "longitude": -1.1766809553
   },
   {
     "3alpha": "SBM",
-    "station_name": "South Bermondsey Rail Station",
+    "station_name": "South Bermondsey",
     "latitude": 51.4881347391,
     "longitude": -0.0546518416
   },
   {
     "3alpha": "SBP",
-    "station_name": "Stonebridge Park Rail Station",
+    "station_name": "Stonebridge Park",
     "latitude": 51.5441109985,
     "longitude": -0.2758051183
   },
   {
     "3alpha": "SBR",
-    "station_name": "Spean Bridge Rail Station",
+    "station_name": "Spean Bridge",
     "latitude": 56.889995674,
     "longitude": -4.921595255
   },
   {
     "3alpha": "SBS",
-    "station_name": "St Bees Rail Station",
+    "station_name": "St Bees",
     "latitude": 54.4925405036,
     "longitude": -3.5911492633
   },
   {
     "3alpha": "SBT",
-    "station_name": "Stourbridge Town Rail Station",
+    "station_name": "Stourbridge Town",
     "latitude": 52.455591256,
     "longitude": -2.1418120086
   },
   {
     "3alpha": "SBU",
-    "station_name": "Southbury Rail Station",
+    "station_name": "Southbury",
     "latitude": 51.6487058202,
     "longitude": -0.0524104286
   },
   {
     "3alpha": "SBV",
-    "station_name": "St Budeaux Victoria Road Rail Station",
+    "station_name": "St Budeaux Victoria Road",
     "latitude": 50.4019952477,
     "longitude": -4.1874330909
   },
   {
     "3alpha": "SBY",
-    "station_name": "Selby Rail Station",
+    "station_name": "Selby",
     "latitude": 53.7828026439,
     "longitude": -1.063791006
   },
   {
     "3alpha": "SCA",
-    "station_name": "Scarborough Rail Station",
+    "station_name": "Scarborough",
     "latitude": 54.2798078946,
     "longitude": -0.4057198208
   },
   {
     "3alpha": "SCF",
-    "station_name": "Stechford Rail Station",
+    "station_name": "Stechford",
     "latitude": 52.4848336609,
     "longitude": -1.81101967
   },
   {
     "3alpha": "SCG",
-    "station_name": "Stone Crossing Rail Station",
+    "station_name": "Stone Crossing",
     "latitude": 51.4513283183,
     "longitude": 0.2637992585
   },
   {
     "3alpha": "SCH",
-    "station_name": "Scotstounhill Rail Station",
+    "station_name": "Scotstounhill",
     "latitude": 55.88513372,
     "longitude": -4.3528726659
   },
   {
     "3alpha": "SCR",
-    "station_name": "St Columb Road Rail Station",
+    "station_name": "St Columb Road",
     "latitude": 50.3986945398,
     "longitude": -4.9407987491
   },
   {
     "3alpha": "SCS",
-    "station_name": "Starcross Rail Station",
+    "station_name": "Starcross",
     "latitude": 50.6277843819,
     "longitude": -3.4477177832
   },
   {
     "3alpha": "SCT",
-    "station_name": "Scotscalder Rail Station",
+    "station_name": "Scotscalder",
     "latitude": 58.4829756671,
     "longitude": -3.5520574676
   },
   {
     "3alpha": "SCU",
-    "station_name": "Scunthorpe Rail Station",
+    "station_name": "Scunthorpe",
     "latitude": 53.5861949288,
     "longitude": -0.6509843133
   },
   {
     "3alpha": "SCY",
-    "station_name": "South Croydon Rail Station",
+    "station_name": "South Croydon",
     "latitude": 51.3629626314,
     "longitude": -0.0934308139
   },
   {
     "3alpha": "SDA",
-    "station_name": "Snodland Rail Station",
+    "station_name": "Snodland",
     "latitude": 51.3302285584,
     "longitude": 0.4482700817
   },
   {
     "3alpha": "SDB",
-    "station_name": "Sandbach Rail Station",
+    "station_name": "Sandbach",
     "latitude": 53.1501833523,
     "longitude": -2.3935053074
   },
   {
     "3alpha": "SDC",
-    "station_name": "Shoreditch High Street Rail Station",
+    "station_name": "Shoreditch High Street",
     "latitude": 51.5233750963,
     "longitude": -0.0752198072
   },
   {
     "3alpha": "SDE",
-    "station_name": "Shadwell Rail Station",
+    "station_name": "Shadwell",
     "latitude": 51.5112835169,
     "longitude": -0.0569079056
   },
   {
     "3alpha": "SDF",
-    "station_name": "Saundersfoot Rail Station",
+    "station_name": "Saundersfoot",
     "latitude": 51.7220987761,
     "longitude": -4.7166131873
   },
   {
     "3alpha": "SDG",
-    "station_name": "Sandling Rail Station",
+    "station_name": "Sandling",
     "latitude": 51.09037099,
     "longitude": 1.0660749872
   },
   {
     "3alpha": "SDH",
-    "station_name": "Sudbury Hill Harrow Rail Station",
+    "station_name": "Sudbury Hill Harrow",
     "latitude": 51.558465264,
     "longitude": -0.3357809724
   },
   {
     "3alpha": "SDL",
-    "station_name": "Sandhills Rail Station",
+    "station_name": "Sandhills",
     "latitude": 53.4299516422,
     "longitude": -2.9914899197
   },
   {
     "3alpha": "SDM",
-    "station_name": "Shieldmuir Rail Station",
+    "station_name": "Shieldmuir",
     "latitude": 55.7774860976,
     "longitude": -3.9569803961
   },
   {
     "3alpha": "SDN",
-    "station_name": "St Denys Rail Station",
+    "station_name": "St Denys",
     "latitude": 50.9221787802,
     "longitude": -1.3877499436
   },
   {
     "3alpha": "SDP",
-    "station_name": "Sandplace Rail Station",
+    "station_name": "Sandplace",
     "latitude": 50.3867379699,
     "longitude": -4.4645157634
   },
   {
     "3alpha": "SDR",
-    "station_name": "Saunderton Rail Station",
+    "station_name": "Saunderton",
     "latitude": 51.6759048289,
     "longitude": -0.8254472358
   },
   {
     "3alpha": "SDW",
-    "station_name": "Sandwich Rail Station",
+    "station_name": "Sandwich",
     "latitude": 51.2699092555,
     "longitude": 1.3425965892
   },
   {
     "3alpha": "SDY",
-    "station_name": "Sandy Rail Station",
+    "station_name": "Sandy",
     "latitude": 52.1247435871,
     "longitude": -0.281167619
   },
   {
     "3alpha": "SEA",
-    "station_name": "Seaham Rail Station",
+    "station_name": "Seaham",
     "latitude": 54.839061911,
     "longitude": -1.3463511926
   },
   {
     "3alpha": "SEB",
-    "station_name": "Seaburn Rail Station",
+    "station_name": "Seaburn",
     "latitude": 54.929542046,
     "longitude": -1.3867070759
   },
   {
     "3alpha": "SEC",
-    "station_name": "Seaton Carew Rail Station",
+    "station_name": "Seaton Carew",
     "latitude": 54.6583208071,
     "longitude": -1.2004437475
   },
   {
     "3alpha": "SED",
-    "station_name": "Shelford (Cambs) Rail Station",
+    "station_name": "Shelford (Cambs)",
     "latitude": 52.1488379665,
     "longitude": 0.1400093409
   },
   {
     "3alpha": "SEE",
-    "station_name": "Southease Rail Station",
+    "station_name": "Southease",
     "latitude": 50.8312579508,
     "longitude": 0.0306695579
   },
   {
     "3alpha": "SEF",
-    "station_name": "Seaford Rail Station",
+    "station_name": "Seaford",
     "latitude": 50.7728366774,
     "longitude": 0.100161285
   },
   {
     "3alpha": "SEG",
-    "station_name": "Selling Rail Station",
+    "station_name": "Selling",
     "latitude": 51.2773559024,
     "longitude": 0.9409001439
   },
   {
     "3alpha": "SEH",
-    "station_name": "Shoreham (Kent) Rail Station",
+    "station_name": "Shoreham (Kent)",
     "latitude": 51.3322156624,
     "longitude": 0.1889169828
   },
   {
     "3alpha": "SEL",
-    "station_name": "Sellafield Rail Station",
+    "station_name": "Sellafield",
     "latitude": 54.4165930704,
     "longitude": -3.5104560059
   },
   {
     "3alpha": "SEM",
-    "station_name": "Seamer Rail Station",
+    "station_name": "Seamer",
     "latitude": 54.2407682264,
     "longitude": -0.4170454656
   },
   {
     "3alpha": "SEN",
-    "station_name": "Shenstone Rail Station",
+    "station_name": "Shenstone",
     "latitude": 52.6393741914,
     "longitude": -1.8441949254
   },
   {
     "3alpha": "SER",
-    "station_name": "St Erth Rail Station",
+    "station_name": "St Erth",
     "latitude": 50.1704799545,
     "longitude": -5.4443040887
   },
   {
     "3alpha": "SES",
-    "station_name": "South Elmsall Rail Station",
+    "station_name": "South Elmsall",
     "latitude": 53.594624192,
     "longitude": -1.2848611415
   },
   {
     "3alpha": "SET",
-    "station_name": "Settle Rail Station",
+    "station_name": "Settle",
     "latitude": 54.0669251994,
     "longitude": -2.2807172129
   },
   {
     "3alpha": "SEV",
-    "station_name": "Sevenoaks Rail Station",
+    "station_name": "Sevenoaks",
     "latitude": 51.2768624115,
     "longitude": 0.1816963041
   },
   {
     "3alpha": "SFA",
-    "station_name": "Stratford International Rail Station",
+    "station_name": "Stratford International",
     "latitude": 51.5448283609,
     "longitude": -0.0087499388
   },
   {
     "3alpha": "SFD",
-    "station_name": "Salford Central Rail Station",
+    "station_name": "Salford Central",
     "latitude": 53.4830977645,
     "longitude": -2.2548383451
   },
   {
     "3alpha": "SFI",
-    "station_name": "Shawfair Rail Station",
+    "station_name": "Shawfair",
     "latitude": 55.9199329881,
     "longitude": -3.0787162657
   },
   {
     "3alpha": "SFL",
-    "station_name": "Seaforth & Litherland Rail Station",
+    "station_name": "Seaforth & Litherland",
     "latitude": 53.4662829283,
     "longitude": -3.0056221352
   },
   {
     "3alpha": "SFN",
-    "station_name": "Shifnal Rail Station",
+    "station_name": "Shifnal",
     "latitude": 52.6660843703,
     "longitude": -2.3718373899
   },
   {
     "3alpha": "SFO",
-    "station_name": "Stanford-le-Hope Rail Station",
+    "station_name": "Stanford-le-Hope",
     "latitude": 51.5143632423,
     "longitude": 0.4230666756
   },
   {
     "3alpha": "SFR",
-    "station_name": "Shalford (Surrey) Rail Station",
+    "station_name": "Shalford (Surrey)",
     "latitude": 51.2143177182,
     "longitude": -0.5667825878
   },
   {
     "3alpha": "SGB",
-    "station_name": "Smethwick Galton Bridge Rail Station",
+    "station_name": "Smethwick Galton Bridge",
     "latitude": 52.5017945032,
     "longitude": -1.9805048854
   },
   {
     "3alpha": "SGL",
-    "station_name": "South Gyle Rail Station",
+    "station_name": "South Gyle",
     "latitude": 55.9363467134,
     "longitude": -3.2994753799
   },
   {
     "3alpha": "SGM",
-    "station_name": "St Germans Rail Station",
+    "station_name": "St Germans",
     "latitude": 50.3942591741,
     "longitude": -4.3084363092
   },
   {
     "3alpha": "SGN",
-    "station_name": "South Greenford Rail Station",
+    "station_name": "South Greenford",
     "latitude": 51.5337487794,
     "longitude": -0.3366818438
   },
   {
     "3alpha": "SGR",
-    "station_name": "Slade Green Rail Station",
+    "station_name": "Slade Green",
     "latitude": 51.4677848035,
     "longitude": 0.19051795
   },
   {
     "3alpha": "SHB",
-    "station_name": "Shirebrook Rail Station",
+    "station_name": "Shirebrook",
     "latitude": 53.20425967,
     "longitude": -1.2024390578
   },
   {
     "3alpha": "SHC",
-    "station_name": "Streethouse Rail Station",
+    "station_name": "Streethouse",
     "latitude": 53.6761699951,
     "longitude": -1.4001215054
   },
   {
     "3alpha": "SHD",
-    "station_name": "Shildon Rail Station",
+    "station_name": "Shildon",
     "latitude": 54.6261726082,
     "longitude": -1.6366159332
   },
   {
     "3alpha": "SHE",
-    "station_name": "Sherborne Rail Station",
+    "station_name": "Sherborne",
     "latitude": 50.9440137558,
     "longitude": -2.5130735512
   },
   {
     "3alpha": "SHF",
-    "station_name": "Sheffield Rail Station",
+    "station_name": "Sheffield",
     "latitude": 53.3782362148,
     "longitude": -1.4621101656
   },
   {
     "3alpha": "SHH",
-    "station_name": "Shirehampton Rail Station",
+    "station_name": "Shirehampton",
     "latitude": 51.4843469177,
     "longitude": -2.6792781047
   },
   {
     "3alpha": "SHI",
-    "station_name": "Shiplake Rail Station",
+    "station_name": "Shiplake",
     "latitude": 51.5114625615,
     "longitude": -0.8825832762
   },
   {
     "3alpha": "SHJ",
-    "station_name": "St Helens Junction Rail Station",
+    "station_name": "St Helens Junction",
     "latitude": 53.4337400237,
     "longitude": -2.7002586912
   },
   {
     "3alpha": "SHL",
-    "station_name": "Shawlands Rail Station",
+    "station_name": "Shawlands",
     "latitude": 55.8292064055,
     "longitude": -4.2923288907
   },
   {
     "3alpha": "SHM",
-    "station_name": "Sheringham Rail Station",
+    "station_name": "Sheringham",
     "latitude": 52.9414541496,
     "longitude": 1.2103377731
   },
   {
     "3alpha": "SHN",
-    "station_name": "Shanklin Rail Station",
+    "station_name": "Shanklin",
     "latitude": 50.633896807,
     "longitude": -1.1798245747
   },
   {
     "3alpha": "SHO",
-    "station_name": "Sholing Rail Station",
+    "station_name": "Sholing",
     "latitude": 50.896742165,
     "longitude": -1.3649055402
   },
   {
     "3alpha": "SHP",
-    "station_name": "Shepperton Rail Station",
+    "station_name": "Shepperton",
     "latitude": 51.3968021836,
     "longitude": -0.4467657574
   },
   {
     "3alpha": "SHR",
-    "station_name": "Shrewsbury Rail Station",
+    "station_name": "Shrewsbury",
     "latitude": 52.7119413175,
     "longitude": -2.749759506
   },
   {
     "3alpha": "SHS",
-    "station_name": "Shotts Rail Station",
+    "station_name": "Shotts",
     "latitude": 55.81864295,
     "longitude": -3.7983094064
   },
   {
     "3alpha": "SHT",
-    "station_name": "Shotton Rail Station",
+    "station_name": "Shotton",
     "latitude": 53.2125551564,
     "longitude": -3.0384238251
   },
   {
     "3alpha": "SHU",
-    "station_name": "Stonehouse Rail Station",
+    "station_name": "Stonehouse",
     "latitude": 51.7458905703,
     "longitude": -2.2794958307
   },
@@ -12427,109 +12511,109 @@
   },
   {
     "3alpha": "SHW",
-    "station_name": "Shawford Rail Station",
+    "station_name": "Shawford",
     "latitude": 51.0221166807,
     "longitude": -1.3277625973
   },
   {
     "3alpha": "SHY",
-    "station_name": "Shipley Rail Station",
+    "station_name": "Shipley",
     "latitude": 53.8330646823,
     "longitude": -1.7734929691
   },
   {
     "3alpha": "SIA",
-    "station_name": "Southend Airport Rail Station",
+    "station_name": "Southend Airport",
     "latitude": 51.5686727167,
     "longitude": 0.7050788997
   },
   {
     "3alpha": "SIC",
-    "station_name": "Silecroft Rail Station",
+    "station_name": "Silecroft",
     "latitude": 54.2259646268,
     "longitude": -3.3344411623
   },
   {
     "3alpha": "SID",
-    "station_name": "Sidcup Rail Station",
+    "station_name": "Sidcup",
     "latitude": 51.4338684504,
     "longitude": 0.103820707
   },
   {
     "3alpha": "SIE",
-    "station_name": "Sherburn-in-Elmet Rail Station",
+    "station_name": "Sherburn-in-Elmet",
     "latitude": 53.797168439,
     "longitude": -1.2326887081
   },
   {
     "3alpha": "SIH",
-    "station_name": "St Helier (London) Rail Station",
+    "station_name": "St Helier (London)",
     "latitude": 51.3898980858,
     "longitude": -0.1987461399
   },
   {
     "3alpha": "SIL",
-    "station_name": "Sileby Rail Station",
+    "station_name": "Sileby",
     "latitude": 52.7316119497,
     "longitude": -1.1099817344
   },
   {
     "3alpha": "SIN",
-    "station_name": "Singer Rail Station",
+    "station_name": "Singer",
     "latitude": 55.9076643414,
     "longitude": -4.4054709223
   },
   {
     "3alpha": "SIP",
-    "station_name": "Shipton Rail Station",
+    "station_name": "Shipton",
     "latitude": 51.8656602235,
     "longitude": -1.5926793251
   },
   {
     "3alpha": "SIT",
-    "station_name": "Sittingbourne Rail Station",
+    "station_name": "Sittingbourne",
     "latitude": 51.3419765756,
     "longitude": 0.734715016
   },
   {
     "3alpha": "SIV",
-    "station_name": "St Ives (Cornwall) Rail Station",
+    "station_name": "St Ives (Cornwall)",
     "latitude": 50.2090340797,
     "longitude": -5.4779638071
   },
   {
     "3alpha": "SJP",
-    "station_name": "St James Park (Devon) Rail Station",
+    "station_name": "St James Park (Devon)",
     "latitude": 50.7311433327,
     "longitude": -3.522008373
   },
   {
     "3alpha": "SJS",
-    "station_name": "St James Street (London) Rail Station",
+    "station_name": "St James Street (London)",
     "latitude": 51.5809810952,
     "longitude": -0.0328918555
   },
   {
     "3alpha": "SKE",
-    "station_name": "Skewen Rail Station",
+    "station_name": "Skewen",
     "latitude": 51.6613929554,
     "longitude": -3.8465246377
   },
   {
     "3alpha": "SKG",
-    "station_name": "Skegness Rail Station",
+    "station_name": "Skegness",
     "latitude": 53.1432054155,
     "longitude": 0.3343478313
   },
   {
     "3alpha": "SKI",
-    "station_name": "Skipton Rail Station",
+    "station_name": "Skipton",
     "latitude": 53.9586993556,
     "longitude": -2.0258762003
   },
   {
     "3alpha": "SKM",
-    "station_name": "Stoke Mandeville Rail Station",
+    "station_name": "Stoke Mandeville",
     "latitude": 51.7878005079,
     "longitude": -0.7840627602
   },
@@ -12541,703 +12625,709 @@
   },
   {
     "3alpha": "SKS",
-    "station_name": "Stocksfield Rail Station",
+    "station_name": "Stocksfield",
     "latitude": 54.9470541409,
     "longitude": -1.9167691115
   },
   {
     "3alpha": "SKW",
-    "station_name": "Stoke Newington Rail Station",
+    "station_name": "Stoke Newington",
     "latitude": 51.5652328179,
     "longitude": -0.0728615603
   },
   {
     "3alpha": "SLA",
-    "station_name": "Slateford Rail Station",
+    "station_name": "Slateford",
     "latitude": 55.9266820904,
     "longitude": -3.2434555997
   },
   {
     "3alpha": "SLB",
-    "station_name": "Saltburn Rail Station",
+    "station_name": "Saltburn",
     "latitude": 54.5834629003,
     "longitude": -0.9741485323
   },
   {
     "3alpha": "SLD",
-    "station_name": "Salford Crescent Rail Station",
+    "station_name": "Salford Crescent",
     "latitude": 53.4866023466,
     "longitude": -2.2757478149
   },
   {
     "3alpha": "SLH",
-    "station_name": "Sleights Rail Station",
+    "station_name": "Sleights",
     "latitude": 54.4610657105,
     "longitude": -0.6624968789
   },
   {
     "3alpha": "SLK",
-    "station_name": "Silkstone Common Rail Station",
+    "station_name": "Silkstone Common",
     "latitude": 53.5349327521,
     "longitude": -1.5634802419
   },
   {
     "3alpha": "SLL",
-    "station_name": "Stallingborough Rail Station",
+    "station_name": "Stallingborough",
     "latitude": 53.5871163761,
     "longitude": -0.1836712695
   },
   {
     "3alpha": "SLO",
-    "station_name": "Slough Rail Station",
+    "station_name": "Slough",
     "latitude": 51.5118802466,
     "longitude": -0.5914931274
   },
   {
     "3alpha": "SLQ",
-    "station_name": "St Leonards Warrior Square Rail Station",
+    "station_name": "St Leonards Warrior Square",
     "latitude": 50.8556892437,
     "longitude": 0.5603085614
   },
   {
     "3alpha": "SLR",
-    "station_name": "Sleaford Rail Station",
+    "station_name": "Sleaford",
     "latitude": 52.9954938802,
     "longitude": -0.4103411047
   },
   {
     "3alpha": "SLS",
-    "station_name": "Shettleston Rail Station",
+    "station_name": "Shettleston",
     "latitude": 55.8535309533,
     "longitude": -4.1600304592
   },
   {
     "3alpha": "SLT",
-    "station_name": "Saltcoats Rail Station",
+    "station_name": "Saltcoats",
     "latitude": 55.6338785668,
     "longitude": -4.7842684101
   },
   {
     "3alpha": "SLV",
-    "station_name": "Silver Street Rail Station",
+    "station_name": "Silver Street",
     "latitude": 51.614688688,
     "longitude": -0.0672151307
   },
   {
     "3alpha": "SLW",
-    "station_name": "Salwick Rail Station",
+    "station_name": "Salwick",
     "latitude": 53.781554319,
     "longitude": -2.8170354918
   },
   {
     "3alpha": "SLY",
-    "station_name": "Selly Oak Rail Station",
+    "station_name": "Selly Oak",
     "latitude": 52.4419948393,
     "longitude": -1.9358085367
   },
   {
     "3alpha": "SMA",
-    "station_name": "Small Heath Rail Station",
+    "station_name": "Small Heath",
     "latitude": 52.4637743964,
     "longitude": -1.8593875424
   },
   {
     "3alpha": "SMB",
-    "station_name": "Smithy Bridge Rail Station",
+    "station_name": "Smithy Bridge",
     "latitude": 53.6332679916,
     "longitude": -2.1135014139
   },
   {
     "3alpha": "SMC",
-    "station_name": "Sampford Courtenay Rail Station",
+    "station_name": "Sampford Courtenay",
     "latitude": 50.7700908969,
     "longitude": -3.9489125512
   },
   {
     "3alpha": "SMD",
-    "station_name": "Stamford Rail Station",
+    "station_name": "Stamford",
     "latitude": 52.6478489455,
     "longitude": -0.4801041079
   },
   {
     "3alpha": "SMG",
-    "station_name": "St Margarets (London) Rail Station",
+    "station_name": "St Margarets (London)",
     "latitude": 51.4552338666,
     "longitude": -0.3201782408
   },
   {
     "3alpha": "SMH",
-    "station_name": "Stamford Hill Rail Station",
+    "station_name": "Stamford Hill",
     "latitude": 51.5744676612,
     "longitude": -0.0766565162
   },
   {
     "3alpha": "SMK",
-    "station_name": "Stowmarket Rail Station",
+    "station_name": "Stowmarket",
     "latitude": 52.189727647,
     "longitude": 1.0000367465
   },
   {
     "3alpha": "SML",
-    "station_name": "Sea Mills Rail Station",
+    "station_name": "Sea Mills",
     "latitude": 51.4799904425,
     "longitude": -2.6499531782
   },
   {
     "3alpha": "SMN",
-    "station_name": "Southminster Rail Station",
+    "station_name": "Southminster",
     "latitude": 51.6606288734,
     "longitude": 0.8352211602
   },
   {
     "3alpha": "SMO",
-    "station_name": "South Merton Rail Station",
+    "station_name": "South Merton",
     "latitude": 51.4029904753,
     "longitude": -0.2051331043
   },
   {
     "3alpha": "SMR",
-    "station_name": "Smethwick Rolfe Street Rail Station",
+    "station_name": "Smethwick Rolfe Street",
     "latitude": 52.4963984863,
     "longitude": -1.9706383988
   },
   {
     "3alpha": "SMT",
-    "station_name": "St Margarets (Herts) Rail Station",
+    "station_name": "St Margarets (Herts)",
     "latitude": 51.7878447991,
     "longitude": 0.0012964611
   },
   {
     "3alpha": "SMY",
-    "station_name": "St Mary Cray Rail Station",
+    "station_name": "St Mary Cray",
     "latitude": 51.3947475934,
     "longitude": 0.1064098734
   },
   {
     "3alpha": "SNA",
-    "station_name": "Sandal & Agbrigg Rail Station",
+    "station_name": "Sandal & Agbrigg",
     "latitude": 53.663093616,
     "longitude": -1.4814212432
   },
   {
     "3alpha": "SND",
-    "station_name": "Sandhurst Rail Station",
+    "station_name": "Sandhurst",
     "latitude": 51.3469294691,
     "longitude": -0.8045742694
   },
   {
     "3alpha": "SNE",
-    "station_name": "Stone Rail Station",
+    "station_name": "Stone",
     "latitude": 52.9083405003,
     "longitude": -2.1550394406
   },
   {
     "3alpha": "SNF",
-    "station_name": "Shenfield Rail Station",
+    "station_name": "Shenfield",
     "latitude": 51.6308782728,
     "longitude": 0.3298784447
   },
   {
     "3alpha": "SNG",
-    "station_name": "Sunningdale Rail Station",
+    "station_name": "Sunningdale",
     "latitude": 51.3919389035,
     "longitude": -0.6330228307
   },
   {
     "3alpha": "SNH",
-    "station_name": "St Helens Central Rail Station",
+    "station_name": "St Helens Central",
     "latitude": 53.4531374207,
     "longitude": -2.7303039117
   },
   {
     "3alpha": "SNI",
-    "station_name": "Snaith Rail Station",
+    "station_name": "Snaith",
     "latitude": 53.6931319312,
     "longitude": -1.0284631537
   },
   {
     "3alpha": "SNK",
-    "station_name": "Sankey for Penketh Rail Station",
+    "station_name": "Sankey for Penketh",
     "latitude": 53.392475627,
     "longitude": -2.6504695097
   },
   {
     "3alpha": "SNL",
-    "station_name": "Stoneleigh Rail Station",
+    "station_name": "Stoneleigh",
     "latitude": 51.3633975389,
     "longitude": -0.248640927
   },
   {
     "3alpha": "SNN",
-    "station_name": "Swinton (Manchester) Rail Station",
+    "station_name": "Swinton (Manchester)",
     "latitude": 53.5148477623,
     "longitude": -2.3374594966
   },
   {
     "3alpha": "SNO",
-    "station_name": "St Neots Rail Station",
+    "station_name": "St Neots",
     "latitude": 52.2315789405,
     "longitude": -0.2473922859
   },
   {
     "3alpha": "SNP",
-    "station_name": "Stanhope Rail Station",
+    "station_name": "Stanhope",
     "latitude": 54.7433166118,
     "longitude": -2.003270368
   },
   {
     "3alpha": "SNR",
-    "station_name": "Sanderstead Rail Station",
+    "station_name": "Sanderstead",
     "latitude": 51.3482809474,
     "longitude": -0.0936522427
   },
   {
     "3alpha": "SNS",
-    "station_name": "Staines Rail Station",
+    "station_name": "Staines",
     "latitude": 51.4324535002,
     "longitude": -0.5031448916
   },
   {
     "3alpha": "SNT",
-    "station_name": "Stanlow & Thornton Rail Station",
+    "station_name": "Stanlow & Thornton",
     "latitude": 53.2783765388,
     "longitude": -2.8420514589
   },
   {
     "3alpha": "SNW",
-    "station_name": "Swanwick Rail Station",
+    "station_name": "Swanwick",
     "latitude": 50.8756583726,
     "longitude": -1.2658406523
   },
   {
     "3alpha": "SNY",
-    "station_name": "Sunnymeads Rail Station",
+    "station_name": "Sunnymeads",
     "latitude": 51.4702876016,
     "longitude": -0.5593563895
   },
   {
     "3alpha": "SOA",
-    "station_name": "Southampton Airport Parkway Rail Station",
+    "station_name": "Southampton Airport Parkway",
     "latitude": 50.9508051335,
     "longitude": -1.3630864575
   },
   {
     "3alpha": "SOB",
-    "station_name": "Southbourne Rail Station",
+    "station_name": "Southbourne",
     "latitude": 50.8482655747,
     "longitude": -0.9080912718
   },
   {
     "3alpha": "SOC",
-    "station_name": "Southend Central Rail Station",
+    "station_name": "Southend Central",
     "latitude": 51.537066598,
     "longitude": 0.7117558649
   },
   {
     "3alpha": "SOE",
-    "station_name": "Southend East Rail Station",
+    "station_name": "Southend East",
     "latitude": 51.5389747276,
     "longitude": 0.7318442913
   },
   {
     "3alpha": "SOF",
-    "station_name": "South Woodham Ferrers Rail Station",
+    "station_name": "South Woodham Ferrers",
     "latitude": 51.6494615164,
     "longitude": 0.6065323444
   },
   {
     "3alpha": "SOG",
-    "station_name": "Stonegate Rail Station",
+    "station_name": "Stonegate",
     "latitude": 51.0199626384,
     "longitude": 0.3638955581
   },
   {
     "3alpha": "SOH",
-    "station_name": "South Hampstead Rail Station",
+    "station_name": "South Hampstead",
     "latitude": 51.5414325626,
     "longitude": -0.1788526652
   },
   {
     "3alpha": "SOI",
-    "station_name": "Stow Rail Station",
+    "station_name": "Stow",
     "latitude": 55.6924175451,
     "longitude": -2.8659523944
   },
   {
+    "3alpha": "SOJ",
+    "station_name": "Soham",
+    "latitude": 52.331,
+    "longitude": -0.337
+  },
+  {
     "3alpha": "SOK",
-    "station_name": "South Kenton Rail Station",
+    "station_name": "South Kenton",
     "latitude": 51.5702144388,
     "longitude": -0.3084401599
   },
   {
     "3alpha": "SOL",
-    "station_name": "Solihull Rail Station",
+    "station_name": "Solihull",
     "latitude": 52.4144038973,
     "longitude": -1.7883836849
   },
   {
     "3alpha": "SOM",
-    "station_name": "South Milford Rail Station",
+    "station_name": "South Milford",
     "latitude": 53.782342555,
     "longitude": -1.2505333925
   },
   {
     "3alpha": "SON",
-    "station_name": "Steeton & Silsden Rail Station",
+    "station_name": "Steeton & Silsden",
     "latitude": 53.9000444561,
     "longitude": -1.9447229013
   },
   {
     "3alpha": "SOO",
-    "station_name": "Strood Rail Station",
+    "station_name": "Strood",
     "latitude": 51.3965463718,
     "longitude": 0.5002161998
   },
   {
     "3alpha": "SOP",
-    "station_name": "Southport Rail Station",
+    "station_name": "Southport",
     "latitude": 53.6465333176,
     "longitude": -3.0024325138
   },
   {
     "3alpha": "SOR",
-    "station_name": "Sole Street Rail Station",
+    "station_name": "Sole Street",
     "latitude": 51.3831433215,
     "longitude": 0.3781256752
   },
   {
     "3alpha": "SOT",
-    "station_name": "Stoke-on-Trent Rail Station",
+    "station_name": "Stoke-on-Trent",
     "latitude": 53.0079958214,
     "longitude": -2.1809866656
   },
   {
     "3alpha": "SOU",
-    "station_name": "Southampton Central Rail Station",
+    "station_name": "Southampton Central",
     "latitude": 50.9074381105,
     "longitude": -1.4135875626
   },
   {
     "3alpha": "SOV",
-    "station_name": "Southend Victoria Rail Station",
+    "station_name": "Southend Victoria",
     "latitude": 51.5415147415,
     "longitude": 0.7115300293
   },
   {
     "3alpha": "SOW",
-    "station_name": "Sowerby Bridge Rail Station",
+    "station_name": "Sowerby Bridge",
     "latitude": 53.7078597734,
     "longitude": -1.9070230861
   },
   {
     "3alpha": "SPA",
-    "station_name": "Spalding Rail Station",
+    "station_name": "Spalding",
     "latitude": 52.7888256516,
     "longitude": -0.1568731307
   },
   {
     "3alpha": "SPB",
-    "station_name": "Shepherds Bush Rail Station",
+    "station_name": "Shepherds Bush",
     "latitude": 51.505284273,
     "longitude": -0.2176304274
   },
   {
     "3alpha": "SPF",
-    "station_name": "Springfield Rail Station",
+    "station_name": "Springfield",
     "latitude": 56.2949608449,
     "longitude": -3.0524499272
   },
   {
     "3alpha": "SPH",
-    "station_name": "Shepherds Well Rail Station",
+    "station_name": "Shepherds Well",
     "latitude": 51.1884029231,
     "longitude": 1.229940616
   },
   {
     "3alpha": "SPI",
-    "station_name": "Spital Rail Station",
+    "station_name": "Spital",
     "latitude": 53.3399518307,
     "longitude": -2.9939065057
   },
   {
     "3alpha": "SPK",
-    "station_name": "Sutton Parkway Rail Station",
+    "station_name": "Sutton Parkway",
     "latitude": 53.1141094224,
     "longitude": -1.2455659505
   },
   {
     "3alpha": "SPL",
-    "station_name": "London St Pancras International LL Rail Station",
+    "station_name": "London St Pancras International LL",
     "latitude": 51.5321682332,
     "longitude": -0.1273170838
   },
   {
     "3alpha": "SPN",
-    "station_name": "Spooner Row Rail Station",
+    "station_name": "Spooner Row",
     "latitude": 52.535018036,
     "longitude": 1.0864987701
   },
   {
     "3alpha": "SPO",
-    "station_name": "Spondon Rail Station",
+    "station_name": "Spondon",
     "latitude": 52.9122360781,
     "longitude": -1.4110901354
   },
   {
     "3alpha": "SPP",
-    "station_name": "Shippea Hill Rail Station",
+    "station_name": "Shippea Hill",
     "latitude": 52.4302290785,
     "longitude": 0.4133683213
   },
   {
     "3alpha": "SPR",
-    "station_name": "Springburn Rail Station",
+    "station_name": "Springburn",
     "latitude": 55.8819306661,
     "longitude": -4.2305204867
   },
   {
     "3alpha": "SPS",
-    "station_name": "Stepps Rail Station",
+    "station_name": "Stepps",
     "latitude": 55.8901303522,
     "longitude": -4.1407948936
   },
   {
     "3alpha": "SPT",
-    "station_name": "Stockport Rail Station",
+    "station_name": "Stockport",
     "latitude": 53.4055533886,
     "longitude": -2.1630118236
   },
   {
     "3alpha": "SPU",
-    "station_name": "Staplehurst Rail Station",
+    "station_name": "Staplehurst",
     "latitude": 51.1714644595,
     "longitude": 0.5504684545
   },
   {
     "3alpha": "SPY",
-    "station_name": "Shepley Rail Station",
+    "station_name": "Shepley",
     "latitude": 53.5887544999,
     "longitude": -1.7049300824
   },
   {
     "3alpha": "SQE",
-    "station_name": "Surrey Quays Rail Station",
+    "station_name": "Surrey Quays",
     "latitude": 51.493195576,
     "longitude": -0.0474925165
   },
   {
     "3alpha": "SQH",
-    "station_name": "Sanquhar Rail Station",
+    "station_name": "Sanquhar",
     "latitude": 55.3701688129,
     "longitude": -3.9245103507
   },
   {
     "3alpha": "SQU",
-    "station_name": "Squires Gate Rail Station",
+    "station_name": "Squires Gate",
     "latitude": 53.7773453923,
     "longitude": -3.0502988204
   },
   {
     "3alpha": "SRA",
-    "station_name": "Stratford (London) Rail Station",
+    "station_name": "Stratford (London)",
     "latitude": 51.541895146,
     "longitude": -0.0033691271
   },
   {
     "3alpha": "SRC",
-    "station_name": "Streatham Common Rail Station",
+    "station_name": "Streatham Common",
     "latitude": 51.4187280874,
     "longitude": -0.1359839628
   },
   {
     "3alpha": "SRD",
-    "station_name": "Stapleton Road Rail Station",
+    "station_name": "Stapleton Road",
     "latitude": 51.4675039991,
     "longitude": -2.5662177437
   },
   {
     "3alpha": "SRG",
-    "station_name": "Seer Green Rail Station",
+    "station_name": "Seer Green",
     "latitude": 51.6098457593,
     "longitude": -0.6077986309
   },
   {
     "3alpha": "SRH",
-    "station_name": "Streatham Hill Rail Station",
+    "station_name": "Streatham Hill",
     "latitude": 51.4381912428,
     "longitude": -0.1271343887
   },
   {
     "3alpha": "SRI",
-    "station_name": "Spring Road Rail Station",
+    "station_name": "Spring Road",
     "latitude": 52.4434290378,
     "longitude": -1.8373837238
   },
   {
     "3alpha": "SRL",
-    "station_name": "Shirley Rail Station",
+    "station_name": "Shirley",
     "latitude": 52.4034335801,
     "longitude": -1.8451727358
   },
   {
     "3alpha": "SRN",
-    "station_name": "Strines Rail Station",
+    "station_name": "Strines",
     "latitude": 53.375053434,
     "longitude": -2.03391498
   },
   {
     "3alpha": "SRO",
-    "station_name": "Shireoaks Rail Station",
+    "station_name": "Shireoaks",
     "latitude": 53.324793696,
     "longitude": -1.1679906243
   },
   {
     "3alpha": "SRR",
-    "station_name": "Sarn Rail Station",
+    "station_name": "Sarn",
     "latitude": 51.538716062,
     "longitude": -3.5899278153
   },
   {
     "3alpha": "SRS",
-    "station_name": "Selhurst Rail Station",
+    "station_name": "Selhurst",
     "latitude": 51.3919256691,
     "longitude": -0.0882746656
   },
   {
     "3alpha": "SRT",
-    "station_name": "Shortlands Rail Station",
+    "station_name": "Shortlands",
     "latitude": 51.4057983982,
     "longitude": 0.0018099278
   },
   {
     "3alpha": "SRU",
-    "station_name": "South Ruislip Rail Station",
+    "station_name": "South Ruislip",
     "latitude": 51.5569197794,
     "longitude": -0.3992385186
   },
   {
     "3alpha": "SRY",
-    "station_name": "Shoeburyness Rail Station",
+    "station_name": "Shoeburyness",
     "latitude": 51.5309751312,
     "longitude": 0.7953748853
   },
   {
     "3alpha": "SSC",
-    "station_name": "Seascale Rail Station",
+    "station_name": "Seascale",
     "latitude": 54.3958826629,
     "longitude": -3.4845106158
   },
   {
     "3alpha": "SSD",
-    "station_name": "Stansted Airport Rail Station",
+    "station_name": "Stansted Airport",
     "latitude": 51.8885969065,
     "longitude": 0.2608429847
   },
   {
     "3alpha": "SSE",
-    "station_name": "Shoreham-by-Sea (Sussex) Rail Station",
+    "station_name": "Shoreham-by-Sea (Sussex)",
     "latitude": 50.8344187806,
     "longitude": -0.2716932437
   },
   {
     "3alpha": "SSM",
-    "station_name": "Stocksmoor Rail Station",
+    "station_name": "Stocksmoor",
     "latitude": 53.5941012185,
     "longitude": -1.723249622
   },
   {
     "3alpha": "SSS",
-    "station_name": "Sheerness-on-Sea Rail Station",
+    "station_name": "Sheerness-on-Sea",
     "latitude": 51.4410626729,
     "longitude": 0.7585627159
   },
   {
     "3alpha": "SST",
-    "station_name": "Stansted Mountfitchet Rail Station",
+    "station_name": "Stansted Mountfitchet",
     "latitude": 51.9014446092,
     "longitude": 0.1998076437
   },
   {
     "3alpha": "STA",
-    "station_name": "Stafford Rail Station",
+    "station_name": "Stafford",
     "latitude": 52.8039040388,
     "longitude": -2.122032317
   },
   {
     "3alpha": "STC",
-    "station_name": "Strathcarron Rail Station",
+    "station_name": "Strathcarron",
     "latitude": 57.4227106139,
     "longitude": -5.4286056714
   },
   {
     "3alpha": "STD",
-    "station_name": "Stroud (Glos) Rail Station",
+    "station_name": "Stroud (Glos)",
     "latitude": 51.7446251691,
     "longitude": -2.2193787757
   },
   {
     "3alpha": "STE",
-    "station_name": "Streatham Rail Station",
+    "station_name": "Streatham",
     "latitude": 51.425806399,
     "longitude": -0.1315244629
   },
   {
     "3alpha": "STF",
-    "station_name": "Stromeferry Rail Station",
+    "station_name": "Stromeferry",
     "latitude": 57.3522743311,
     "longitude": -5.5511508974
   },
   {
     "3alpha": "STG",
-    "station_name": "Stirling Rail Station",
+    "station_name": "Stirling",
     "latitude": 56.1198084255,
     "longitude": -3.9356129186
   },
   {
     "3alpha": "STH",
-    "station_name": "Shepreth Rail Station",
+    "station_name": "Shepreth",
     "latitude": 52.1141714275,
     "longitude": 0.0313474706
   },
   {
     "3alpha": "STJ",
-    "station_name": "Severn Tunnel Junction Rail Station",
+    "station_name": "Severn Tunnel Junction",
     "latitude": 51.5846753669,
     "longitude": -2.777896695
   },
   {
     "3alpha": "STK",
-    "station_name": "Stockton Rail Station",
+    "station_name": "Stockton",
     "latitude": 54.5696329596,
     "longitude": -1.3185563444
   },
   {
     "3alpha": "STL",
-    "station_name": "Southall Rail Station",
+    "station_name": "Southall",
     "latitude": 51.5059555535,
     "longitude": -0.3785893432
   },
   {
     "3alpha": "STM",
-    "station_name": "St Michaels Rail Station",
+    "station_name": "St Michaels",
     "latitude": 53.3756143466,
     "longitude": -2.9527983882
   },
   {
     "3alpha": "STN",
-    "station_name": "Stonehaven Rail Station",
+    "station_name": "Stonehaven",
     "latitude": 56.9668074474,
     "longitude": -2.2253042533
   },
   {
     "3alpha": "STO",
-    "station_name": "South Tottenham Rail Station",
+    "station_name": "South Tottenham",
     "latitude": 51.580372482,
     "longitude": -0.0720773948
   },
   {
     "3alpha": "STP",
-    "station_name": "London St Pancras International Rail Station",
+    "station_name": "London St Pancras International",
     "latitude": 51.5323906044,
     "longitude": -0.1271637715
   },
@@ -13249,823 +13339,823 @@
   },
   {
     "3alpha": "STR",
-    "station_name": "Stranraer Rail Station",
+    "station_name": "Stranraer",
     "latitude": 54.9096119416,
     "longitude": -5.0247136457
   },
   {
     "3alpha": "STS",
-    "station_name": "Saltash Rail Station",
+    "station_name": "Saltash",
     "latitude": 50.407341292,
     "longitude": -4.2091429608
   },
   {
     "3alpha": "STT",
-    "station_name": "Stewarton Rail Station",
+    "station_name": "Stewarton",
     "latitude": 55.6821494442,
     "longitude": -4.5180405975
   },
   {
     "3alpha": "STU",
-    "station_name": "Sturry Rail Station",
+    "station_name": "Sturry",
     "latitude": 51.301071637,
     "longitude": 1.1222846311
   },
   {
     "3alpha": "STV",
-    "station_name": "Stevenston Rail Station",
+    "station_name": "Stevenston",
     "latitude": 55.6342752646,
     "longitude": -4.7507681765
   },
   {
     "3alpha": "STW",
-    "station_name": "Strawberry Hill Rail Station",
+    "station_name": "Strawberry Hill",
     "latitude": 51.4389610182,
     "longitude": -0.3393370866
   },
   {
     "3alpha": "STY",
-    "station_name": "Stratford-upon-Avon Parkway Rail Station",
+    "station_name": "Stratford-upon-Avon Parkway",
     "latitude": 52.20679123,
     "longitude": -1.7308347436
   },
   {
     "3alpha": "STZ",
-    "station_name": "St Peters Rail Station",
+    "station_name": "St Peters",
     "latitude": 54.9114465319,
     "longitude": -1.3838157241
   },
   {
     "3alpha": "SUC",
-    "station_name": "Sutton Common Rail Station",
+    "station_name": "Sutton Common",
     "latitude": 51.374887892,
     "longitude": -0.1963176971
   },
   {
     "3alpha": "SUD",
-    "station_name": "Sudbury & Harrow Road Rail Station",
+    "station_name": "Sudbury & Harrow Road",
     "latitude": 51.5543983927,
     "longitude": -0.3154454426
   },
   {
     "3alpha": "SUG",
-    "station_name": "Sugar Loaf Rail Station",
+    "station_name": "Sugar Loaf",
     "latitude": 52.082277733,
     "longitude": -3.6869603427
   },
   {
     "3alpha": "SUM",
-    "station_name": "Summerston Rail Station",
+    "station_name": "Summerston",
     "latitude": 55.8988291055,
     "longitude": -4.2915239477
   },
   {
     "3alpha": "SUN",
-    "station_name": "Sunderland Rail Station",
+    "station_name": "Sunderland",
     "latitude": 54.9053460619,
     "longitude": -1.382318101
   },
   {
     "3alpha": "SUO",
-    "station_name": "Sutton (London) Rail Station",
+    "station_name": "Sutton (London)",
     "latitude": 51.359530184,
     "longitude": -0.1911898264
   },
   {
     "3alpha": "SUP",
-    "station_name": "Sundridge Park Rail Station",
+    "station_name": "Sundridge Park",
     "latitude": 51.4137794712,
     "longitude": 0.0214722343
   },
   {
     "3alpha": "SUR",
-    "station_name": "Surbiton Rail Station",
+    "station_name": "Surbiton",
     "latitude": 51.392457041,
     "longitude": -0.3039362021
   },
   {
     "3alpha": "SUT",
-    "station_name": "Sutton Coldfield Rail Station",
+    "station_name": "Sutton Coldfield",
     "latitude": 52.5649558162,
     "longitude": -1.824837271
   },
   {
     "3alpha": "SUU",
-    "station_name": "Sunbury Rail Station",
+    "station_name": "Sunbury",
     "latitude": 51.4183118212,
     "longitude": -0.4177615601
   },
   {
     "3alpha": "SUY",
-    "station_name": "Sudbury (Suffolk) Rail Station",
+    "station_name": "Sudbury (Suffolk)",
     "latitude": 52.0362894221,
     "longitude": 0.7354756664
   },
   {
     "3alpha": "SVB",
-    "station_name": "Severn Beach Rail Station",
+    "station_name": "Severn Beach",
     "latitude": 51.560023655,
     "longitude": -2.6644812454
   },
   {
     "3alpha": "SVG",
-    "station_name": "Stevenage Rail Station",
+    "station_name": "Stevenage",
     "latitude": 51.9016927995,
     "longitude": -0.2070860807
   },
   {
     "3alpha": "SVK",
-    "station_name": "Seven Kings Rail Station",
+    "station_name": "Seven Kings",
     "latitude": 51.5640254913,
     "longitude": 0.0971266259
   },
   {
     "3alpha": "SVL",
-    "station_name": "Staveley Rail Station",
+    "station_name": "Staveley",
     "latitude": 54.3755397414,
     "longitude": -2.8188650127
   },
   {
     "3alpha": "SVR",
-    "station_name": "Silverdale Rail Station",
+    "station_name": "Silverdale",
     "latitude": 54.1699177481,
     "longitude": -2.8038415221
   },
   {
     "3alpha": "SVS",
-    "station_name": "Seven Sisters Rail Station",
+    "station_name": "Seven Sisters",
     "latitude": 51.5822680092,
     "longitude": -0.0752448572
   },
   {
     "3alpha": "SWA",
-    "station_name": "Swansea Rail Station",
+    "station_name": "Swansea",
     "latitude": 51.6251487596,
     "longitude": -3.9415644468
   },
   {
     "3alpha": "SWD",
-    "station_name": "Swinderby Rail Station",
+    "station_name": "Swinderby",
     "latitude": 53.1695752058,
     "longitude": -0.7026776123
   },
   {
     "3alpha": "SWE",
-    "station_name": "Swineshead Rail Station",
+    "station_name": "Swineshead",
     "latitude": 52.9698246032,
     "longitude": -0.1871603301
   },
   {
     "3alpha": "SWG",
-    "station_name": "Swaythling Rail Station",
+    "station_name": "Swaythling",
     "latitude": 50.9411378896,
     "longitude": -1.3763987158
   },
   {
     "3alpha": "SWI",
-    "station_name": "Swindon Rail Station",
+    "station_name": "Swindon",
     "latitude": 51.5654717291,
     "longitude": -1.7854997597
   },
   {
     "3alpha": "SWK",
-    "station_name": "Southwick Rail Station",
+    "station_name": "Southwick",
     "latitude": 50.8325078755,
     "longitude": -0.2359343912
   },
   {
     "3alpha": "SWL",
-    "station_name": "Swale Rail Station",
+    "station_name": "Swale",
     "latitude": 51.3892367714,
     "longitude": 0.7471634594
   },
   {
     "3alpha": "SWM",
-    "station_name": "Swanscombe Rail Station",
+    "station_name": "Swanscombe",
     "latitude": 51.4490684493,
     "longitude": 0.3095719354
   },
   {
     "3alpha": "SWN",
-    "station_name": "Swinton (South Yorks) Rail Station",
+    "station_name": "Swinton (South Yorks)",
     "latitude": 53.4862573953,
     "longitude": -1.3058228385
   },
   {
     "3alpha": "SWO",
-    "station_name": "Snowdown Rail Station",
+    "station_name": "Snowdown",
     "latitude": 51.2153033313,
     "longitude": 1.2137349076
   },
   {
     "3alpha": "SWR",
-    "station_name": "Stewartby Rail Station",
+    "station_name": "Stewartby",
     "latitude": 52.0690889946,
     "longitude": -0.5206700583
   },
   {
     "3alpha": "SWS",
-    "station_name": "South Wigston Rail Station",
+    "station_name": "South Wigston",
     "latitude": 52.5822411091,
     "longitude": -1.1340686433
   },
   {
     "3alpha": "SWT",
-    "station_name": "Slaithwaite Rail Station",
+    "station_name": "Slaithwaite",
     "latitude": 53.6238425513,
     "longitude": -1.8815786683
   },
   {
     "3alpha": "SWY",
-    "station_name": "Sway Rail Station",
+    "station_name": "Sway",
     "latitude": 50.7846919652,
     "longitude": -1.6099880732
   },
   {
     "3alpha": "SXY",
-    "station_name": "Saxilby Rail Station",
+    "station_name": "Saxilby",
     "latitude": 53.2672239409,
     "longitude": -0.664039544
   },
   {
     "3alpha": "SYA",
-    "station_name": "Styal Rail Station",
+    "station_name": "Styal",
     "latitude": 53.3483444707,
     "longitude": -2.2404551552
   },
   {
     "3alpha": "SYB",
-    "station_name": "Stalybridge Rail Station",
+    "station_name": "Stalybridge",
     "latitude": 53.4845940592,
     "longitude": -2.0627406537
   },
   {
     "3alpha": "SYD",
-    "station_name": "Sydenham Rail Station",
+    "station_name": "Sydenham",
     "latitude": 51.4272456275,
     "longitude": -0.0542181492
   },
   {
     "3alpha": "SYH",
-    "station_name": "Sydenham Hill Rail Station",
+    "station_name": "Sydenham Hill",
     "latitude": 51.4327121996,
     "longitude": -0.0803137756
   },
   {
     "3alpha": "SYL",
-    "station_name": "Syon Lane Rail Station",
+    "station_name": "Syon Lane",
     "latitude": 51.4817833206,
     "longitude": -0.3248202577
   },
   {
     "3alpha": "SYS",
-    "station_name": "Syston Rail Station",
+    "station_name": "Syston",
     "latitude": 52.6942282549,
     "longitude": -1.0823921267
   },
   {
     "3alpha": "SYT",
-    "station_name": "Somerleyton Rail Station",
+    "station_name": "Somerleyton",
     "latitude": 52.510254523,
     "longitude": 1.65228441
   },
   {
     "3alpha": "TAB",
-    "station_name": "Tame Bridge Parkway Rail Station",
+    "station_name": "Tame Bridge Parkway",
     "latitude": 52.5529462534,
     "longitude": -1.9762062325
   },
   {
     "3alpha": "TAC",
-    "station_name": "Tackley Rail Station",
+    "station_name": "Tackley",
     "latitude": 51.8812440038,
     "longitude": -1.2975180267
   },
   {
     "3alpha": "TAD",
-    "station_name": "Tadworth Rail Station",
+    "station_name": "Tadworth",
     "latitude": 51.2916337745,
     "longitude": -0.2359396303
   },
   {
     "3alpha": "TAF",
-    "station_name": "Taffs Well Rail Station",
+    "station_name": "Taffs Well",
     "latitude": 51.5408038104,
     "longitude": -3.2629475716
   },
   {
     "3alpha": "TAH",
-    "station_name": "Tamworth High Level Rail Station",
+    "station_name": "Tamworth High Level",
     "latitude": 52.6374896703,
     "longitude": -1.6864429533
   },
   {
     "3alpha": "TAI",
-    "station_name": "Tain Rail Station",
+    "station_name": "Tain",
     "latitude": 57.814403344,
     "longitude": -4.052050677
   },
   {
     "3alpha": "TAL",
-    "station_name": "Talsarnau Rail Station",
+    "station_name": "Talsarnau",
     "latitude": 52.9043217775,
     "longitude": -4.0681617526
   },
   {
     "3alpha": "TAM",
-    "station_name": "Tamworth Rail Station",
+    "station_name": "Tamworth",
     "latitude": 52.6374897095,
     "longitude": -1.6864577321
   },
   {
     "3alpha": "TAP",
-    "station_name": "Taplow Rail Station",
+    "station_name": "Taplow",
     "latitude": 51.5235630262,
     "longitude": -0.6813523989
   },
   {
     "3alpha": "TAT",
-    "station_name": "Tattenham Corner Rail Station",
+    "station_name": "Tattenham Corner",
     "latitude": 51.3091795736,
     "longitude": -0.242584206
   },
   {
     "3alpha": "TAU",
-    "station_name": "Taunton Rail Station",
+    "station_name": "Taunton",
     "latitude": 51.0232957201,
     "longitude": -3.1027501001
   },
   {
     "3alpha": "TAY",
-    "station_name": "Taynuilt Rail Station",
+    "station_name": "Taynuilt",
     "latitude": 56.4307929324,
     "longitude": -5.2395897581
   },
   {
     "3alpha": "TBD",
-    "station_name": "Three Bridges Rail Station",
+    "station_name": "Three Bridges",
     "latitude": 51.1169179407,
     "longitude": -0.1611569978
   },
   {
     "3alpha": "TBW",
-    "station_name": "Tunbridge Wells Rail Station",
+    "station_name": "Tunbridge Wells",
     "latitude": 51.1302300678,
     "longitude": 0.2628373001
   },
   {
     "3alpha": "TBY",
-    "station_name": "Thornaby Rail Station",
+    "station_name": "Thornaby",
     "latitude": 54.5592813582,
     "longitude": -1.3014251552
   },
   {
     "3alpha": "TDU",
-    "station_name": "Tondu Rail Station",
+    "station_name": "Tondu",
     "latitude": 51.547362229,
     "longitude": -3.5955651626
   },
   {
     "3alpha": "TEA",
-    "station_name": "Tees-side Airport Rail Station",
+    "station_name": "Tees-side Airport",
     "latitude": 54.5181424575,
     "longitude": -1.4253223693
   },
   {
     "3alpha": "TED",
-    "station_name": "Teddington Rail Station",
+    "station_name": "Teddington",
     "latitude": 51.4244788122,
     "longitude": -0.3326846191
   },
   {
     "3alpha": "TEN",
-    "station_name": "Tenby Rail Station",
+    "station_name": "Tenby",
     "latitude": 51.672951966,
     "longitude": -4.7067273929
   },
   {
     "3alpha": "TEO",
-    "station_name": "Theobalds Grove Rail Station",
+    "station_name": "Theobalds Grove",
     "latitude": 51.692457758,
     "longitude": -0.0348052112
   },
   {
     "3alpha": "TEY",
-    "station_name": "Teynham Rail Station",
+    "station_name": "Teynham",
     "latitude": 51.3333932934,
     "longitude": 0.8074562729
   },
   {
     "3alpha": "TFC",
-    "station_name": "Telford Central Rail Station",
+    "station_name": "Telford Central",
     "latitude": 52.6811206446,
     "longitude": -2.4409698489
   },
   {
     "3alpha": "TGM",
-    "station_name": "Teignmouth Rail Station",
+    "station_name": "Teignmouth",
     "latitude": 50.5480477205,
     "longitude": -3.4946764735
   },
   {
     "3alpha": "TGS",
-    "station_name": "Ty Glas Rail Station",
+    "station_name": "Ty Glas",
     "latitude": 51.5215383785,
     "longitude": -3.1965433402
   },
   {
     "3alpha": "THA",
-    "station_name": "Thatcham Rail Station",
+    "station_name": "Thatcham",
     "latitude": 51.3938422697,
     "longitude": -1.2431703674
   },
   {
     "3alpha": "THB",
-    "station_name": "Thornliebank Rail Station",
+    "station_name": "Thornliebank",
     "latitude": 55.8110931929,
     "longitude": -4.3116934017
   },
   {
     "3alpha": "THC",
-    "station_name": "Thurnscoe Rail Station",
+    "station_name": "Thurnscoe",
     "latitude": 53.5450596404,
     "longitude": -1.3087865327
   },
   {
     "3alpha": "THD",
-    "station_name": "Thames Ditton Rail Station",
+    "station_name": "Thames Ditton",
     "latitude": 51.389094233,
     "longitude": -0.3391301451
   },
   {
     "3alpha": "THE",
-    "station_name": "Theale Rail Station",
+    "station_name": "Theale",
     "latitude": 51.4334510541,
     "longitude": -1.074953188
   },
   {
     "3alpha": "THH",
-    "station_name": "Thatto Heath Rail Station",
+    "station_name": "Thatto Heath",
     "latitude": 53.4365966678,
     "longitude": -2.7593735619
   },
   {
     "3alpha": "THI",
-    "station_name": "Thirsk Rail Station",
+    "station_name": "Thirsk",
     "latitude": 54.2282229773,
     "longitude": -1.3725964904
   },
   {
     "3alpha": "THL",
-    "station_name": "Tile Hill Rail Station",
+    "station_name": "Tile Hill",
     "latitude": 52.3951180004,
     "longitude": -1.5968388563
   },
   {
     "3alpha": "THO",
-    "station_name": "Thornford Rail Station",
+    "station_name": "Thornford",
     "latitude": 50.9105671531,
     "longitude": -2.5789881669
   },
   {
     "3alpha": "THS",
-    "station_name": "Thurso Rail Station",
+    "station_name": "Thurso",
     "latitude": 58.5901618735,
     "longitude": -3.5275560192
   },
   {
     "3alpha": "THT",
-    "station_name": "Thorntonhall Rail Station",
+    "station_name": "Thorntonhall",
     "latitude": 55.7686725545,
     "longitude": -4.251148703
   },
   {
     "3alpha": "THU",
-    "station_name": "Thurgarton Rail Station",
+    "station_name": "Thurgarton",
     "latitude": 53.0289614147,
     "longitude": -0.9622529876
   },
   {
     "3alpha": "THW",
-    "station_name": "The Hawthorns Rail Station",
+    "station_name": "The Hawthorns",
     "latitude": 52.5053866205,
     "longitude": -1.9640028874
   },
   {
     "3alpha": "TIL",
-    "station_name": "Tilbury Town Rail Station",
+    "station_name": "Tilbury Town",
     "latitude": 51.4623579727,
     "longitude": 0.3540684253
   },
   {
     "3alpha": "TIP",
-    "station_name": "Tipton Rail Station",
+    "station_name": "Tipton",
     "latitude": 52.5304554489,
     "longitude": -2.0656957349
   },
   {
     "3alpha": "TIR",
-    "station_name": "Tir-phil Rail Station",
+    "station_name": "Tir-phil",
     "latitude": 51.720908438,
     "longitude": -3.2463907704
   },
   {
     "3alpha": "TIS",
-    "station_name": "Tisbury Rail Station",
+    "station_name": "Tisbury",
     "latitude": 51.0608447298,
     "longitude": -2.078996052
   },
   {
     "3alpha": "TLB",
-    "station_name": "Talybont Rail Station",
+    "station_name": "Talybont",
     "latitude": 52.7726445507,
     "longitude": -4.0966036401
   },
   {
     "3alpha": "TLC",
-    "station_name": "Tal-y-Cafn Rail Station",
+    "station_name": "Tal-y-Cafn",
     "latitude": 53.2283776011,
     "longitude": -3.8182676092
   },
   {
     "3alpha": "TLH",
-    "station_name": "Tilehurst Rail Station",
+    "station_name": "Tilehurst",
     "latitude": 51.4715086374,
     "longitude": -1.0297956661
   },
   {
     "3alpha": "TLK",
-    "station_name": "The Lakes Rail Station",
+    "station_name": "The Lakes",
     "latitude": 52.3591567803,
     "longitude": -1.8446654141
   },
   {
     "3alpha": "TLS",
-    "station_name": "Thorpe-le-Soken Rail Station",
+    "station_name": "Thorpe-le-Soken",
     "latitude": 51.847646828,
     "longitude": 1.1614320188
   },
   {
     "3alpha": "TMC",
-    "station_name": "Templecombe Rail Station",
+    "station_name": "Templecombe",
     "latitude": 51.0014953975,
     "longitude": -2.4177222648
   },
   {
     "3alpha": "TNA",
-    "station_name": "Thornton Abbey Rail Station",
+    "station_name": "Thornton Abbey",
     "latitude": 53.6543223993,
     "longitude": -0.3230275398
   },
   {
     "3alpha": "TNF",
-    "station_name": "Tonfanau Rail Station",
+    "station_name": "Tonfanau",
     "latitude": 52.6135565545,
     "longitude": -4.1237062703
   },
   {
     "3alpha": "TNN",
-    "station_name": "Thorne North Rail Station",
+    "station_name": "Thorne North",
     "latitude": 53.6160814226,
     "longitude": -0.9723356959
   },
   {
     "3alpha": "TNP",
-    "station_name": "Tonypandy Rail Station",
+    "station_name": "Tonypandy",
     "latitude": 51.6197644665,
     "longitude": -3.4488804142
   },
   {
     "3alpha": "TNS",
-    "station_name": "Thorne South Rail Station",
+    "station_name": "Thorne South",
     "latitude": 53.6033482935,
     "longitude": -0.9551144553
   },
   {
     "3alpha": "TOD",
-    "station_name": "Todmorden Rail Station",
+    "station_name": "Todmorden",
     "latitude": 53.7138309013,
     "longitude": -2.0996605197
   },
   {
     "3alpha": "TOK",
-    "station_name": "Three Oaks Rail Station",
+    "station_name": "Three Oaks",
     "latitude": 50.9011098188,
     "longitude": 0.6130803485
   },
   {
     "3alpha": "TOL",
-    "station_name": "Tolworth Rail Station",
+    "station_name": "Tolworth",
     "latitude": 51.376857174,
     "longitude": -0.279438167
   },
   {
     "3alpha": "TOM",
-    "station_name": "Tottenham Hale Rail Station",
+    "station_name": "Tottenham Hale",
     "latitude": 51.5883098971,
     "longitude": -0.0599041132
   },
   {
     "3alpha": "TON",
-    "station_name": "Tonbridge Rail Station",
+    "station_name": "Tonbridge",
     "latitude": 51.1914072217,
     "longitude": 0.27100092
   },
   {
     "3alpha": "TOO",
-    "station_name": "Tooting Rail Station",
+    "station_name": "Tooting",
     "latitude": 51.4198462078,
     "longitude": -0.1612523385
   },
   {
     "3alpha": "TOP",
-    "station_name": "Topsham Rail Station",
+    "station_name": "Topsham",
     "latitude": 50.6862032067,
     "longitude": -3.4644362802
   },
   {
     "3alpha": "TOT",
-    "station_name": "Totnes Rail Station",
+    "station_name": "Totnes",
     "latitude": 50.4358486966,
     "longitude": -3.6887120337
   },
   {
     "3alpha": "TPB",
-    "station_name": "Thorpe Bay Rail Station",
+    "station_name": "Thorpe Bay",
     "latitude": 51.5375725855,
     "longitude": 0.761757978
   },
   {
     "3alpha": "TPC",
-    "station_name": "Thorpe Culvert Rail Station",
+    "station_name": "Thorpe Culvert",
     "latitude": 53.1231171411,
     "longitude": 0.199418712
   },
   {
     "3alpha": "TPN",
-    "station_name": "Ton Pentre Rail Station",
+    "station_name": "Ton Pentre",
     "latitude": 51.6478022913,
     "longitude": -3.4861984834
   },
   {
     "3alpha": "TQY",
-    "station_name": "Torquay Rail Station",
+    "station_name": "Torquay",
     "latitude": 50.4611182406,
     "longitude": -3.5432904492
   },
   {
     "3alpha": "TRA",
-    "station_name": "Trafford Park Rail Station",
+    "station_name": "Trafford Park",
     "latitude": 53.4548323413,
     "longitude": -2.310631341
   },
   {
     "3alpha": "TRB",
-    "station_name": "Treherbert Rail Station",
+    "station_name": "Treherbert",
     "latitude": 51.6722450222,
     "longitude": -3.5363140662
   },
   {
     "3alpha": "TRD",
-    "station_name": "Troed-y-Rhiw Rail Station",
+    "station_name": "Troed-y-Rhiw",
     "latitude": 51.7124284343,
     "longitude": -3.3467559182
   },
   {
     "3alpha": "TRE",
-    "station_name": "Trefforest Estate Rail Station",
+    "station_name": "Trefforest Estate",
     "latitude": 51.5682913986,
     "longitude": -3.2902588749
   },
   {
     "3alpha": "TRF",
-    "station_name": "Trefforest Rail Station",
+    "station_name": "Trefforest",
     "latitude": 51.5914619743,
     "longitude": -3.3251300368
   },
   {
     "3alpha": "TRH",
-    "station_name": "Trehafod Rail Station",
+    "station_name": "Trehafod",
     "latitude": 51.6101512603,
     "longitude": -3.3809848496
   },
   {
     "3alpha": "TRI",
-    "station_name": "Tring Rail Station",
+    "station_name": "Tring",
     "latitude": 51.8007474169,
     "longitude": -0.6224150693
   },
   {
     "3alpha": "TRM",
-    "station_name": "Trimley Rail Station",
+    "station_name": "Trimley",
     "latitude": 51.9765411505,
     "longitude": 1.3195660189
   },
   {
     "3alpha": "TRN",
-    "station_name": "Troon Rail Station",
+    "station_name": "Troon",
     "latitude": 55.5428092479,
     "longitude": -4.6552789194
   },
   {
     "3alpha": "TRO",
-    "station_name": "Trowbridge Rail Station",
+    "station_name": "Trowbridge",
     "latitude": 51.3198258981,
     "longitude": -2.2143311551
   },
   {
     "3alpha": "TRR",
-    "station_name": "Torre Rail Station",
+    "station_name": "Torre",
     "latitude": 50.4731733437,
     "longitude": -3.546431156
   },
   {
     "3alpha": "TRS",
-    "station_name": "Thurston Rail Station",
+    "station_name": "Thurston",
     "latitude": 52.250018318,
     "longitude": 0.80868287
   },
   {
     "3alpha": "TRU",
-    "station_name": "Truro Rail Station",
+    "station_name": "Truro",
     "latitude": 50.2638281307,
     "longitude": -5.0648592797
   },
   {
     "3alpha": "TRY",
-    "station_name": "Treorchy Rail Station",
+    "station_name": "Treorchy",
     "latitude": 51.6575345216,
     "longitude": -3.5057452076
   },
   {
     "3alpha": "TTF",
-    "station_name": "Thetford Rail Station",
+    "station_name": "Thetford",
     "latitude": 52.4191425696,
     "longitude": 0.7450983124
   },
   {
     "3alpha": "TTH",
-    "station_name": "Thornton Heath Rail Station",
+    "station_name": "Thornton Heath",
     "latitude": 51.3987754716,
     "longitude": -0.100280296
   },
   {
     "3alpha": "TTN",
-    "station_name": "Totton Rail Station",
+    "station_name": "Totton",
     "latitude": 50.917871726,
     "longitude": -1.4824091536
   },
   {
     "3alpha": "TUH",
-    "station_name": "Tulse Hill Rail Station",
+    "station_name": "Tulse Hill",
     "latitude": 51.439859554,
     "longitude": -0.1050510178
   },
   {
     "3alpha": "TUL",
-    "station_name": "Tulloch Rail Station",
+    "station_name": "Tulloch",
     "latitude": 56.8842613618,
     "longitude": -4.7013115681
   },
   {
     "3alpha": "TUR",
-    "station_name": "Turkey Street Rail Station",
+    "station_name": "Turkey Street",
     "latitude": 51.6726289265,
     "longitude": -0.047190258
   },
   {
     "3alpha": "TUT",
-    "station_name": "Tutbury & Hatton Rail Station",
+    "station_name": "Tutbury & Hatton",
     "latitude": 52.8641515138,
     "longitude": -1.6822308376
   },
   {
     "3alpha": "TVP",
-    "station_name": "Tiverton Parkway Rail Station",
+    "station_name": "Tiverton Parkway",
     "latitude": 50.917168904,
     "longitude": -3.3596569642
   },
   {
     "3alpha": "TWB",
-    "station_name": "Tweedbank Rail Station",
+    "station_name": "Tweedbank",
     "latitude": 55.6057393628,
     "longitude": -2.7595353637
   },
   {
     "3alpha": "TWI",
-    "station_name": "Twickenham Rail Station",
+    "station_name": "Twickenham",
     "latitude": 51.4500290431,
     "longitude": -0.3303719704
   },
   {
     "3alpha": "TWN",
-    "station_name": "Town Green Rail Station",
+    "station_name": "Town Green",
     "latitude": 53.5428211891,
     "longitude": -2.9044849794
   },
   {
     "3alpha": "TWY",
-    "station_name": "Twyford Rail Station",
+    "station_name": "Twyford",
     "latitude": 51.4755339055,
     "longitude": -0.8632740226
   },
@@ -14077,1465 +14167,1478 @@
   },
   {
     "3alpha": "TYC",
-    "station_name": "Ty Croes Rail Station",
+    "station_name": "Ty Croes",
     "latitude": 53.2225738882,
     "longitude": -4.4747394282
   },
   {
     "3alpha": "TYG",
-    "station_name": "Tygwyn Rail Station",
+    "station_name": "Tygwyn",
     "latitude": 52.8937988543,
     "longitude": -4.0786617087
   },
   {
     "3alpha": "TYL",
-    "station_name": "Tyndrum Lower Rail Station",
+    "station_name": "Tyndrum Lower",
     "latitude": 56.4333287654,
     "longitude": -4.7148053177
   },
   {
     "3alpha": "TYS",
-    "station_name": "Tyseley Rail Station",
+    "station_name": "Tyseley",
     "latitude": 52.4541295073,
     "longitude": -1.839110539
   },
   {
     "3alpha": "TYW",
-    "station_name": "Tywyn Rail Station",
+    "station_name": "Tywyn",
     "latitude": 52.5855906404,
     "longitude": -4.0935677848
   },
   {
     "3alpha": "UCK",
-    "station_name": "Uckfield Rail Station",
+    "station_name": "Uckfield",
     "latitude": 50.9687336094,
     "longitude": 0.0964070853
   },
   {
     "3alpha": "UDD",
-    "station_name": "Uddingston Rail Station",
+    "station_name": "Uddingston",
     "latitude": 55.8235220757,
     "longitude": -4.0866850065
   },
   {
     "3alpha": "UHA",
-    "station_name": "Uphall Rail Station",
+    "station_name": "Uphall",
     "latitude": 55.9190364207,
     "longitude": -3.5021160921
   },
   {
     "3alpha": "UHL",
-    "station_name": "Upper Holloway Rail Station",
+    "station_name": "Upper Holloway",
     "latitude": 51.5636322354,
     "longitude": -0.1294870843
   },
   {
     "3alpha": "ULC",
-    "station_name": "Ulceby Rail Station",
+    "station_name": "Ulceby",
     "latitude": 53.619221029,
     "longitude": -0.3008319145
   },
   {
     "3alpha": "ULL",
-    "station_name": "Ulleskelf Rail Station",
+    "station_name": "Ulleskelf",
     "latitude": 53.8536281296,
     "longitude": -1.2139769916
   },
   {
     "3alpha": "ULV",
-    "station_name": "Ulverston Rail Station",
+    "station_name": "Ulverston",
     "latitude": 54.1915918364,
     "longitude": -3.0979152379
   },
   {
     "3alpha": "UMB",
-    "station_name": "Umberleigh Rail Station",
+    "station_name": "Umberleigh",
     "latitude": 50.996741205,
     "longitude": -3.9829094548
   },
   {
     "3alpha": "UNI",
-    "station_name": "University Rail Station",
+    "station_name": "University",
     "latitude": 52.4512550606,
     "longitude": -1.9366781951
   },
   {
     "3alpha": "UPH",
-    "station_name": "Upper Halliford Rail Station",
+    "station_name": "Upper Halliford",
     "latitude": 51.4130654507,
     "longitude": -0.4308849859
   },
   {
     "3alpha": "UPL",
-    "station_name": "Upholland Rail Station",
+    "station_name": "Upholland",
     "latitude": 53.5283938559,
     "longitude": -2.7414050505
   },
   {
     "3alpha": "UPM",
-    "station_name": "Upminster Rail Station",
+    "station_name": "Upminster",
     "latitude": 51.5591080891,
     "longitude": 0.2509114423
   },
   {
     "3alpha": "UPT",
-    "station_name": "Upton Rail Station",
+    "station_name": "Upton",
     "latitude": 53.3865027098,
     "longitude": -3.0841516558
   },
   {
     "3alpha": "UPW",
-    "station_name": "Upwey Rail Station",
+    "station_name": "Upwey",
     "latitude": 50.6482597109,
     "longitude": -2.4661355254
   },
   {
     "3alpha": "URM",
-    "station_name": "Urmston Rail Station",
+    "station_name": "Urmston",
     "latitude": 53.4482848621,
     "longitude": -2.353796027
   },
   {
     "3alpha": "UTT",
-    "station_name": "Uttoxeter Rail Station",
+    "station_name": "Uttoxeter",
     "latitude": 52.896806652,
     "longitude": -1.8572519121
   },
   {
     "3alpha": "UTY",
-    "station_name": "Upper Tyndrum Rail Station",
+    "station_name": "Upper Tyndrum",
     "latitude": 56.4346498324,
     "longitude": -4.7037058912
   },
   {
     "3alpha": "UWL",
-    "station_name": "Upper Warlingham Rail Station",
+    "station_name": "Upper Warlingham",
     "latitude": 51.3085086648,
     "longitude": -0.0779244127
   },
   {
     "3alpha": "VAL",
-    "station_name": "Valley Rail Station",
+    "station_name": "Valley",
     "latitude": 53.2813003565,
     "longitude": -4.5633754695
   },
   {
     "3alpha": "VIC",
-    "station_name": "London Victoria Rail Station",
+    "station_name": "London Victoria",
     "latitude": 51.4952569307,
     "longitude": -0.144534171
   },
   {
     "3alpha": "VIR",
-    "station_name": "Virginia Water Rail Station",
+    "station_name": "Virginia Water",
     "latitude": 51.4018001404,
     "longitude": -0.5621549173
   },
   {
     "3alpha": "VXH",
-    "station_name": "Vauxhall Rail Station",
+    "station_name": "Vauxhall",
     "latitude": 51.4861891618,
     "longitude": -0.1228646018
   },
   {
     "3alpha": "WAC",
-    "station_name": "Warrington Central Rail Station",
+    "station_name": "Warrington Central",
     "latitude": 53.3918305175,
     "longitude": -2.5931678177
   },
   {
     "3alpha": "WAD",
-    "station_name": "Wadhurst Rail Station",
+    "station_name": "Wadhurst",
     "latitude": 51.0734564722,
     "longitude": 0.3132008907
   },
   {
     "3alpha": "WAE",
-    "station_name": "London Waterloo East Rail Station",
+    "station_name": "London Waterloo East",
     "latitude": 51.504075761,
     "longitude": -0.108872757
   },
   {
     "3alpha": "WAF",
-    "station_name": "Wallyford Rail Station",
+    "station_name": "Wallyford",
     "latitude": 55.9402786267,
     "longitude": -3.0149549323
   },
   {
     "3alpha": "WAL",
-    "station_name": "Walton-on-Thames Rail Station",
+    "station_name": "Walton-on-Thames",
     "latitude": 51.3729282422,
     "longitude": -0.4146141512
   },
   {
     "3alpha": "WAM",
-    "station_name": "Walmer Rail Station",
+    "station_name": "Walmer",
     "latitude": 51.2033289364,
     "longitude": 1.3829045251
   },
   {
     "3alpha": "WAN",
-    "station_name": "Wanborough Rail Station",
+    "station_name": "Wanborough",
     "latitude": 51.2445185634,
     "longitude": -0.6675689513
   },
   {
     "3alpha": "WAO",
-    "station_name": "Walton (Merseyside) Rail Station",
+    "station_name": "Walton (Merseyside)",
     "latitude": 53.4562297489,
     "longitude": -2.9657463744
   },
   {
     "3alpha": "WAR",
-    "station_name": "Ware Rail Station",
+    "station_name": "Ware",
     "latitude": 51.8079649403,
     "longitude": -0.0287536426
   },
   {
     "3alpha": "WAS",
-    "station_name": "Watton-at-Stone Rail Station",
+    "station_name": "Watton-at-Stone",
     "latitude": 51.8564430342,
     "longitude": -0.1194009287
   },
   {
     "3alpha": "WAT",
-    "station_name": "London Waterloo Rail Station",
+    "station_name": "London Waterloo",
     "latitude": 51.5032982602,
     "longitude": -0.1130836248
   },
   {
+    "3alpha":"WAW",
+    "station_name":"Warrington West",
+    "latitude": 53.393744,
+    "longitude": 2.636929
+  },
+  {
     "3alpha": "WAV",
-    "station_name": "Wavertree Technology Park Rail Station",
+    "station_name": "Wavertree Technology Park",
     "latitude": 53.405206521,
     "longitude": -2.9229088929
   },
   {
     "3alpha": "WBC",
-    "station_name": "Waterbeach Rail Station",
+    "station_name": "Waterbeach",
     "latitude": 52.2623177182,
     "longitude": 0.1968191721
   },
   {
     "3alpha": "WBD",
-    "station_name": "Whitley Bridge Rail Station",
+    "station_name": "Whitley Bridge",
     "latitude": 53.6991474904,
     "longitude": -1.1582841752
   },
   {
     "3alpha": "WBL",
-    "station_name": "Warblington Rail Station",
+    "station_name": "Warblington",
     "latitude": 50.8534343877,
     "longitude": -0.9671408737
   },
   {
     "3alpha": "WBO",
-    "station_name": "Wimbledon Chase Rail Station",
+    "station_name": "Wimbledon Chase",
     "latitude": 51.4095558211,
     "longitude": -0.214007061
   },
   {
     "3alpha": "WBP",
-    "station_name": "West Brompton Rail Station",
+    "station_name": "West Brompton",
     "latitude": 51.4870605518,
     "longitude": -0.1955689841
   },
   {
     "3alpha": "WBQ",
-    "station_name": "Warrington Bank Quay Rail Station",
+    "station_name": "Warrington Bank Quay",
     "latitude": 53.3860225082,
     "longitude": -2.6023634292
   },
   {
     "3alpha": "WBR",
-    "station_name": "Whaley Bridge Rail Station",
+    "station_name": "Whaley Bridge",
     "latitude": 53.3302489394,
     "longitude": -1.9846443668
   },
   {
     "3alpha": "WBY",
-    "station_name": "West Byfleet Rail Station",
+    "station_name": "West Byfleet",
     "latitude": 51.3392223062,
     "longitude": -0.5054647648
   },
   {
     "3alpha": "WCB",
-    "station_name": "Westcombe Park Rail Station",
+    "station_name": "Westcombe Park",
     "latitude": 51.484201535,
     "longitude": 0.0184203333
   },
   {
     "3alpha": "WCF",
-    "station_name": "Westcliff-on-Sea Rail Station",
+    "station_name": "Westcliff-on-Sea",
     "latitude": 51.5373355032,
     "longitude": 0.6914948438
   },
   {
     "3alpha": "WCH",
-    "station_name": "Whitchurch (Hants) Rail Station",
+    "station_name": "Whitchurch (Hants)",
     "latitude": 51.2375390314,
     "longitude": -1.3377316326
   },
   {
     "3alpha": "WCK",
-    "station_name": "Wick Rail Station",
+    "station_name": "Wick",
     "latitude": 58.441552763,
     "longitude": -3.0968646871
   },
   {
     "3alpha": "WCL",
-    "station_name": "West Calder Rail Station",
+    "station_name": "West Calder",
     "latitude": 55.8537981997,
     "longitude": -3.5670119586
   },
   {
     "3alpha": "WCM",
-    "station_name": "Wickham Market Rail Station",
+    "station_name": "Wickham Market",
     "latitude": 52.151115559,
     "longitude": 1.3987106267
   },
   {
     "3alpha": "WCP",
-    "station_name": "Worcester Park Rail Station",
+    "station_name": "Worcester Park",
     "latitude": 51.3812496853,
     "longitude": -0.2451435039
   },
   {
     "3alpha": "WCR",
-    "station_name": "Whitecraigs Rail Station",
+    "station_name": "Whitecraigs",
     "latitude": 55.7903161404,
     "longitude": -4.310143285
   },
   {
     "3alpha": "WCX",
-    "station_name": "Wembley Stadium Rail Station",
+    "station_name": "Wembley Stadium",
     "latitude": 51.5544157634,
     "longitude": -0.2855850739
   },
   {
     "3alpha": "WCY",
-    "station_name": "West Croydon Rail Station",
+    "station_name": "West Croydon",
     "latitude": 51.3784258204,
     "longitude": -0.1025603616
   },
   {
     "3alpha": "WDB",
-    "station_name": "Woodbridge Rail Station",
+    "station_name": "Woodbridge",
     "latitude": 52.0904601291,
     "longitude": 1.317801029
   },
   {
     "3alpha": "WDD",
-    "station_name": "Widdrington Rail Station",
+    "station_name": "Widdrington",
     "latitude": 55.2413084934,
     "longitude": -1.6164875215
   },
   {
     "3alpha": "WDE",
-    "station_name": "Wood End Rail Station",
+    "station_name": "Wood End",
     "latitude": 52.3436934001,
     "longitude": -1.8442057013
   },
   {
     "3alpha": "WDH",
-    "station_name": "Woodhouse Rail Station",
+    "station_name": "Woodhouse",
     "latitude": 53.363760625,
     "longitude": -1.357553357
   },
   {
     "3alpha": "WDL",
-    "station_name": "Woodhall Rail Station",
+    "station_name": "Woodhall",
     "latitude": 55.9311983025,
     "longitude": -4.6553823064
   },
   {
     "3alpha": "WDM",
-    "station_name": "Windermere Rail Station",
+    "station_name": "Windermere",
     "latitude": 54.3796096377,
     "longitude": -2.9033943659
   },
   {
     "3alpha": "WDN",
-    "station_name": "Walsden Rail Station",
+    "station_name": "Walsden",
     "latitude": 53.6962732634,
     "longitude": -2.104464907
   },
   {
     "3alpha": "WDO",
-    "station_name": "Waddon Rail Station",
+    "station_name": "Waddon",
     "latitude": 51.3673957219,
     "longitude": -0.1173106836
   },
   {
     "3alpha": "WDS",
-    "station_name": "Woodlesford Rail Station",
+    "station_name": "Woodlesford",
     "latitude": 53.7568021778,
     "longitude": -1.4428831514
   },
   {
     "3alpha": "WDT",
-    "station_name": "West Drayton Rail Station",
+    "station_name": "West Drayton",
     "latitude": 51.5100546283,
     "longitude": -0.4722138153
   },
   {
     "3alpha": "WDU",
-    "station_name": "West Dulwich Rail Station",
+    "station_name": "West Dulwich",
     "latitude": 51.4407162507,
     "longitude": -0.0913457383
   },
   {
     "3alpha": "WEA",
-    "station_name": "West Ealing Rail Station",
+    "station_name": "West Ealing",
     "latitude": 51.5135045768,
     "longitude": -0.3201109918
   },
   {
     "3alpha": "WED",
-    "station_name": "Wedgwood Rail Station",
+    "station_name": "Wedgwood",
     "latitude": 52.951063264,
     "longitude": -2.1708212356
   },
   {
     "3alpha": "WEE",
-    "station_name": "Weeley Rail Station",
+    "station_name": "Weeley",
     "latitude": 51.8531089886,
     "longitude": 1.115513113
   },
   {
     "3alpha": "WEH",
-    "station_name": "West Ham Rail Station",
+    "station_name": "West Ham",
     "latitude": 51.5284892546,
     "longitude": 0.0054585883
   },
   {
     "3alpha": "WEL",
-    "station_name": "Wellingborough Rail Station",
+    "station_name": "Wellingborough",
     "latitude": 52.3037949376,
     "longitude": -0.6766340582
   },
   {
     "3alpha": "WEM",
-    "station_name": "Wem Rail Station",
+    "station_name": "Wem",
     "latitude": 52.8564224306,
     "longitude": -2.7180138594
   },
   {
     "3alpha": "WES",
-    "station_name": "Westerton Rail Station",
+    "station_name": "Westerton",
     "latitude": 55.9047998365,
     "longitude": -4.3348647949
   },
   {
     "3alpha": "WET",
-    "station_name": "Weeton Rail Station",
+    "station_name": "Weeton",
     "latitude": 53.9231914641,
     "longitude": -1.5812210981
   },
   {
     "3alpha": "WEY",
-    "station_name": "Weymouth Rail Station",
+    "station_name": "Weymouth",
     "latitude": 50.6153023761,
     "longitude": -2.4542188409
   },
   {
     "3alpha": "WFF",
-    "station_name": "Whifflet Rail Station",
+    "station_name": "Whifflet",
     "latitude": 55.8536860909,
     "longitude": -4.0186440499
   },
   {
     "3alpha": "WFH",
-    "station_name": "Watford High Street Rail Station",
+    "station_name": "Watford High Street",
     "latitude": 51.6526581832,
     "longitude": -0.3916880939
   },
   {
     "3alpha": "WFI",
-    "station_name": "Westerfield Rail Station",
+    "station_name": "Westerfield",
     "latitude": 52.0809953585,
     "longitude": 1.1659358409
   },
   {
     "3alpha": "WFJ",
-    "station_name": "Watford Junction Rail Station",
+    "station_name": "Watford Junction",
     "latitude": 51.6635326348,
     "longitude": -0.3964938369
   },
   {
     "3alpha": "WFL",
-    "station_name": "Wainfleet Rail Station",
+    "station_name": "Wainfleet",
     "latitude": 53.1051521478,
     "longitude": 0.2347308866
   },
   {
     "3alpha": "WFN",
-    "station_name": "Watford North Rail Station",
+    "station_name": "Watford North",
     "latitude": 51.6757075829,
     "longitude": -0.3899023411
   },
   {
     "3alpha": "WGA",
-    "station_name": "Westgate-on-Sea Rail Station",
+    "station_name": "Westgate-on-Sea",
     "latitude": 51.3814500239,
     "longitude": 1.3383886434
   },
   {
     "3alpha": "WGC",
-    "station_name": "Welwyn Garden City Rail Station",
+    "station_name": "Welwyn Garden City",
     "latitude": 51.8010528857,
     "longitude": -0.2040464223
   },
   {
     "3alpha": "WGN",
-    "station_name": "Wigan North Western Rail Station",
+    "station_name": "Wigan North Western",
     "latitude": 53.5436746706,
     "longitude": -2.6332734056
   },
   {
     "3alpha": "WGR",
-    "station_name": "Woodgrange Park Rail Station",
+    "station_name": "Woodgrange Park",
     "latitude": 51.5492631072,
     "longitude": 0.0444499653
   },
   {
     "3alpha": "WGT",
-    "station_name": "Wigton Rail Station",
+    "station_name": "Wigton",
     "latitude": 54.8291221455,
     "longitude": -3.1643456818
   },
   {
     "3alpha": "WGV",
-    "station_name": "Wargrave Rail Station",
+    "station_name": "Wargrave",
     "latitude": 51.4981592025,
     "longitude": -0.8764978044
   },
   {
     "3alpha": "WGW",
-    "station_name": "Wigan Wallgate Rail Station",
+    "station_name": "Wigan Wallgate",
     "latitude": 53.5448346342,
     "longitude": -2.633185063
   },
   {
     "3alpha": "WHA",
-    "station_name": "Westenhanger Rail Station",
+    "station_name": "Westenhanger",
     "latitude": 51.0949607041,
     "longitude": 1.0380815591
   },
   {
     "3alpha": "WHC",
-    "station_name": "Walthamstow Central Rail Station",
+    "station_name": "Walthamstow Central",
     "latitude": 51.5829189505,
     "longitude": -0.0197878799
   },
   {
     "3alpha": "WHD",
-    "station_name": "West Hampstead Rail Station",
+    "station_name": "West Hampstead",
     "latitude": 51.5474681384,
     "longitude": -0.1911595369
   },
   {
     "3alpha": "WHE",
-    "station_name": "Whalley Rail Station",
+    "station_name": "Whalley",
     "latitude": 53.8240295678,
     "longitude": -2.412253049
   },
   {
     "3alpha": "WHG",
-    "station_name": "Westhoughton Rail Station",
+    "station_name": "Westhoughton",
     "latitude": 53.5556848068,
     "longitude": -2.5237269574
   },
   {
     "3alpha": "WHI",
-    "station_name": "Whitstable Rail Station",
+    "station_name": "Whitstable",
     "latitude": 51.3575849431,
     "longitude": 1.0333248141
   },
   {
     "3alpha": "WHL",
-    "station_name": "White Hart Lane Rail Station",
+    "station_name": "White Hart Lane",
     "latitude": 51.6050372456,
     "longitude": -0.0708886785
   },
   {
     "3alpha": "WHM",
-    "station_name": "Whimple Rail Station",
+    "station_name": "Whimple",
     "latitude": 50.7680161469,
     "longitude": -3.3543350506
   },
   {
     "3alpha": "WHN",
-    "station_name": "Whiston Rail Station",
+    "station_name": "Whiston",
     "latitude": 53.4138830477,
     "longitude": -2.7964313384
   },
   {
     "3alpha": "WHP",
-    "station_name": "West Hampstead Thameslink Rail Station",
+    "station_name": "West Hampstead Thameslink",
     "latitude": 51.5484763715,
     "longitude": -0.1918118442
   },
   {
     "3alpha": "WHR",
-    "station_name": "West Horndon Rail Station",
+    "station_name": "West Horndon",
     "latitude": 51.5679455135,
     "longitude": 0.3406719119
   },
   {
     "3alpha": "WHS",
-    "station_name": "Whyteleafe South Rail Station",
+    "station_name": "Whyteleafe South",
     "latitude": 51.3033836423,
     "longitude": -0.076890083
   },
   {
     "3alpha": "WHT",
-    "station_name": "Whitchurch (Cardiff) Rail Station",
+    "station_name": "Whitchurch (Cardiff)",
     "latitude": 51.5207503854,
     "longitude": -3.2232604275
   },
   {
     "3alpha": "WHY",
-    "station_name": "Whyteleafe Rail Station",
+    "station_name": "Whyteleafe",
     "latitude": 51.3099550362,
     "longitude": -0.0811212248
   },
   {
     "3alpha": "WIC",
-    "station_name": "Wickford Rail Station",
+    "station_name": "Wickford",
     "latitude": 51.6150252316,
     "longitude": 0.5192126597
   },
   {
     "3alpha": "WID",
-    "station_name": "Widnes Rail Station",
+    "station_name": "Widnes",
     "latitude": 53.3785111245,
     "longitude": -2.7335372039
   },
   {
     "3alpha": "WIH",
-    "station_name": "Winchmore Hill Rail Station",
+    "station_name": "Winchmore Hill",
     "latitude": 51.6339428901,
     "longitude": -0.1008743449
   },
   {
     "3alpha": "WIJ",
-    "station_name": "Willesden Junction Rail Station",
+    "station_name": "Willesden Junction",
     "latitude": 51.5324966867,
     "longitude": -0.2445240688
   },
   {
     "3alpha": "WIL",
-    "station_name": "Willington Rail Station",
+    "station_name": "Willington",
     "latitude": 52.8536609081,
     "longitude": -1.5633566039
   },
   {
     "3alpha": "WIM",
-    "station_name": "Wimbledon Rail Station",
+    "station_name": "Wimbledon",
     "latitude": 51.4212733693,
     "longitude": -0.2063586485
   },
   {
     "3alpha": "WIN",
-    "station_name": "Winchester Rail Station",
+    "station_name": "Winchester",
     "latitude": 51.0672031347,
     "longitude": -1.3196880282
   },
   {
     "3alpha": "WIV",
-    "station_name": "Wivenhoe Rail Station",
+    "station_name": "Wivenhoe",
     "latitude": 51.8565396555,
     "longitude": 0.9561671919
   },
   {
     "3alpha": "WKB",
-    "station_name": "West Kilbride Rail Station",
+    "station_name": "West Kilbride",
     "latitude": 55.6961504044,
     "longitude": -4.8517231169
   },
   {
     "3alpha": "WKD",
-    "station_name": "Walkden Rail Station",
+    "station_name": "Walkden",
     "latitude": 53.5197896484,
     "longitude": -2.3963191924
   },
   {
     "3alpha": "WKF",
-    "station_name": "Wakefield Westgate Rail Station",
+    "station_name": "Wakefield Westgate",
     "latitude": 53.6830884864,
     "longitude": -1.5061128915
   },
   {
     "3alpha": "WKG",
-    "station_name": "Workington Rail Station",
+    "station_name": "Workington",
     "latitude": 54.6451016394,
     "longitude": -3.5585006973
   },
   {
     "3alpha": "WKI",
-    "station_name": "West Kirby Rail Station",
+    "station_name": "West Kirby",
     "latitude": 53.3731876944,
     "longitude": -3.1837707177
   },
   {
     "3alpha": "WKK",
-    "station_name": "Wakefield Kirkgate Rail Station",
+    "station_name": "Wakefield Kirkgate",
     "latitude": 53.6786734429,
     "longitude": -1.4885726643
   },
   {
     "3alpha": "WKM",
-    "station_name": "Wokingham Rail Station",
+    "station_name": "Wokingham",
     "latitude": 51.4112171669,
     "longitude": -0.8425250632
   },
   {
     "3alpha": "WLC",
-    "station_name": "Waltham Cross Rail Station",
+    "station_name": "Waltham Cross",
     "latitude": 51.6850619631,
     "longitude": -0.0265322372
   },
   {
     "3alpha": "WLD",
-    "station_name": "West St Leonards Rail Station",
+    "station_name": "West St Leonards",
     "latitude": 50.8531478652,
     "longitude": 0.539964669
   },
   {
     "3alpha": "WLE",
-    "station_name": "Whittlesea Rail Station",
+    "station_name": "Whittlesea",
     "latitude": 52.5495457817,
     "longitude": -0.1189720533
   },
   {
     "3alpha": "WLF",
-    "station_name": "Whittlesford Parkway Rail Station",
+    "station_name": "Whittlesford Parkway",
     "latitude": 52.1035981209,
     "longitude": 0.1656457011
   },
   {
     "3alpha": "WLG",
-    "station_name": "Wallasey Grove Road Rail Station",
+    "station_name": "Wallasey Grove Road",
     "latitude": 53.4280187313,
     "longitude": -3.069705311
   },
   {
     "3alpha": "WLH",
-    "station_name": "Wolsingham Rail Station",
+    "station_name": "Wolsingham",
     "latitude": 54.7263219512,
     "longitude": -1.8835277375
   },
   {
     "3alpha": "WLI",
-    "station_name": "Welling Rail Station",
+    "station_name": "Welling",
     "latitude": 51.4647970094,
     "longitude": 0.1017165383
   },
   {
     "3alpha": "WLM",
-    "station_name": "Williamwood Rail Station",
+    "station_name": "Williamwood",
     "latitude": 55.7936801397,
     "longitude": -4.2903211229
   },
   {
     "3alpha": "WLN",
-    "station_name": "Wellington (Shropshire) Rail Station",
+    "station_name": "Wellington (Shropshire)",
     "latitude": 52.7013189006,
     "longitude": -2.5171628549
   },
   {
     "3alpha": "WLO",
-    "station_name": "Waterloo (Merseyside) Rail Station",
+    "station_name": "Waterloo (Merseyside)",
     "latitude": 53.4749677015,
     "longitude": -3.0255345128
   },
   {
     "3alpha": "WLP",
-    "station_name": "Welshpool Rail Station",
+    "station_name": "Welshpool",
     "latitude": 52.6575072859,
     "longitude": -3.1398692323
   },
   {
     "3alpha": "WLS",
-    "station_name": "Woolston Rail Station",
+    "station_name": "Woolston",
     "latitude": 50.898912011,
     "longitude": -1.3770486087
   },
   {
     "3alpha": "WLT",
-    "station_name": "Wallington Rail Station",
+    "station_name": "Wallington",
     "latitude": 51.3603838072,
     "longitude": -0.1508078249
   },
   {
     "3alpha": "WLV",
-    "station_name": "Wallasey Village Rail Station",
+    "station_name": "Wallasey Village",
     "latitude": 53.4229003142,
     "longitude": -3.0691254064
   },
   {
     "3alpha": "WLW",
-    "station_name": "Welwyn North Rail Station",
+    "station_name": "Welwyn North",
     "latitude": 51.8235025409,
     "longitude": -0.1920673777
   },
   {
     "3alpha": "WLY",
-    "station_name": "Woodley Rail Station",
+    "station_name": "Woodley",
     "latitude": 53.4292679007,
     "longitude": -2.0932702851
   },
   {
     "3alpha": "WMA",
-    "station_name": "West Malling Rail Station",
+    "station_name": "West Malling",
     "latitude": 51.2920176581,
     "longitude": 0.4186819525
   },
   {
     "3alpha": "WMB",
-    "station_name": "Wembley Central Rail Station",
+    "station_name": "Wembley Central",
     "latitude": 51.552325148,
     "longitude": -0.2964096325
   },
   {
     "3alpha": "WMC",
-    "station_name": "Wilmcote Rail Station",
+    "station_name": "Wilmcote",
     "latitude": 52.2230107026,
     "longitude": -1.7560030891
   },
   {
     "3alpha": "WMD",
-    "station_name": "Wymondham Rail Station",
+    "station_name": "Wymondham",
     "latitude": 52.5654338739,
     "longitude": 1.1180480575
   },
   {
     "3alpha": "WME",
-    "station_name": "Woodmansterne Rail Station",
+    "station_name": "Woodmansterne",
     "latitude": 51.3190162934,
     "longitude": -0.1542365305
   },
   {
     "3alpha": "WMG",
-    "station_name": "Welham Green Rail Station",
+    "station_name": "Welham Green",
     "latitude": 51.736355041,
     "longitude": -0.210669375
   },
   {
     "3alpha": "WMI",
-    "station_name": "Wildmill Rail Station",
+    "station_name": "Wildmill",
     "latitude": 51.5208701744,
     "longitude": -3.5796491532
   },
   {
     "3alpha": "WML",
-    "station_name": "Wilmslow Rail Station",
+    "station_name": "Wilmslow",
     "latitude": 53.3268623597,
     "longitude": -2.226326187
   },
   {
     "3alpha": "WMN",
-    "station_name": "Warminster Rail Station",
+    "station_name": "Warminster",
     "latitude": 51.2067697704,
     "longitude": -2.1767285454
   },
   {
     "3alpha": "WMR",
-    "station_name": "Widney Manor Rail Station",
+    "station_name": "Widney Manor",
     "latitude": 52.3959484322,
     "longitude": -1.7743630129
   },
   {
     "3alpha": "WMS",
-    "station_name": "Wemyss Bay Rail Station",
+    "station_name": "Wemyss Bay",
     "latitude": 55.8761375469,
     "longitude": -4.8890595221
   },
   {
     "3alpha": "WMW",
-    "station_name": "Walthamstow Queens Road Rail Station",
+    "station_name": "Walthamstow Queens Road",
     "latitude": 51.5815031634,
     "longitude": -0.0238187685
   },
   {
     "3alpha": "WNC",
-    "station_name": "Windsor & Eton Central Rail Station",
+    "station_name": "Windsor & Eton Central",
     "latitude": 51.4832677885,
     "longitude": -0.6103634231
   },
   {
     "3alpha": "WND",
-    "station_name": "Wendover Rail Station",
+    "station_name": "Wendover",
     "latitude": 51.7617617158,
     "longitude": -0.7473477525
   },
   {
     "3alpha": "WNE",
-    "station_name": "Wilnecote (Staffs) Rail Station",
+    "station_name": "Wilnecote (Staffs)",
     "latitude": 52.6107271717,
     "longitude": -1.6797075751
   },
   {
     "3alpha": "WNF",
-    "station_name": "Winchfield Rail Station",
+    "station_name": "Winchfield",
     "latitude": 51.2849477502,
     "longitude": -0.9069607416
   },
   {
     "3alpha": "WNG",
-    "station_name": "Waun-gron Park Rail Station",
+    "station_name": "Waun-gron Park",
     "latitude": 51.4881949213,
     "longitude": -3.2296615036
   },
   {
     "3alpha": "WNH",
-    "station_name": "Warnham Rail Station",
+    "station_name": "Warnham",
     "latitude": 51.0928963956,
     "longitude": -0.3294372471
   },
   {
     "3alpha": "WNL",
-    "station_name": "Whinhill Rail Station",
+    "station_name": "Whinhill",
     "latitude": 55.9383637813,
     "longitude": -4.7466746978
   },
   {
     "3alpha": "WNM",
-    "station_name": "Weston Milton Rail Station",
+    "station_name": "Weston Milton",
     "latitude": 51.348465771,
     "longitude": -2.9423917485
   },
   {
     "3alpha": "WNN",
-    "station_name": "Wennington Rail Station",
+    "station_name": "Wennington",
     "latitude": 54.1237145615,
     "longitude": -2.5875119193
   },
   {
     "3alpha": "WNP",
-    "station_name": "Wanstead Park Rail Station",
+    "station_name": "Wanstead Park",
     "latitude": 51.5516926945,
     "longitude": 0.0262400164
   },
   {
     "3alpha": "WNR",
-    "station_name": "Windsor & Eton Riverside Rail Station",
+    "station_name": "Windsor & Eton Riverside",
     "latitude": 51.4856499617,
     "longitude": -0.6065175067
   },
   {
     "3alpha": "WNS",
-    "station_name": "Winnersh Rail Station",
+    "station_name": "Winnersh",
     "latitude": 51.4302818498,
     "longitude": -0.87683995
   },
   {
     "3alpha": "WNT",
-    "station_name": "Wandsworth Town Rail Station",
+    "station_name": "Wandsworth Town",
     "latitude": 51.4610465985,
     "longitude": -0.1881010831
   },
   {
     "3alpha": "WNW",
-    "station_name": "West Norwood Rail Station",
+    "station_name": "West Norwood",
     "latitude": 51.4317458109,
     "longitude": -0.1038042183
   },
   {
     "3alpha": "WNY",
-    "station_name": "White Notley Rail Station",
+    "station_name": "White Notley",
     "latitude": 51.8389190888,
     "longitude": 0.5958911326
   },
   {
     "3alpha": "WOB",
-    "station_name": "Woburn Sands Rail Station",
+    "station_name": "Woburn Sands",
     "latitude": 52.0181602116,
     "longitude": -0.6540621907
   },
   {
     "3alpha": "WOF",
-    "station_name": "Worcester Foregate Street Rail Station",
+    "station_name": "Worcester Foregate Street",
     "latitude": 52.1951552361,
     "longitude": -2.2215923384
   },
   {
     "3alpha": "WOH",
-    "station_name": "Woldingham Rail Station",
+    "station_name": "Woldingham",
     "latitude": 51.2901548311,
     "longitude": -0.0518430517
   },
   {
     "3alpha": "WOK",
-    "station_name": "Woking Rail Station",
+    "station_name": "Woking",
     "latitude": 51.3184663679,
     "longitude": -0.5569403769
   },
   {
     "3alpha": "WOL",
-    "station_name": "Wolverton Rail Station",
+    "station_name": "Wolverton",
     "latitude": 52.0658873901,
     "longitude": -0.8042463611
   },
   {
     "3alpha": "WOM",
-    "station_name": "Wombwell Rail Station",
+    "station_name": "Wombwell",
     "latitude": 53.517362766,
     "longitude": -1.4161637925
   },
   {
     "3alpha": "WON",
-    "station_name": "Walton-on-the-Naze Rail Station",
+    "station_name": "Walton-on-the-Naze",
     "latitude": 51.8461792474,
     "longitude": 1.2676990657
   },
   {
     "3alpha": "WOO",
-    "station_name": "Wool Rail Station",
+    "station_name": "Wool",
     "latitude": 50.681626061,
     "longitude": -2.2214563212
   },
+  {"3alpha":"WOP","station_name":"Worcestershire Parkway","latitude":52.1556,"longitude": -2.1609},
   {
     "3alpha": "WOR",
-    "station_name": "Worle Rail Station",
+    "station_name": "Worle",
     "latitude": 51.3580317777,
     "longitude": -2.9096264535
   },
   {
     "3alpha": "WOS",
-    "station_name": "Worcester Shrub Hill Rail Station",
+    "station_name": "Worcester Shrub Hill",
     "latitude": 52.194736867,
     "longitude": -2.2094036358
   },
   {
     "3alpha": "WPE",
-    "station_name": "Wapping Rail Station",
+    "station_name": "Wapping",
     "latitude": 51.5043874917,
     "longitude": -0.0559045836
   },
   {
     "3alpha": "WPL",
-    "station_name": "Worplesdon Rail Station",
+    "station_name": "Worplesdon",
     "latitude": 51.289013057,
     "longitude": -0.5825586496
   },
   {
     "3alpha": "WRB",
-    "station_name": "Wrabness Rail Station",
+    "station_name": "Wrabness",
     "latitude": 51.9395205813,
     "longitude": 1.1715280173
   },
   {
     "3alpha": "WRE",
-    "station_name": "Wrenbury Rail Station",
+    "station_name": "Wrenbury",
     "latitude": 53.0194020901,
     "longitude": -2.5959470421
   },
   {
     "3alpha": "WRH",
-    "station_name": "Worthing Rail Station",
+    "station_name": "Worthing",
     "latitude": 50.8184892196,
     "longitude": -0.3761461656
   },
   {
     "3alpha": "WRK",
-    "station_name": "Worksop Rail Station",
+    "station_name": "Worksop",
     "latitude": 53.3115252628,
     "longitude": -1.1227713307
   },
   {
     "3alpha": "WRL",
-    "station_name": "Wetheral Rail Station",
+    "station_name": "Wetheral",
     "latitude": 54.8838456329,
     "longitude": -2.8317175358
   },
   {
     "3alpha": "WRM",
-    "station_name": "Wareham Rail Station",
+    "station_name": "Wareham",
     "latitude": 50.6928762389,
     "longitude": -2.1152411345
   },
   {
     "3alpha": "WRN",
-    "station_name": "West Runton Rail Station",
+    "station_name": "West Runton",
     "latitude": 52.9355527634,
     "longitude": 1.2454754855
   },
   {
     "3alpha": "WRP",
-    "station_name": "Warwick Parkway Rail Station",
+    "station_name": "Warwick Parkway",
     "latitude": 52.2861162934,
     "longitude": -1.6120460343
   },
   {
     "3alpha": "WRS",
-    "station_name": "Wressle Rail Station",
+    "station_name": "Wressle",
     "latitude": 53.7729422572,
     "longitude": -0.9243539655
   },
   {
     "3alpha": "WRT",
-    "station_name": "Worstead Rail Station",
+    "station_name": "Worstead",
     "latitude": 52.7774520547,
     "longitude": 1.4041024484
   },
   {
     "3alpha": "WRU",
-    "station_name": "West Ruislip Rail Station",
+    "station_name": "West Ruislip",
     "latitude": 51.5697585389,
     "longitude": -0.4377469365
   },
   {
     "3alpha": "WRW",
-    "station_name": "Warwick Rail Station",
+    "station_name": "Warwick",
     "latitude": 52.2865527555,
     "longitude": -1.5818426042
   },
   {
     "3alpha": "WRX",
-    "station_name": "Wrexham General Rail Station",
+    "station_name": "Wrexham General",
     "latitude": 53.0502463948,
     "longitude": -3.0024435025
   },
   {
     "3alpha": "WRY",
-    "station_name": "Wraysbury Rail Station",
+    "station_name": "Wraysbury",
     "latitude": 51.4577071718,
     "longitude": -0.5419033065
   },
   {
     "3alpha": "WSA",
-    "station_name": "West Allerton Rail Station",
+    "station_name": "West Allerton",
     "latitude": 53.3691394493,
     "longitude": -2.9069642345
   },
   {
     "3alpha": "WSB",
-    "station_name": "Westbury (Wilts) Rail Station",
+    "station_name": "Westbury (Wilts)",
     "latitude": 51.2669801221,
     "longitude": -2.1991779411
   },
   {
     "3alpha": "WSE",
-    "station_name": "Winchelsea Rail Station",
+    "station_name": "Winchelsea",
     "latitude": 50.933760407,
     "longitude": 0.7022917517
   },
   {
     "3alpha": "WSF",
-    "station_name": "Winsford Rail Station",
+    "station_name": "Winsford",
     "latitude": 53.190525188,
     "longitude": -2.4945975727
   },
   {
     "3alpha": "WSH",
-    "station_name": "Wishaw Rail Station",
+    "station_name": "Wishaw",
     "latitude": 55.7720379365,
     "longitude": -3.9264142917
   },
   {
     "3alpha": "WSL",
-    "station_name": "Walsall Rail Station",
+    "station_name": "Walsall",
     "latitude": 52.5844123362,
     "longitude": -1.9847496237
   },
   {
     "3alpha": "WSM",
-    "station_name": "Weston-super-Mare Rail Station",
+    "station_name": "Weston-super-Mare",
     "latitude": 51.3443145157,
     "longitude": -2.9716684624
   },
   {
     "3alpha": "WSR",
-    "station_name": "Woodsmoor Rail Station",
+    "station_name": "Woodsmoor",
     "latitude": 53.3864885313,
     "longitude": -2.1420856045
   },
   {
     "3alpha": "WST",
-    "station_name": "Wood Street Rail Station",
+    "station_name": "Wood Street",
     "latitude": 51.5865803321,
     "longitude": -0.0023784573
   },
   {
     "3alpha": "WSU",
-    "station_name": "West Sutton Rail Station",
+    "station_name": "West Sutton",
     "latitude": 51.3658510426,
     "longitude": -0.2051484336
   },
   {
     "3alpha": "WSW",
-    "station_name": "Wandsworth Common Rail Station",
+    "station_name": "Wandsworth Common",
     "latitude": 51.4461834495,
     "longitude": -0.1633607829
   },
   {
     "3alpha": "WTA",
-    "station_name": "Wester Hailes Rail Station",
+    "station_name": "Wester Hailes",
     "latitude": 55.9143114673,
     "longitude": -3.2843381703
   },
   {
     "3alpha": "WTB",
-    "station_name": "Whitby Rail Station",
+    "station_name": "Whitby",
     "latitude": 54.4846228934,
     "longitude": -0.6154196587
   },
   {
     "3alpha": "WTC",
-    "station_name": "Whitchurch (Shrops) Rail Station",
+    "station_name": "Whitchurch (Shrops)",
     "latitude": 52.9680723073,
     "longitude": -2.6716975313
   },
   {
     "3alpha": "WTE",
-    "station_name": "Whitlocks End Rail Station",
+    "station_name": "Whitlocks End",
     "latitude": 52.3918444057,
     "longitude": -1.8515316565
   },
   {
     "3alpha": "WTG",
-    "station_name": "Watlington Rail Station",
+    "station_name": "Watlington",
     "latitude": 52.6731905958,
     "longitude": 0.383333413
   },
   {
     "3alpha": "WTH",
-    "station_name": "Whitehaven Rail Station",
+    "station_name": "Whitehaven",
     "latitude": 54.5530370984,
     "longitude": -3.5869341489
   },
   {
     "3alpha": "WTI",
-    "station_name": "Winnersh Triangle Rail Station",
+    "station_name": "Winnersh Triangle",
     "latitude": 51.436740952,
     "longitude": -0.891312814
   },
   {
     "3alpha": "WTL",
-    "station_name": "Whitland Rail Station",
+    "station_name": "Whitland",
     "latitude": 51.8180389016,
     "longitude": -4.6144179575
   },
   {
     "3alpha": "WTM",
-    "station_name": "Witham (Essex) Rail Station",
+    "station_name": "Witham (Essex)",
     "latitude": 51.8059754077,
     "longitude": 0.6391569064
   },
   {
     "3alpha": "WTN",
-    "station_name": "Whitton Rail Station",
+    "station_name": "Whitton",
     "latitude": 51.4496053939,
     "longitude": -0.3576601374
   },
   {
     "3alpha": "WTO",
-    "station_name": "Water Orton Rail Station",
+    "station_name": "Water Orton",
     "latitude": 52.5185987323,
     "longitude": -1.743083154
   },
   {
     "3alpha": "WTR",
-    "station_name": "Wateringbury Rail Station",
+    "station_name": "Wateringbury",
     "latitude": 51.2497316844,
     "longitude": 0.4224946816
   },
   {
     "3alpha": "WTS",
-    "station_name": "Whatstandwell Rail Station",
+    "station_name": "Whatstandwell",
     "latitude": 53.0833304944,
     "longitude": -1.5040836241
   },
   {
     "3alpha": "WTT",
-    "station_name": "Witton (West Midlands) Rail Station",
+    "station_name": "Witton (West Midlands)",
     "latitude": 52.512392581,
     "longitude": -1.88442989
   },
   {
     "3alpha": "WTY",
-    "station_name": "Witley Rail Station",
+    "station_name": "Witley",
     "latitude": 51.1331560769,
     "longitude": -0.6457625387
   },
   {
     "3alpha": "WVF",
-    "station_name": "Wivelsfield Rail Station",
+    "station_name": "Wivelsfield",
     "latitude": 50.9642899705,
     "longitude": -0.1207633726
   },
   {
     "3alpha": "WVH",
-    "station_name": "Wolverhampton Rail Station",
+    "station_name": "Wolverhampton",
     "latitude": 52.5878584294,
     "longitude": -2.1195080884
   },
   {
     "3alpha": "WWA",
-    "station_name": "Woolwich Arsenal Rail Station",
+    "station_name": "Woolwich Arsenal",
     "latitude": 51.4899075996,
     "longitude": 0.0692207097
   },
   {
+    "3alpha": "WWC",
+    "station_name": "Woolwich",
+    "latitude": 51.491578,
+    "longitude": 0.071819
+  },
+  {
     "3alpha": "WWD",
-    "station_name": "Woolwich Dockyard Rail Station",
+    "station_name": "Woolwich Dockyard",
     "latitude": 51.4911257712,
     "longitude": 0.0546684641
   },
   {
     "3alpha": "WWI",
-    "station_name": "West Wickham Rail Station",
+    "station_name": "West Wickham",
     "latitude": 51.381299435,
     "longitude": -0.01440507
   },
   {
     "3alpha": "WWL",
-    "station_name": "Whitwell (Derbys) Rail Station",
+    "station_name": "Whitwell (Derbys)",
     "latitude": 53.2799805667,
     "longitude": -1.2002056127
   },
   {
     "3alpha": "WWO",
-    "station_name": "West Worthing Rail Station",
+    "station_name": "West Worthing",
     "latitude": 50.8183442209,
     "longitude": -0.3929601185
   },
   {
     "3alpha": "WWR",
-    "station_name": "Wandsworth Road Rail Station",
+    "station_name": "Wandsworth Road",
     "latitude": 51.4702155479,
     "longitude": -0.1384945236
   },
   {
     "3alpha": "WWW",
-    "station_name": "Wootton Wawen Rail Station",
+    "station_name": "Wootton Wawen",
     "latitude": 52.2669127478,
     "longitude": -1.7846878163
   },
   {
     "3alpha": "WXC",
-    "station_name": "Wrexham Central Rail Station",
+    "station_name": "Wrexham Central",
     "latitude": 53.0462026991,
     "longitude": -2.9990529112
   },
   {
     "3alpha": "WYB",
-    "station_name": "Weybridge Rail Station",
+    "station_name": "Weybridge",
     "latitude": 51.3617683693,
     "longitude": -0.4577187292
   },
   {
     "3alpha": "WYE",
-    "station_name": "Wye Rail Station",
+    "station_name": "Wye",
     "latitude": 51.1850110281,
     "longitude": 0.9293337289
   },
   {
     "3alpha": "WYL",
-    "station_name": "Wylde Green Rail Station",
+    "station_name": "Wylde Green",
     "latitude": 52.545726518,
     "longitude": -1.8314010655
   },
   {
     "3alpha": "WYM",
-    "station_name": "Wylam Rail Station",
+    "station_name": "Wylam",
     "latitude": 54.9749775863,
     "longitude": -1.8140737353
   },
   {
     "3alpha": "WYT",
-    "station_name": "Wythall Rail Station",
+    "station_name": "Wythall",
     "latitude": 52.3799491076,
     "longitude": -1.8655274464
   },
   {
     "3alpha": "YAE",
-    "station_name": "Yate Rail Station",
+    "station_name": "Yate",
     "latitude": 51.5405996642,
     "longitude": -2.4325201347
   },
   {
     "3alpha": "YAL",
-    "station_name": "Yalding Rail Station",
+    "station_name": "Yalding",
     "latitude": 51.2264801343,
     "longitude": 0.4121922549
   },
   {
     "3alpha": "YAT",
-    "station_name": "Yatton Rail Station",
+    "station_name": "Yatton",
     "latitude": 51.3910100893,
     "longitude": -2.8277833431
   },
   {
     "3alpha": "YEO",
-    "station_name": "Yeoford Rail Station",
+    "station_name": "Yeoford",
     "latitude": 50.7769135717,
     "longitude": -3.7271368279
   },
   {
     "3alpha": "YET",
-    "station_name": "Yetminster Rail Station",
+    "station_name": "Yetminster",
     "latitude": 50.8957550733,
     "longitude": -2.5737566578
   },
   {
     "3alpha": "YNW",
-    "station_name": "Ynyswen Rail Station",
+    "station_name": "Ynyswen",
     "latitude": 51.6649733413,
     "longitude": -3.5216084057
   },
   {
     "3alpha": "YOK",
-    "station_name": "Yoker Rail Station",
+    "station_name": "Yoker",
     "latitude": 55.8925792728,
     "longitude": -4.3862714831
   },
   {
     "3alpha": "YRD",
-    "station_name": "Yardley Wood Rail Station",
+    "station_name": "Yardley Wood",
     "latitude": 52.4215152176,
     "longitude": -1.8543739528
   },
   {
     "3alpha": "YRK",
-    "station_name": "York Rail Station",
+    "station_name": "York",
     "latitude": 53.9579821958,
     "longitude": -1.0931909318
   },
   {
     "3alpha": "YRM",
-    "station_name": "Yarm Rail Station",
+    "station_name": "Yarm",
     "latitude": 54.493908683,
     "longitude": -1.3515575298
   },
   {
     "3alpha": "YRT",
-    "station_name": "Yorton Rail Station",
+    "station_name": "Yorton",
     "latitude": 52.8089705446,
     "longitude": -2.736458295
   },
   {
     "3alpha": "YSM",
-    "station_name": "Ystrad Mynach Rail Station",
+    "station_name": "Ystrad Mynach",
     "latitude": 51.6409356979,
     "longitude": -3.2413052794
   },
   {
     "3alpha": "YSR",
-    "station_name": "Ystrad Rhondda Rail Station",
+    "station_name": "Ystrad Rhondda",
     "latitude": 51.6436413608,
     "longitude": -3.4666955023
   },
   {
     "3alpha": "YVJ",
-    "station_name": "Yeovil Junction Rail Station",
+    "station_name": "Yeovil Junction",
     "latitude": 50.9247392604,
     "longitude": -2.6124572985
   },
   {
     "3alpha": "YVP",
-    "station_name": "Yeovil Pen Mill Rail Station",
+    "station_name": "Yeovil Pen Mill",
     "latitude": 50.9445178485,
     "longitude": -2.6134285854
   },
@@ -15547,25 +15650,25 @@
   },
   {
     "3alpha": "ZCW",
-    "station_name": "Canada Water Rail Station",
+    "station_name": "Canada Water",
     "latitude": 51.4979894212,
     "longitude": -0.0496935895
   },
   {
     "3alpha": "ZFD",
-    "station_name": "Farringdon (London) Rail Station",
+    "station_name": "Farringdon (London)",
     "latitude": 51.5201671742,
     "longitude": -0.1051789136
   },
   {
     "3alpha": "ZWL",
-    "station_name": "Whitechapel Rail Station",
+    "station_name": "Whitechapel",
     "latitude": 51.5194686455,
     "longitude": -0.0597305213
   },
   {
     "3alpha": "ZZT",
-    "station_name": "Lintley Rail Station",
+    "station_name": "Lintley",
     "latitude": 54.853558347,
     "longitude": -2.4883171256
   }


### PR DESCRIPTION
Added:

- Maghull North
- Meridian Water
- Robroyston
- Warrington West
- Horden
- Kintore
- Worcestershire Parkway
- Bow Street
- Okehampton
- Soham
- Barking Riverside
- Canary Wharf (XR)
- Reston
- Woolwich
- Brent Cross West
- Headbolt Lane
- East Linton
- Portway Park and Ride
- Reading Green Park
- Thanet Parkway
- Ashington
- Ashley Down
- Cameron Bridge
- Leven
- Seaton Deleval

Removal of 'rail station' from the names to make it easier to utilise in the development of applications. 